### PR TITLE
test: bump PHPUnit 10 -> 11, fix broken test:verbose, finish attribute migration

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,6 +29,16 @@ jobs:
           path: porting-sdk
           token: ${{ secrets.PORTING_SDK_TOKEN }}
 
+      # The EMISSION gate compares this port's to_dict() output against the
+      # signalwire-python oracle (FunctionResult), which pulls fastapi via
+      # signalwire/__init__. Check it out so the EMISSION gate has its reference.
+      - name: Checkout signalwire-python (EMISSION oracle)
+        uses: actions/checkout@v5
+        with:
+          repository: signalwire/signalwire-python
+          path: signalwire-python
+          ref: main
+
       - name: Set up PHP
         uses: shivammathur/setup-php@v2
         with:
@@ -48,6 +58,16 @@ jobs:
         run: |
           pip install -e porting-sdk/test_harness/mock_relay
           pip install -e porting-sdk/test_harness/mock_signalwire
+
+      # EMISSION needs `import signalwire` (the oracle). Install from the
+      # adjacent checkout only if not already importable.
+      - name: Install signalwire-python (EMISSION oracle) if not importable
+        run: |
+          if python -c "import signalwire.core.function_result" 2>/dev/null; then
+            echo "signalwire-python already importable; skipping install"
+          else
+            pip install ./signalwire-python
+          fi
 
       - name: Composer install (PHP deps)
         working-directory: signalwire-php

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "workerman/workerman": "^5.2"
     },
     "require-dev": {
-        "phpunit/phpunit": "^10.0"
+        "phpunit/phpunit": "^11.0"
     },
     "autoload": {
         "psr-4": {
@@ -32,7 +32,7 @@
     ],
     "scripts": {
         "test": "phpunit --configuration phpunit.xml",
-        "test:verbose": "phpunit --configuration phpunit.xml --verbose"
+        "test:verbose": "phpunit --configuration phpunit.xml --testdox --display-deprecations --display-phpunit-deprecations"
     },
     "config": {
         "sort-packages": true

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd"
          bootstrap="vendor/autoload.php"
          colors="true"
          failOnRisky="true"

--- a/tests/Tls/TlsRelayWssTest.php
+++ b/tests/Tls/TlsRelayWssTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace SignalWire\Tests\Tls;
 
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 use SignalWire\Relay\Client as RelayClient;
 
@@ -24,9 +25,8 @@ use SignalWire\Relay\Client as RelayClient;
  * A negative test points an otherwise-identical client (NO trusted CA) at the
  * same endpoint and asserts the handshake is rejected — proving the cert is
  * actually verified, not skipped.
- *
- * @group tls
  */
+#[Group('tls')]
 final class TlsRelayWssTest extends TestCase
 {
     private static ?string $certs = null;

--- a/tests/Tls/TlsRestHttpsTest.php
+++ b/tests/Tls/TlsRestHttpsTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace SignalWire\Tests\Tls;
 
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 use SignalWire\REST\RestClient;
 use SignalWire\REST\SignalWireRestError;
@@ -23,9 +24,8 @@ use SignalWire\REST\SignalWireRestError;
  *
  * A negative test issues the same GET with NO trusted CA and asserts the
  * handshake is rejected, proving genuine certificate verification.
- *
- * @group tls
  */
+#[Group('tls')]
 final class TlsRestHttpsTest extends TestCase
 {
     private static ?string $certs = null;

--- a/tests/Tls/TlsServerHttpsTest.php
+++ b/tests/Tls/TlsServerHttpsTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace SignalWire\Tests\Tls;
 
+use PHPUnit\Framework\Attributes\Depends;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -22,9 +24,8 @@ use PHPUnit\Framework\TestCase;
  *
  * A negative test reaches the same endpoint with NO trusted CA and asserts the
  * handshake is rejected, proving the server's cert is genuinely verified.
- *
- * @group tls
  */
+#[Group('tls')]
 final class TlsServerHttpsTest extends TestCase
 {
     private static ?string $certs = null;
@@ -151,9 +152,7 @@ final class TlsServerHttpsTest extends TestCase
         $this->assertSame('healthy', $payload['status'] ?? null, 'health status not "healthy"');
     }
 
-    /**
-     * @depends testHealthOverHttpsWithTrustedCa
-     */
+    #[Depends('testHealthOverHttpsWithTrustedCa')]
     public function testUntrustedClientIsRejected(): void
     {
         $url = 'https://127.0.0.1:' . self::$port . '/health';


### PR DESCRIPTION
## Changes
- **PHPUnit `^10.0` → `^11.0`** (resolves 11.5.55). 11 is the ceiling — PHPUnit 12 needs PHP 8.3, 13 needs 8.4.1, and the lib floor is `>=8.1`.
- **`phpunit.xml` schema** 10.5 → 11.5. No config keys needed reconciliation.
- **Fixed the already-broken `composer test:verbose`** — its `--verbose` flag was removed back in PHPUnit 10 (so the script was failing on the current 10.5 too). Replaced with `--testdox --display-deprecations --display-phpunit-deprecations`.
- **Annotation → attribute migration** in 3 TLS test files: `@group tls` → `#[Group('tls')]`, `@depends ...` → `#[Depends('...')]` (+ the `use` imports). This clears 4 PHPUnit-11 deprecations and is the forward-compat fix (these annotations hard-break in PHPUnit 12). No `@dataProvider`/`@test`/`@covers` existed; the 853 `function test*` name-convention methods are unaffected.

## Verification
- `composer test`: 1289 tests pass, **0 deprecations** (was 4), 2 pre-existing env-skips.
- `composer test:verbose`: now works (was broken).
- `scripts/run-ci.sh`: all 6 gates PASS; `port_signatures.json` unchanged (test-only change, no drift).

🤖 Generated with [Claude Code](https://claude.com/claude-code)