### PR TITLE
test(mock): session-isolate mock suites for safe parallel execution

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
         "workerman/workerman": "^5.2"
     },
     "require-dev": {
+        "brianium/paratest": "^7",
         "phpunit/phpunit": "^11.0"
     },
     "autoload": {

--- a/scripts/run-ci.sh
+++ b/scripts/run-ci.sh
@@ -44,6 +44,73 @@ PORTING_SDK_DIR="$(resolve_porting_sdk)" || {
     exit 2
 }
 
+# ── Mock-server lifecycle (for the PARALLEL test gate) ────────────────────
+#
+# The mock-backed suites are session-isolated (RELAY journal/scenarios scoped
+# by the connect-handshake sessionid; REST journal/scenarios scoped by the
+# per-test random project's Authorization header), so they are safe to run
+# under file/process parallelism. But paratest runs each test file in its own
+# PHP process, and the per-test harness's probe-OR-spawn helper would otherwise
+# have several workers race to spawn the mock — and worse, the worker that
+# spawned it kills it (via register_shutdown_function) when that worker exits,
+# yanking the server out from under still-running workers.
+#
+# Fix: spawn each mock ONCE here, wait for health, export the fixed ports so
+# every worker just probes-and-reuses (never spawns, never registers a kill
+# hook), and tear them down in a trap. This mirrors the dotnet lifecycle in
+# MOCK_TEST_HARNESS.md.
+MOCK_SIGNALWIRE_PORT="${MOCK_SIGNALWIRE_PORT:-8768}"
+MOCK_RELAY_PORT="${MOCK_RELAY_PORT:-8778}"
+MOCK_RELAY_HTTP_PORT="${MOCK_RELAY_HTTP_PORT:-9778}"
+export MOCK_SIGNALWIRE_PORT MOCK_RELAY_PORT MOCK_RELAY_HTTP_PORT
+
+PARALLEL_PROCS="${PARATEST_PROCS:-8}"
+MOCK_PIDS=""
+PYTHON_BIN="${MOCK_SIGNALWIRE_PYTHON:-$(command -v python3 || command -v python || echo python3)}"
+
+probe_mock() {  # $1 = url, $2 = needle
+    curl -fsS --max-time 2 "$1" 2>/dev/null | grep -q "$2"
+}
+
+spawn_mocks() {
+    local relay_pkg signalwire_pkg
+    relay_pkg="$PORTING_SDK_DIR/test_harness/mock_relay"
+    signalwire_pkg="$PORTING_SDK_DIR/test_harness/mock_signalwire"
+
+    if ! probe_mock "http://127.0.0.1:$MOCK_SIGNALWIRE_PORT/__mock__/health" '"specs_loaded"'; then
+        PYTHONPATH="$signalwire_pkg${PYTHONPATH:+:$PYTHONPATH}" \
+            "$PYTHON_BIN" -m mock_signalwire --host 127.0.0.1 \
+            --port "$MOCK_SIGNALWIRE_PORT" --log-level error >/dev/null 2>&1 &
+        MOCK_PIDS="$MOCK_PIDS $!"
+    fi
+    if ! probe_mock "http://127.0.0.1:$MOCK_RELAY_HTTP_PORT/__mock__/health" '"schemas_loaded"'; then
+        PYTHONPATH="$relay_pkg${PYTHONPATH:+:$PYTHONPATH}" \
+            "$PYTHON_BIN" -m mock_relay --host 127.0.0.1 \
+            --ws-port "$MOCK_RELAY_PORT" --http-port "$MOCK_RELAY_HTTP_PORT" \
+            --log-level error >/dev/null 2>&1 &
+        MOCK_PIDS="$MOCK_PIDS $!"
+    fi
+
+    local deadline=$(( $(date +%s) + 30 ))
+    while [ "$(date +%s)" -lt "$deadline" ]; do
+        if probe_mock "http://127.0.0.1:$MOCK_SIGNALWIRE_PORT/__mock__/health" '"specs_loaded"' \
+            && probe_mock "http://127.0.0.1:$MOCK_RELAY_HTTP_PORT/__mock__/health" '"schemas_loaded"'; then
+            return 0
+        fi
+        sleep 0.2
+    done
+    echo "FATAL: mock servers did not become ready" >&2
+    return 1
+}
+
+kill_mocks() {
+    [ -n "$MOCK_PIDS" ] || return 0
+    # shellcheck disable=SC2086
+    kill $MOCK_PIDS 2>/dev/null || true
+    MOCK_PIDS=""
+}
+trap kill_mocks EXIT INT TERM
+
 FAILED_GATES=""
 
 run_gate() {
@@ -100,9 +167,17 @@ cd "$PORT_ROOT"
 
 echo "==> running CI gates for $PORT_NAME (porting-sdk at $PORTING_SDK_DIR)"
 
-# Gate 1: phpunit
-run_gate "TEST" "vendor/bin/phpunit" \
-    vendor/bin/phpunit
+# Gate 1: tests — run the full suite in PARALLEL via paratest (each file in
+# its own process). The mock-backed suites are session-isolated, so file
+# parallelism is safe; pure-unit files run independently too. We pre-spawn the
+# shared mock servers once (see spawn_mocks) so workers probe-and-reuse rather
+# than each spawning (and killing) their own.
+if spawn_mocks; then
+    run_gate "TEST" "paratest -p $PARALLEL_PROCS (parallel)" \
+        vendor/bin/paratest --runner=WrapperRunner -p "$PARALLEL_PROCS" --no-coverage
+else
+    FAILED_GATES="$FAILED_GATES TEST"
+fi
 
 # Gate 2: signature regen
 run_gate "SIGNATURES" "regenerate port_signatures.json" \

--- a/src/SignalWire/Relay/Client.php
+++ b/src/SignalWire/Relay/Client.php
@@ -243,7 +243,12 @@ class Client
 
         $result = $this->execute('signalwire.connect', $params);
 
-        $this->sessionId = $result['session_id'] ?? $this->sessionId;
+        // The RELAY ConnectResult carries the server-assigned id under the
+        // ``sessionid`` key (switchblade's ConnectResult shape; the mock
+        // mirrors it). Read that key — the journal records this connection's
+        // frames under the same value, which lets a test scope its journal
+        // reads/resets to its own session for concurrency-safe testing.
+        $this->sessionId = $result['sessionid'] ?? $this->sessionId;
         $this->protocol  = $result['protocol']   ?? $this->protocol;
         // Capture authorization blob if RELAY/audit fixture sent one.
         $authBlob = $result['authorization'] ?? null;

--- a/tests/Relay/ActionsMockTest.php
+++ b/tests/Relay/ActionsMockTest.php
@@ -44,9 +44,7 @@ class ActionsMockTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->mock = MockTest::harness();
-        $this->mock->reset();
-        $this->client = MockTest::client();
+        [$this->client, $this->mock] = MockTest::scopedClient();
     }
 
     protected function tearDown(): void

--- a/tests/Relay/CallConvenienceMockTest.php
+++ b/tests/Relay/CallConvenienceMockTest.php
@@ -38,9 +38,7 @@ class CallConvenienceMockTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->mock = MockTest::harness();
-        $this->mock->reset();
-        $this->client = MockTest::client();
+        [$this->client, $this->mock] = MockTest::scopedClient();
     }
 
     protected function tearDown(): void

--- a/tests/Relay/ConnectMockTest.php
+++ b/tests/Relay/ConnectMockTest.php
@@ -23,8 +23,26 @@ class ConnectMockTest extends TestCase
 
     protected function setUp(): void
     {
+        // Unscoped shared harness — used only for relayHost()/wsUrl() and for
+        // building hand-rolled clients. Tests that assert on journaled connect
+        // frames re-scope a harness to their own client's session via
+        // scopedFor() so they see ONLY their own frames and run parallel-safe.
+        // No global reset here: a global wipe would race a concurrent test.
         $this->mock = MockTest::harness();
-        $this->mock->reset();
+    }
+
+    /**
+     * Return a harness view scoped to a connected client's RELAY session, so
+     * journal reads see only that client's frames. Pass several clients to
+     * cover a reconnect pair (the second connect reuses the first's session
+     * id when it resumes a protocol, so scoping to either id surfaces both).
+     */
+    private function scopedFor(RelayClient $client): RelayHarness
+    {
+        $h = MockTest::harness();
+        $scoped = new RelayHarness($h->httpUrl(), $h->wsPort(), $h->httpPort());
+        $scoped->scopeTo((string) $client->sessionId);
+        return $scoped;
     }
 
     // ------------------------------------------------------------------
@@ -34,7 +52,7 @@ class ConnectMockTest extends TestCase
     #[Test]
     public function connectReturnsProtocolString(): void
     {
-        $client = MockTest::client();
+        [$client, $mock] = MockTest::scopedClient();
         try {
             $this->assertTrue($client->connected);
             $this->assertNotNull($client->protocol);
@@ -43,21 +61,22 @@ class ConnectMockTest extends TestCase
                 (string) $client->protocol,
                 'unexpected protocol: ' . var_export($client->protocol, true),
             );
+
+            // Journal assertion — the connect frame was recorded (scoped to
+            // this client's session, so exactly one even under parallelism).
+            $entries = $mock->journal()->recv('signalwire.connect');
+            $this->assertCount(1, $entries, 'exactly one signalwire.connect was journaled');
         } finally {
             $client->disconnect();
         }
-
-        // Journal assertion — the connect frame was recorded.
-        $entries = $this->mock->journal()->recv('signalwire.connect');
-        $this->assertCount(1, $entries, 'exactly one signalwire.connect was journaled');
     }
 
     #[Test]
     public function connectJournalRecordsSignalwireConnect(): void
     {
-        $client = MockTest::client();
+        [$client, $mock] = MockTest::scopedClient();
         try {
-            $entries = $this->mock->journal()->recv('signalwire.connect');
+            $entries = $mock->journal()->recv('signalwire.connect');
             $this->assertCount(1, $entries);
         } finally {
             $client->disconnect();
@@ -67,9 +86,9 @@ class ConnectMockTest extends TestCase
     #[Test]
     public function connectJournalCarriesProjectAndToken(): void
     {
-        $client = MockTest::client();
+        [$client, $mock] = MockTest::scopedClient();
         try {
-            $entries = $this->mock->journal()->recv('signalwire.connect');
+            $entries = $mock->journal()->recv('signalwire.connect');
             $this->assertCount(1, $entries);
             $auth = $entries[0]->frame['params']['authentication'] ?? null;
             $this->assertIsArray($auth);
@@ -83,9 +102,9 @@ class ConnectMockTest extends TestCase
     #[Test]
     public function connectJournalCarriesContexts(): void
     {
-        $client = MockTest::client();
+        [$client, $mock] = MockTest::scopedClient();
         try {
-            $entries = $this->mock->journal()->recv('signalwire.connect');
+            $entries = $mock->journal()->recv('signalwire.connect');
             $this->assertCount(1, $entries);
             $this->assertSame(['default'], $entries[0]->frame['params']['contexts'] ?? null);
         } finally {
@@ -96,9 +115,9 @@ class ConnectMockTest extends TestCase
     #[Test]
     public function connectJournalCarriesAgentAndVersion(): void
     {
-        $client = MockTest::client();
+        [$client, $mock] = MockTest::scopedClient();
         try {
-            $entries = $this->mock->journal()->recv('signalwire.connect');
+            $entries = $mock->journal()->recv('signalwire.connect');
             $this->assertCount(1, $entries);
             $p = $entries[0]->frame['params'] ?? [];
             $this->assertIsArray($p);
@@ -112,9 +131,9 @@ class ConnectMockTest extends TestCase
     #[Test]
     public function connectJournalEventAcksTrue(): void
     {
-        $client = MockTest::client();
+        [$client, $mock] = MockTest::scopedClient();
         try {
-            $entries = $this->mock->journal()->recv('signalwire.connect');
+            $entries = $mock->journal()->recv('signalwire.connect');
             $this->assertCount(1, $entries);
             $this->assertTrue($entries[0]->frame['params']['event_acks'] ?? null);
         } finally {
@@ -131,7 +150,9 @@ class ConnectMockTest extends TestCase
     {
         $issuedProtocol = null;
 
-        $c1 = MockTest::client();
+        // scopedClient() (NOT the legacy client(), which does a GLOBAL journal
+        // reset that would wipe concurrent workers' journals under parallelism).
+        [$c1] = MockTest::scopedClient();
         try {
             $issuedProtocol = $c1->protocol;
             $this->assertNotNull($issuedProtocol);
@@ -150,24 +171,26 @@ class ConnectMockTest extends TestCase
         $c2->protocol = $issuedProtocol;
         try {
             $c2->connect();
+            // The resume connect carries the protocol and is journaled under
+            // c2's own session — scope to it so we read only this test's frame.
+            $matches = [];
+            foreach ($this->scopedFor($c2)->journal()->recv('signalwire.connect') as $entry) {
+                if (($entry->frame['params']['protocol'] ?? null) === $issuedProtocol) {
+                    $matches[] = $entry;
+                }
+            }
+            $this->assertNotEmpty($matches, 'no resume connect carried the issued protocol');
         } finally {
             $c2->disconnect();
         }
-
-        // Find a connect frame that carries the resumed protocol.
-        $matches = [];
-        foreach ($this->mock->journal()->recv('signalwire.connect') as $entry) {
-            if (($entry->frame['params']['protocol'] ?? null) === $issuedProtocol) {
-                $matches[] = $entry;
-            }
-        }
-        $this->assertNotEmpty($matches, 'no resume connect carried the issued protocol');
     }
 
     #[Test]
     public function reconnectWithProtocolPreservesProtocolValue(): void
     {
-        $c1 = MockTest::client();
+        // scopedClient() (NOT the legacy client(), which does a GLOBAL journal
+        // reset that would wipe concurrent workers' journals under parallelism).
+        [$c1] = MockTest::scopedClient();
         try {
             $issuedProtocol = $c1->protocol;
             $this->assertNotNull($issuedProtocol);
@@ -185,19 +208,19 @@ class ConnectMockTest extends TestCase
         try {
             $c2->connect();
             $this->assertSame($issuedProtocol, $c2->protocol);
+
+            // Confirm c2's own journaled connect carries that protocol.
+            $found = false;
+            foreach ($this->scopedFor($c2)->journal()->recv('signalwire.connect') as $entry) {
+                if (($entry->frame['params']['protocol'] ?? null) === $issuedProtocol) {
+                    $found = true;
+                    break;
+                }
+            }
+            $this->assertTrue($found, 'no journal entry carried the resumed protocol');
         } finally {
             $c2->disconnect();
         }
-
-        // Confirm at least one journaled connect carries that protocol.
-        $found = false;
-        foreach ($this->mock->journal()->recv('signalwire.connect') as $entry) {
-            if (($entry->frame['params']['protocol'] ?? null) === $issuedProtocol) {
-                $found = true;
-                break;
-            }
-        }
-        $this->assertTrue($found, 'no journal entry carried the resumed protocol');
     }
 
     // ------------------------------------------------------------------
@@ -207,9 +230,8 @@ class ConnectMockTest extends TestCase
     #[Test]
     public function connectRejectsEmptyCredsAtConstructor(): void
     {
-        // Reset journal so we can also assert that nothing was sent.
-        $this->mock->reset();
-
+        // No journal reset needed: the constructor throws before any wire I/O,
+        // and a global reset would race a concurrent test under parallelism.
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessageMatches('/project and token are required/');
         new RelayClient(['project' => '', 'token' => '', 'host' => 'anywhere']);
@@ -268,18 +290,18 @@ class ConnectMockTest extends TestCase
         try {
             $client->connect();
             $this->assertTrue($client->connected);
+
+            $entries = $this->scopedFor($client)->journal()->recv('signalwire.connect');
+            $this->assertCount(1, $entries);
+            $auth = $entries[0]->frame['params']['authentication'] ?? null;
+            $this->assertIsArray($auth);
+            $this->assertSame('fake-jwt-eyJ.AaaA.BbB', $auth['jwt_token'] ?? null);
+            // JWT path: project/token must NOT be on the wire.
+            $this->assertArrayNotHasKey('project', $auth);
+            $this->assertArrayNotHasKey('token', $auth);
         } finally {
             $client->disconnect();
         }
-
-        $entries = $this->mock->journal()->recv('signalwire.connect');
-        $this->assertCount(1, $entries);
-        $auth = $entries[0]->frame['params']['authentication'] ?? null;
-        $this->assertIsArray($auth);
-        $this->assertSame('fake-jwt-eyJ.AaaA.BbB', $auth['jwt_token'] ?? null);
-        // JWT path: project/token must NOT be on the wire.
-        $this->assertArrayNotHasKey('project', $auth);
-        $this->assertArrayNotHasKey('token', $auth);
     }
 }
 

--- a/tests/Relay/EventDispatchMockTest.php
+++ b/tests/Relay/EventDispatchMockTest.php
@@ -26,9 +26,7 @@ class EventDispatchMockTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->mock = MockTest::harness();
-        $this->mock->reset();
-        $this->client = MockTest::client();
+        [$this->client, $this->mock] = MockTest::scopedClient();
     }
 
     protected function tearDown(): void
@@ -276,9 +274,11 @@ class EventDispatchMockTest extends TestCase
     public function dialEventRoutesViaTagWhenNoTopLevelCallId(): void
     {
         // Use a fresh client so the dial is independent of the shared one.
-        $client = MockTest::client();
+        // It needs its OWN scoped harness so the armed scenario and journal
+        // reads target this second client's session, not setUp's.
+        [$client, $mock] = MockTest::scopedClient();
         try {
-            $this->mock->scenarios()->armDial([
+            $mock->scenarios()->armDial([
                 'tag'            => 'ec-tag-route',
                 'winner_call_id' => 'WINTAG',
                 'states'         => ['created', 'answered'],
@@ -291,7 +291,7 @@ class EventDispatchMockTest extends TestCase
             );
             $this->assertSame('WINTAG', $call->callId);
 
-            $sends = $this->mock->journal()->send('calling.call.dial');
+            $sends = $mock->journal()->send('calling.call.dial');
             $this->assertNotEmpty($sends);
             $inner = $sends[count($sends) - 1]->frame['params']['params'] ?? [];
             // Top-level params: tag, dial_state, call. NO call_id.

--- a/tests/Relay/FaxActionConstructorTest.php
+++ b/tests/Relay/FaxActionConstructorTest.php
@@ -29,8 +29,8 @@ class FaxActionConstructorTest extends TestCase
         // Bring up a real (mock-backed) client so we have something to
         // pass as the $client param. We never actually drive the wire
         // here — these are unit-shape tests on the Action class itself.
-        MockTest::harness()->reset();
-        $this->client = MockTest::client();
+        // Use a scoped client (no global reset) so this is parallel-safe.
+        [$this->client] = MockTest::scopedClient();
     }
 
     protected function tearDown(): void

--- a/tests/Relay/InboundCallMockTest.php
+++ b/tests/Relay/InboundCallMockTest.php
@@ -26,9 +26,7 @@ class InboundCallMockTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->mock = MockTest::harness();
-        $this->mock->reset();
-        $this->client = MockTest::client();
+        [$this->client, $this->mock] = MockTest::scopedClient();
     }
 
     protected function tearDown(): void
@@ -455,11 +453,18 @@ class InboundCallMockTest extends TestCase
         // thread on its expect_recv waiting for calling.answer that the
         // SDK can't ship until we read.
         $http = $this->mock->httpUrl();
+        // Stamp every push/expect_recv op with THIS test's session id so the
+        // timeline (run from a forked curl that bypasses the harness's own
+        // op-stamping) targets only this client and expect_recv matches only
+        // this session's frames — parallel-safe. The output file is also made
+        // session-unique so concurrent runs don't clobber each other's status.
+        $sid = $this->mock->sessionId();
+        $outFile = sys_get_temp_dir() . '/scenario_play_' . $sid . '.out';
         $cmd = sprintf(
             'curl -fsS -X POST -H "Content-Type: application/json" '
-            . '-d %s %s/__mock__/scenario_play > /tmp/scenario_play.out 2>&1 & echo $!',
+            . '-d %s %s/__mock__/scenario_play > %s 2>&1 & echo $!',
             escapeshellarg(json_encode([
-                ['push' => ['frame' => [
+                ['push' => ['session_id' => $sid, 'frame' => [
                     'jsonrpc' => '2.0',
                     'id'      => bin2hex(random_bytes(8)),
                     'method'  => 'signalwire.event',
@@ -482,12 +487,13 @@ class InboundCallMockTest extends TestCase
                         ],
                     ],
                 ]]],
-                ['expect_recv' => ['method' => 'calling.answer', 'timeout_ms' => 5000]],
-                ['push' => ['frame' => self::stateFrame('c-scen', 'answered')]],
+                ['expect_recv' => ['method' => 'calling.answer', 'timeout_ms' => 5000, 'session_id' => $sid]],
+                ['push' => ['session_id' => $sid, 'frame' => self::stateFrame('c-scen', 'answered')]],
                 ['sleep_ms' => 50],
-                ['push' => ['frame' => self::stateFrame('c-scen', 'ended')]],
+                ['push' => ['session_id' => $sid, 'frame' => self::stateFrame('c-scen', 'ended')]],
             ], JSON_THROW_ON_ERROR)),
             escapeshellarg($http),
+            escapeshellarg($outFile),
         );
         $pid = trim((string) shell_exec($cmd));
         $this->assertNotEmpty($pid, 'failed to fork scenario_play curl');
@@ -508,8 +514,8 @@ class InboundCallMockTest extends TestCase
         $deadline = microtime(true) + 5.0;
         $out = '';
         while (microtime(true) < $deadline) {
-            if (file_exists('/tmp/scenario_play.out')) {
-                $out = (string) file_get_contents('/tmp/scenario_play.out');
+            if (file_exists($outFile)) {
+                $out = (string) file_get_contents($outFile);
                 if (str_contains($out, 'completed') || str_contains($out, 'timeout')) {
                     break;
                 }

--- a/tests/Relay/MessagingMockTest.php
+++ b/tests/Relay/MessagingMockTest.php
@@ -27,9 +27,7 @@ class MessagingMockTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->mock = MockTest::harness();
-        $this->mock->reset();
-        $this->client = MockTest::client();
+        [$this->client, $this->mock] = MockTest::scopedClient();
     }
 
     protected function tearDown(): void

--- a/tests/Relay/MockTest.php
+++ b/tests/Relay/MockTest.php
@@ -46,21 +46,32 @@ class MockTest extends TestCase
      */
     public function testHarnessIsReachable(): void
     {
-        $h = self::harness();
-        $h->reset();
-        $this->assertSame(self::resolveHttpPort(), $h->httpPort());
-        $this->assertStringStartsWith('ws://127.0.0.1:', $h->wsUrl());
-        $this->assertStringStartsWith('http://127.0.0.1:', $h->httpUrl());
-        // Hitting /__mock__/health via the harness returns at least one
-        // entry of the mock's introspection — sanity-check journal/scenarios
-        // are wired up.
-        $this->assertSame([], $h->journal()->all());
+        // Use a SCOPED client so this sentinel is parallel-safe: it neither
+        // wipes the shared journal (a global reset would race a concurrent
+        // test) nor asserts on the global journal (other sessions' frames are
+        // in it). A fresh session's scoped journal contains only its own
+        // connect frame.
+        [$client, $mock] = self::scopedClient();
+        try {
+            $this->assertSame(self::resolveHttpPort(), $mock->httpPort());
+            $this->assertStringStartsWith('ws://127.0.0.1:', $mock->wsUrl());
+            $this->assertStringStartsWith('http://127.0.0.1:', $mock->httpUrl());
+            $this->assertNotSame('', $mock->sessionId(), 'client captured a session id');
+            // Scoped journal sees this session's own signalwire.connect.
+            $this->assertNotEmpty($mock->journal()->recv('signalwire.connect'));
+        } finally {
+            $client->disconnect();
+        }
     }
 
     /**
      * Boot a freshly connected RelayClient pointed at the local mock server.
      * Resets the journal + scenarios before returning. The caller is
      * responsible for calling $client->disconnect() on teardown.
+     *
+     * Legacy/unscoped helper — kept for callers that drive the shared mock
+     * serially (and resets the GLOBAL journal/scenarios). Parallel-safe tests
+     * should use {@link scopedClient()} instead.
      *
      * @param array<string,mixed> $extra Additional constructor options.
      */
@@ -84,6 +95,49 @@ class MockTest extends TestCase
     }
 
     /**
+     * Boot a freshly connected RelayClient plus a per-test {@link RelayHarness}
+     * scoped to THIS client's RELAY session, so the test's journal reads/resets
+     * see only its own frames and scenario arming/pushes target only its own
+     * session — making the shared mock safe under file/process parallelism.
+     *
+     * Isolation key: the server-assigned ``sessionid`` from the connect
+     * handshake (RELAY's session key), captured by the SDK into
+     * ``$client->sessionId``. The mock journals this connection's frames under
+     * that id and scopes scenarios by it, so a scoped harness threads
+     * ``?session_id=<id>`` onto every control-plane call.
+     *
+     * No global reset is needed: a brand-new session starts with an empty
+     * (scoped) journal. The caller MUST call ``$client->disconnect()`` on
+     * teardown.
+     *
+     * @param array<string,mixed> $extra Additional constructor options.
+     * @return array{0: RelayClient, 1: RelayHarness}  [client, scopedHarness]
+     */
+    public static function scopedClient(array $extra = []): array
+    {
+        $shared = self::harness();
+        $opts = array_merge(
+            [
+                'project'  => 'test_proj',
+                'token'    => 'test_tok',
+                'host'     => $shared->relayHost(),
+                'scheme'   => 'ws',
+                'contexts' => ['default'],
+            ],
+            $extra,
+        );
+        $client = new RelayClient($opts);
+        $client->connect();
+
+        // Per-call harness view scoped to THIS client's session id, so the
+        // test only ever sees/disturbs its own frames + scenarios.
+        $mock = new RelayHarness($shared->httpUrl(), $shared->wsPort(), $shared->httpPort());
+        $mock->scopeTo((string) $client->sessionId);
+
+        return [$client, $mock];
+    }
+
+    /**
      * Return the Harness (lazily booting the mock server). Tests that need
      * to inspect the journal or push scenarios should call this directly;
      * client() is a convenience wrapper that also resets state.
@@ -104,51 +158,79 @@ class MockTest extends TestCase
         $httpPort = self::resolveHttpPort();
         $base = 'http://127.0.0.1:' . $httpPort;
 
-        if (self::probeHealth($base)) {
+        // Probe with retries BEFORE deciding to spawn. Under heavy parallel
+        // load (e.g. paratest with many workers), the single-threaded mock can
+        // be slow to answer a health probe; a single short probe would falsely
+        // conclude "not running" and spawn a REDUNDANT server on the same port
+        // — which then can't bind and leaves WS/HTTP hitting inconsistent
+        // instances. Retrying over a few seconds detects a busy-but-alive
+        // server and reuses it, so under parallelism exactly one server is ever
+        // used. (The run-ci.sh lifecycle pre-spawns one; this is the safety net
+        // for any worker that probes while the server is saturated.)
+        if (self::probeHealthWithRetries($base)) {
             self::$sharedHarness = new RelayHarness($base, $wsPort, $httpPort);
             return self::$sharedHarness;
         }
 
-        try {
-            self::$mockProcess = self::spawnMockServer($wsPort, $httpPort);
-        } catch (\Throwable $e) {
-            self::$startupFailure = $e;
-            throw new \RuntimeException(
-                'MockTest: failed to spawn `python -m mock_relay`: ' . $e->getMessage()
-                . ' (set MOCK_RELAY_PORT / MOCK_RELAY_HTTP_PORT to use a pre-running instance)',
-                0,
-                $e
-            );
+        // Serialize spawning across parallel paratest workers with a
+        // cross-process file lock so AT MOST ONE worker ever spawns a server on
+        // this port. After acquiring the lock we re-probe: another worker may
+        // have just spawned it while we waited. We deliberately do NOT register
+        // a per-worker shutdown hook to kill the server — under parallelism the
+        // worker that spawned it usually exits first, and killing the shared
+        // server would yank it out from under still-running workers. The mock
+        // is reused across runs (probe-and-reuse) and torn down by the
+        // run-ci.sh lifecycle trap; a leaked idle server between local runs is
+        // harmless (the next run reuses it).
+        $lock = @fopen(sys_get_temp_dir() . '/sw_mock_relay_' . $httpPort . '.lock', 'c');
+        if ($lock !== false) {
+            @flock($lock, LOCK_EX);
         }
-
-        $deadline = microtime(true) + self::STARTUP_TIMEOUT_SEC;
-        while (microtime(true) < $deadline) {
+        try {
+            // Re-probe under the lock — another worker may have spawned it.
             if (self::probeHealth($base)) {
                 self::$sharedHarness = new RelayHarness($base, $wsPort, $httpPort);
-                $proc = self::$mockProcess;
-                register_shutdown_function(static function () use ($proc): void {
-                    if (is_resource($proc)) {
-                        @proc_terminate($proc);
-                        @proc_close($proc);
-                    }
-                });
                 return self::$sharedHarness;
             }
-            usleep(150_000);
+            try {
+                self::$mockProcess = self::spawnMockServer($wsPort, $httpPort);
+            } catch (\Throwable $e) {
+                self::$startupFailure = $e;
+                throw new \RuntimeException(
+                    'MockTest: failed to spawn `python -m mock_relay`: ' . $e->getMessage()
+                    . ' (set MOCK_RELAY_PORT / MOCK_RELAY_HTTP_PORT to use a pre-running instance)',
+                    0,
+                    $e
+                );
+            }
+
+            $deadline = microtime(true) + self::STARTUP_TIMEOUT_SEC;
+            while (microtime(true) < $deadline) {
+                if (self::probeHealth($base)) {
+                    self::$sharedHarness = new RelayHarness($base, $wsPort, $httpPort);
+                    return self::$sharedHarness;
+                }
+                usleep(150_000);
+            }
+            if (is_resource(self::$mockProcess)) {
+                @proc_terminate(self::$mockProcess);
+                @proc_close(self::$mockProcess);
+                self::$mockProcess = null;
+            }
+            $err = new \RuntimeException(
+                'MockTest: `python -m mock_relay` did not become ready within '
+                . self::STARTUP_TIMEOUT_SEC . 's on http port ' . $httpPort
+                . ' (clone porting-sdk next to signalwire-php so tests can find '
+                . 'porting-sdk/test_harness/mock_relay/, or pip install the mock_relay package)'
+            );
+            self::$startupFailure = $err;
+            throw $err;
+        } finally {
+            if ($lock !== false) {
+                @flock($lock, LOCK_UN);
+                @fclose($lock);
+            }
         }
-        if (is_resource(self::$mockProcess)) {
-            @proc_terminate(self::$mockProcess);
-            @proc_close(self::$mockProcess);
-            self::$mockProcess = null;
-        }
-        $err = new \RuntimeException(
-            'MockTest: `python -m mock_relay` did not become ready within '
-            . self::STARTUP_TIMEOUT_SEC . 's on http port ' . $httpPort
-            . ' (clone porting-sdk next to signalwire-php so tests can find '
-            . 'porting-sdk/test_harness/mock_relay/, or pip install the mock_relay package)'
-        );
-        self::$startupFailure = $err;
-        throw $err;
     }
 
     /**
@@ -295,14 +377,16 @@ class MockTest extends TestCase
 
     /**
      * Probe /__mock__/health. Returns true on 200 + "schemas_loaded" in body.
+     * A generous timeout so a busy (but alive) single-threaded mock under
+     * parallel load isn't mistaken for "down".
      */
     private static function probeHealth(string $base): bool
     {
         $ch = curl_init($base . '/__mock__/health');
         curl_setopt_array($ch, [
             CURLOPT_RETURNTRANSFER => true,
-            CURLOPT_TIMEOUT => 2,
-            CURLOPT_CONNECTTIMEOUT => 2,
+            CURLOPT_TIMEOUT => 10,
+            CURLOPT_CONNECTTIMEOUT => 5,
         ]);
         $body = curl_exec($ch);
         $code = (int) curl_getinfo($ch, CURLINFO_HTTP_CODE);
@@ -311,6 +395,23 @@ class MockTest extends TestCase
             return false;
         }
         return str_contains($body, '"schemas_loaded"');
+    }
+
+    /**
+     * Probe repeatedly for up to ~10s before concluding the server is down.
+     * Reuses a busy-but-alive server under parallel load so no worker ever
+     * spawns a redundant second server on an occupied port.
+     */
+    private static function probeHealthWithRetries(string $base): bool
+    {
+        $deadline = microtime(true) + 10.0;
+        do {
+            if (self::probeHealth($base)) {
+                return true;
+            }
+            usleep(200_000);
+        } while (microtime(true) < $deadline);
+        return false;
     }
 }
 
@@ -326,6 +427,15 @@ final class RelayHarness
     private RelayJournal $journal;
     private RelayScenarios $scenarios;
 
+    /**
+     * When set, journal reads/resets, scenario arming/reset, and the default
+     * target of push()/inboundCall()/scenarioPlay() are scoped to this session
+     * id (the server-assigned ``sessionid`` from the connect handshake), so a
+     * test only ever sees/disturbs its own frames. Empty => global (legacy,
+     * single-threaded). {@link MockTest::scopedClient()} sets this.
+     */
+    private string $sessionId = '';
+
     public function __construct(string $httpUrl, int $wsPort, int $httpPort)
     {
         $this->httpUrl = $httpUrl;
@@ -333,6 +443,25 @@ final class RelayHarness
         $this->httpPort = $httpPort;
         $this->journal = new RelayJournal($httpUrl);
         $this->scenarios = new RelayScenarios($httpUrl);
+    }
+
+    /**
+     * Scope this harness to one RELAY session (the connect-handshake
+     * ``sessionid``). Threads ``?session_id=<id>`` onto every control-plane
+     * call so the harness is safe to use concurrently with other tests against
+     * the one shared mock.
+     */
+    public function scopeTo(string $sessionId): void
+    {
+        $this->sessionId = $sessionId;
+        $this->journal->scopeTo($sessionId);
+        $this->scenarios->scopeTo($sessionId);
+    }
+
+    /** The session id this harness is scoped to ('' when unscoped). */
+    public function sessionId(): string
+    {
+        return $this->sessionId;
     }
 
     public function httpUrl(): string
@@ -378,9 +507,13 @@ final class RelayHarness
      */
     public function push(array $frame, ?string $sessionId = null): array
     {
+        // Default to this harness's session so a parallel test's client never
+        // receives the push; an explicit arg overrides; an unscoped harness
+        // with no arg broadcasts (legacy single-threaded behavior).
+        $target = $sessionId ?? ($this->sessionId !== '' ? $this->sessionId : null);
         $url = $this->httpUrl . '/__mock__/push';
-        if ($sessionId !== null && $sessionId !== '') {
-            $url .= '?session_id=' . rawurlencode($sessionId);
+        if ($target !== null && $target !== '') {
+            $url .= '?session_id=' . rawurlencode($target);
         }
         $payload = json_encode(['frame' => $frame], JSON_THROW_ON_ERROR);
         $body = RelayMockHttp::postJson($url, $payload);
@@ -396,6 +529,12 @@ final class RelayHarness
      */
     public function inboundCall(array $opts = []): array
     {
+        // Target this harness's session by default so the inbound-call sequence
+        // is delivered only to this test's client (an unscoped harness
+        // broadcasts, as before). An explicit opts['session_id'] overrides.
+        if ($this->sessionId !== '' && !array_key_exists('session_id', $opts)) {
+            $opts['session_id'] = $this->sessionId;
+        }
         $payload = json_encode($opts, JSON_THROW_ON_ERROR);
         $body = RelayMockHttp::postJson($this->httpUrl . '/__mock__/inbound_call', $payload);
         return self::decode($body);
@@ -409,6 +548,13 @@ final class RelayHarness
      */
     public function scenarioPlay(array $ops): array
     {
+        // When scoped, stamp every push/expect_recv op with this session id
+        // (unless the op already carries one), so the timeline targets only
+        // this test's client and expect_recv matches only this session's
+        // frames — making it parallel-safe.
+        if ($this->sessionId !== '') {
+            $ops = array_map(fn (array $op): array => $this->scopeOp($op), $ops);
+        }
         $payload = json_encode($ops, JSON_THROW_ON_ERROR);
         $body = RelayMockHttp::postJson(
             $this->httpUrl . '/__mock__/scenario_play',
@@ -416,6 +562,26 @@ final class RelayHarness
             timeoutSec: 30,
         );
         return self::decode($body);
+    }
+
+    /**
+     * Inject this harness's session id into a timeline op's push/expect_recv
+     * spec when the op doesn't already specify a session_id. Leaves sleep ops
+     * untouched.
+     *
+     * @param array<string,mixed> $op
+     * @return array<string,mixed>
+     */
+    private function scopeOp(array $op): array
+    {
+        foreach (['push', 'expect_recv'] as $key) {
+            $spec = $op[$key] ?? null;
+            if (is_array($spec) && !array_key_exists('session_id', $spec)) {
+                $spec['session_id'] = $this->sessionId;
+                $op[$key] = $spec;
+            }
+        }
+        return $op;
     }
 
     /**
@@ -461,21 +627,43 @@ final class RelayJournal
 {
     private string $base;
 
+    /**
+     * When set, journal reads/resets are scoped to this session id (the
+     * server-assigned ``sessionid``), so a test only ever sees its own frames.
+     * Empty => global (legacy, single-threaded).
+     */
+    private string $sessionId = '';
+
     public function __construct(string $base)
     {
         $this->base = $base;
     }
 
+    /** Scope journal reads/resets to one session id. */
+    public function scopeTo(string $sessionId): void
+    {
+        $this->sessionId = $sessionId;
+    }
+
+    /** ``?session_id=<id>`` suffix when scoped, else ''. */
+    private function sessionQuery(): string
+    {
+        return $this->sessionId !== ''
+            ? '?session_id=' . rawurlencode($this->sessionId)
+            : '';
+    }
+
     /**
      * Return every frame the mock recorded since the last reset, in
      * arrival order (server PoV: ``recv`` = frame from the SDK,
-     * ``send`` = frame from the server back to the SDK).
+     * ``send`` = frame from the server back to the SDK). Scoped to this
+     * session when set.
      *
      * @return list<RelayJournalEntry>
      */
     public function all(): array
     {
-        $body = RelayMockHttp::get($this->base . '/__mock__/journal');
+        $body = RelayMockHttp::get($this->base . '/__mock__/journal' . $this->sessionQuery());
         $decoded = json_decode($body, true, flags: JSON_THROW_ON_ERROR);
         if (!is_array($decoded)) {
             throw new \RuntimeException('mock_relay: journal body is not a JSON array');
@@ -556,7 +744,7 @@ final class RelayJournal
 
     public function reset(): void
     {
-        RelayMockHttp::post($this->base . '/__mock__/journal/reset');
+        RelayMockHttp::post($this->base . '/__mock__/journal/reset' . $this->sessionQuery());
     }
 }
 
@@ -612,13 +800,35 @@ final class RelayScenarios
 {
     private string $base;
 
+    /**
+     * When set, scenarios are armed/reset under this session id (scenarios are
+     * session-scoped on the mock), so a scoped harness arms only its own queue
+     * and clears only its own — safe under parallel execution. Empty => global.
+     */
+    private string $sessionId = '';
+
     public function __construct(string $base)
     {
         $this->base = $base;
     }
 
+    /** Scope scenario arming/reset to one session id. */
+    public function scopeTo(string $sessionId): void
+    {
+        $this->sessionId = $sessionId;
+    }
+
+    /** ``?session_id=<id>`` suffix when scoped, else ''. */
+    private function sessionQuery(): string
+    {
+        return $this->sessionId !== ''
+            ? '?session_id=' . rawurlencode($this->sessionId)
+            : '';
+    }
+
     /**
      * Queue scripted post-RPC events for the named method (FIFO consume-once).
+     * Scoped to this harness's session when set.
      *
      * @param list<array<string,mixed>> $events
      */
@@ -626,14 +836,14 @@ final class RelayScenarios
     {
         $payload = json_encode($events, JSON_THROW_ON_ERROR);
         RelayMockHttp::postJson(
-            $this->base . '/__mock__/scenarios/' . rawurlencode($method),
+            $this->base . '/__mock__/scenarios/' . rawurlencode($method) . $this->sessionQuery(),
             $payload,
         );
     }
 
     /**
      * Queue a dial-dance scenario (winner state events + per-loser state
-     * events + final dial event).
+     * events + final dial event). Scoped to this harness's session when set.
      *
      * @param array<string,mixed> $body
      */
@@ -641,14 +851,14 @@ final class RelayScenarios
     {
         $payload = json_encode($body, JSON_THROW_ON_ERROR);
         RelayMockHttp::postJson(
-            $this->base . '/__mock__/scenarios/dial',
+            $this->base . '/__mock__/scenarios/dial' . $this->sessionQuery(),
             $payload,
         );
     }
 
     public function reset(): void
     {
-        RelayMockHttp::post($this->base . '/__mock__/scenarios/reset');
+        RelayMockHttp::post($this->base . '/__mock__/scenarios/reset' . $this->sessionQuery());
     }
 }
 

--- a/tests/Relay/OutboundCallMockTest.php
+++ b/tests/Relay/OutboundCallMockTest.php
@@ -27,9 +27,7 @@ class OutboundCallMockTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->mock = MockTest::harness();
-        $this->mock->reset();
-        $this->client = MockTest::client();
+        [$this->client, $this->mock] = MockTest::scopedClient();
     }
 
     protected function tearDown(): void
@@ -91,7 +89,25 @@ class OutboundCallMockTest extends TestCase
             ['tag' => 't-frame', 'dial_timeout' => 5.0],
         );
         $entries = $this->mock->journal()->recv('calling.dial');
-        $this->assertCount(1, $entries);
+        $diag = '';
+        if (count($entries) !== 1) {
+            $globalRaw = \SignalWire\Tests\Relay\RelayMockHttp::get($this->mock->httpUrl() . '/__mock__/journal');
+            $global = json_decode($globalRaw, true) ?: [];
+            $dials = [];
+            $sessions = [];
+            foreach ($global as $e) {
+                $sessions[$e['session_id'] ?? '?'] = true;
+                if (($e['method'] ?? '') === 'calling.dial' && ($e['direction'] ?? '') === 'recv') {
+                    $dials[] = ['session_id' => $e['session_id'] ?? '?', 'tag' => $e['frame']['params']['tag'] ?? '?'];
+                }
+            }
+            $diag = "\nDIAG scopedSid=" . $this->mock->sessionId()
+                . " clientSid=" . (string) $this->client->sessionId
+                . " globalEntries=" . count($global)
+                . " distinctSessions=" . count($sessions)
+                . " globalDials=" . json_encode($dials);
+        }
+        $this->assertCount(1, $entries, $diag);
         $p = $entries[0]->frame['params'] ?? [];
         $this->assertSame('t-frame', $p['tag'] ?? null);
         $this->assertIsArray($p['devices'] ?? null);
@@ -164,8 +180,12 @@ class OutboundCallMockTest extends TestCase
         $worker = AsyncWorker::launch(<<<'WORKER'
             $http = $argv[1];
             $winnerCallId = $argv[2];
+            // Session id scopes both the journal read and the push so this
+            // worker only ever sees / targets ITS test's client — parallel-safe.
+            $sid = $argv[3] ?? '';
+            $q = $sid !== '' ? '?session_id=' . rawurlencode($sid) : '';
             for ($i = 0; $i < 400; $i++) {
-                $body = @file_get_contents($http . '/__mock__/journal');
+                $body = @file_get_contents($http . '/__mock__/journal' . $q);
                 if (is_string($body)) {
                     $entries = json_decode($body, true) ?? [];
                     foreach ($entries as $e) {
@@ -175,7 +195,6 @@ class OutboundCallMockTest extends TestCase
                         ) {
                             $tag = $e['frame']['params']['tag'] ?? '';
                             if ($tag === '') break 2;
-                            file_put_contents('/tmp/auto_tag.txt', $tag);
                             $payload = json_encode([
                                 'frame' => [
                                     'jsonrpc' => '2.0',
@@ -212,14 +231,14 @@ class OutboundCallMockTest extends TestCase
                                     'timeout' => 5,
                                 ],
                             ]);
-                            @file_get_contents($http . '/__mock__/push', false, $ctx);
+                            @file_get_contents($http . '/__mock__/push' . $q, false, $ctx);
                             exit(0);
                         }
                     }
                 }
                 usleep(50_000);
             }
-            WORKER, [$this->mock->httpUrl(), 'auto-tag-winner']);
+            WORKER, [$this->mock->httpUrl(), 'auto-tag-winner', $this->mock->sessionId()]);
 
         try {
             $call = $this->client->dial(
@@ -253,8 +272,12 @@ class OutboundCallMockTest extends TestCase
         $worker = AsyncWorker::launch(<<<'WORKER'
             $http = $argv[1];
             $tag = $argv[2];
+            // Session id scopes both the journal read and the push so this
+            // worker only ever sees / targets ITS test's client — parallel-safe.
+            $sid = $argv[3] ?? '';
+            $q = $sid !== '' ? '?session_id=' . rawurlencode($sid) : '';
             for ($i = 0; $i < 400; $i++) {
-                $body = @file_get_contents($http . '/__mock__/journal');
+                $body = @file_get_contents($http . '/__mock__/journal' . $q);
                 if (is_string($body)) {
                     $entries = json_decode($body, true) ?? [];
                     foreach ($entries as $e) {
@@ -286,14 +309,14 @@ class OutboundCallMockTest extends TestCase
                                     'timeout' => 5,
                                 ],
                             ]);
-                            @file_get_contents($http . '/__mock__/push', false, $ctx);
+                            @file_get_contents($http . '/__mock__/push' . $q, false, $ctx);
                             exit(0);
                         }
                     }
                 }
                 usleep(50_000);
             }
-            WORKER, [$this->mock->httpUrl(), 't-fail']);
+            WORKER, [$this->mock->httpUrl(), 't-fail', $this->mock->sessionId()]);
 
         try {
             $thrown = null;

--- a/tests/Relay/QueueAndDigitMockTest.php
+++ b/tests/Relay/QueueAndDigitMockTest.php
@@ -25,9 +25,7 @@ class QueueAndDigitMockTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->mock = MockTest::harness();
-        $this->mock->reset();
-        $this->client = MockTest::client();
+        [$this->client, $this->mock] = MockTest::scopedClient();
     }
 
     protected function tearDown(): void

--- a/tests/Rest/BaseResourceTest.php
+++ b/tests/Rest/BaseResourceTest.php
@@ -23,9 +23,7 @@ class BaseResourceTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->mock = MockTest::harness();
-        $this->mock->reset();
-        $this->client = new RestClient('test_proj', 'test_tok', $this->mock->url());
+        [$this->client, $this->mock] = MockTest::scopedClient();
     }
 
     private function http(): HttpClient

--- a/tests/Rest/CallingMockTest.php
+++ b/tests/Rest/CallingMockTest.php
@@ -26,9 +26,7 @@ class CallingMockTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->mock = MockTest::harness();
-        $this->mock->reset();
-        $this->client = new RestClient('test_proj', 'test_tok', $this->mock->url());
+        [$this->client, $this->mock] = MockTest::scopedClient();
     }
 
     /**

--- a/tests/Rest/CompatAccountsMockTest.php
+++ b/tests/Rest/CompatAccountsMockTest.php
@@ -23,9 +23,7 @@ class CompatAccountsMockTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->mock = MockTest::harness();
-        $this->mock->reset();
-        $this->client = new RestClient('test_proj', 'test_tok', $this->mock->url());
+        [$this->client, $this->mock] = MockTest::scopedClient();
     }
 
     // ----- create --------------------------------------------------------

--- a/tests/Rest/CompatCallsStreamsMockTest.php
+++ b/tests/Rest/CompatCallsStreamsMockTest.php
@@ -23,9 +23,7 @@ class CompatCallsStreamsMockTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->mock = MockTest::harness();
-        $this->mock->reset();
-        $this->client = new RestClient('test_proj', 'test_tok', $this->mock->url());
+        [$this->client, $this->mock] = MockTest::scopedClient();
     }
 
     // ----------------------------------------------------------------
@@ -57,7 +55,7 @@ class CompatCallsStreamsMockTest extends TestCase
         $j = $this->mock->journal()->last();
         $this->assertSame('POST', $j->method);
         $this->assertSame(
-            '/api/laml/2010-04-01/Accounts/test_proj/Calls/CA_JX1/Streams',
+            '/api/laml/2010-04-01/Accounts/' . $this->mock->project() . '/Calls/CA_JX1/Streams',
             $j->path
         );
         $body = $j->bodyMap();
@@ -96,7 +94,7 @@ class CompatCallsStreamsMockTest extends TestCase
         $j = $this->mock->journal()->last();
         $this->assertSame('POST', $j->method);
         $this->assertSame(
-            '/api/laml/2010-04-01/Accounts/test_proj/Calls/CA_S1/Streams/ST_S1',
+            '/api/laml/2010-04-01/Accounts/' . $this->mock->project() . '/Calls/CA_S1/Streams/ST_S1',
             $j->path
         );
         $body = $j->bodyMap();
@@ -133,7 +131,7 @@ class CompatCallsStreamsMockTest extends TestCase
         $j = $this->mock->journal()->last();
         $this->assertSame('POST', $j->method);
         $this->assertSame(
-            '/api/laml/2010-04-01/Accounts/test_proj/Calls/CA_R1/Recordings/RE_R1',
+            '/api/laml/2010-04-01/Accounts/' . $this->mock->project() . '/Calls/CA_R1/Recordings/RE_R1',
             $j->path
         );
         $body = $j->bodyMap();

--- a/tests/Rest/CompatConferencesMockTest.php
+++ b/tests/Rest/CompatConferencesMockTest.php
@@ -22,9 +22,7 @@ class CompatConferencesMockTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->mock = MockTest::harness();
-        $this->mock->reset();
-        $this->client = new RestClient('test_proj', 'test_tok', $this->mock->url());
+        [$this->client, $this->mock] = MockTest::scopedClient();
     }
 
     // ----- conference itself ------------------------------------------
@@ -47,7 +45,7 @@ class CompatConferencesMockTest extends TestCase
         $j = $this->mock->journal()->last();
         $this->assertSame('GET', $j->method);
         $this->assertSame(
-            '/api/laml/2010-04-01/Accounts/test_proj/Conferences',
+            '/api/laml/2010-04-01/Accounts/' . $this->mock->project() . '/Conferences',
             $j->path
         );
         $this->assertNotNull($j->matchedRoute, 'spec gap: conferences.list');
@@ -70,7 +68,7 @@ class CompatConferencesMockTest extends TestCase
         $j = $this->mock->journal()->last();
         $this->assertSame('GET', $j->method);
         $this->assertSame(
-            '/api/laml/2010-04-01/Accounts/test_proj/Conferences/CF_GETSID',
+            '/api/laml/2010-04-01/Accounts/' . $this->mock->project() . '/Conferences/CF_GETSID',
             $j->path
         );
     }
@@ -98,7 +96,7 @@ class CompatConferencesMockTest extends TestCase
         $j = $this->mock->journal()->last();
         $this->assertSame('POST', $j->method);
         $this->assertSame(
-            '/api/laml/2010-04-01/Accounts/test_proj/Conferences/CF_UPD',
+            '/api/laml/2010-04-01/Accounts/' . $this->mock->project() . '/Conferences/CF_UPD',
             $j->path
         );
         $body = $j->bodyMap();
@@ -126,7 +124,7 @@ class CompatConferencesMockTest extends TestCase
         $j = $this->mock->journal()->last();
         $this->assertSame('GET', $j->method);
         $this->assertSame(
-            '/api/laml/2010-04-01/Accounts/test_proj/Conferences/CF_GP/Participants/CA_GP',
+            '/api/laml/2010-04-01/Accounts/' . $this->mock->project() . '/Conferences/CF_GP/Participants/CA_GP',
             $j->path
         );
     }
@@ -156,7 +154,7 @@ class CompatConferencesMockTest extends TestCase
         $j = $this->mock->journal()->last();
         $this->assertSame('POST', $j->method);
         $this->assertSame(
-            '/api/laml/2010-04-01/Accounts/test_proj/Conferences/CF_M/Participants/CA_M',
+            '/api/laml/2010-04-01/Accounts/' . $this->mock->project() . '/Conferences/CF_M/Participants/CA_M',
             $j->path
         );
         $body = $j->bodyMap();
@@ -181,7 +179,7 @@ class CompatConferencesMockTest extends TestCase
         $j = $this->mock->journal()->last();
         $this->assertSame('DELETE', $j->method);
         $this->assertSame(
-            '/api/laml/2010-04-01/Accounts/test_proj/Conferences/CF_RM/Participants/CA_RM',
+            '/api/laml/2010-04-01/Accounts/' . $this->mock->project() . '/Conferences/CF_RM/Participants/CA_RM',
             $j->path
         );
     }
@@ -204,7 +202,7 @@ class CompatConferencesMockTest extends TestCase
         $j = $this->mock->journal()->last();
         $this->assertSame('GET', $j->method);
         $this->assertSame(
-            '/api/laml/2010-04-01/Accounts/test_proj/Conferences/CF_LRX/Recordings',
+            '/api/laml/2010-04-01/Accounts/' . $this->mock->project() . '/Conferences/CF_LRX/Recordings',
             $j->path
         );
     }
@@ -226,7 +224,7 @@ class CompatConferencesMockTest extends TestCase
         $j = $this->mock->journal()->last();
         $this->assertSame('GET', $j->method);
         $this->assertSame(
-            '/api/laml/2010-04-01/Accounts/test_proj/Conferences/CF_GRX/Recordings/RE_GRX',
+            '/api/laml/2010-04-01/Accounts/' . $this->mock->project() . '/Conferences/CF_GRX/Recordings/RE_GRX',
             $j->path
         );
     }
@@ -256,7 +254,7 @@ class CompatConferencesMockTest extends TestCase
         $j = $this->mock->journal()->last();
         $this->assertSame('POST', $j->method);
         $this->assertSame(
-            '/api/laml/2010-04-01/Accounts/test_proj/Conferences/CF_UR/Recordings/RE_UR',
+            '/api/laml/2010-04-01/Accounts/' . $this->mock->project() . '/Conferences/CF_UR/Recordings/RE_UR',
             $j->path
         );
         $body = $j->bodyMap();
@@ -278,7 +276,7 @@ class CompatConferencesMockTest extends TestCase
         $j = $this->mock->journal()->last();
         $this->assertSame('DELETE', $j->method);
         $this->assertSame(
-            '/api/laml/2010-04-01/Accounts/test_proj/Conferences/CF_DRX/Recordings/RE_DRX',
+            '/api/laml/2010-04-01/Accounts/' . $this->mock->project() . '/Conferences/CF_DRX/Recordings/RE_DRX',
             $j->path
         );
     }
@@ -308,7 +306,7 @@ class CompatConferencesMockTest extends TestCase
         $j = $this->mock->journal()->last();
         $this->assertSame('POST', $j->method);
         $this->assertSame(
-            '/api/laml/2010-04-01/Accounts/test_proj/Conferences/CF_SSX/Streams',
+            '/api/laml/2010-04-01/Accounts/' . $this->mock->project() . '/Conferences/CF_SSX/Streams',
             $j->path
         );
         $body = $j->bodyMap();
@@ -341,7 +339,7 @@ class CompatConferencesMockTest extends TestCase
         $j = $this->mock->journal()->last();
         $this->assertSame('POST', $j->method);
         $this->assertSame(
-            '/api/laml/2010-04-01/Accounts/test_proj/Conferences/CF_TSX/Streams/ST_TSX',
+            '/api/laml/2010-04-01/Accounts/' . $this->mock->project() . '/Conferences/CF_TSX/Streams/ST_TSX',
             $j->path
         );
         $body = $j->bodyMap();

--- a/tests/Rest/CompatMessagesFaxesMockTest.php
+++ b/tests/Rest/CompatMessagesFaxesMockTest.php
@@ -22,9 +22,7 @@ class CompatMessagesFaxesMockTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->mock = MockTest::harness();
-        $this->mock->reset();
-        $this->client = new RestClient('test_proj', 'test_tok', $this->mock->url());
+        [$this->client, $this->mock] = MockTest::scopedClient();
     }
 
     // ----- Messages -------------------------------------------------------
@@ -52,7 +50,7 @@ class CompatMessagesFaxesMockTest extends TestCase
         $j = $this->mock->journal()->last();
         $this->assertSame('POST', $j->method);
         $this->assertSame(
-            '/api/laml/2010-04-01/Accounts/test_proj/Messages/MM_U1',
+            '/api/laml/2010-04-01/Accounts/' . $this->mock->project() . '/Messages/MM_U1',
             $j->path
         );
         $body = $j->bodyMap();
@@ -78,7 +76,7 @@ class CompatMessagesFaxesMockTest extends TestCase
         $j = $this->mock->journal()->last();
         $this->assertSame('GET', $j->method);
         $this->assertSame(
-            '/api/laml/2010-04-01/Accounts/test_proj/Messages/MM_X/Media/ME_X',
+            '/api/laml/2010-04-01/Accounts/' . $this->mock->project() . '/Messages/MM_X/Media/ME_X',
             $j->path
         );
     }
@@ -99,7 +97,7 @@ class CompatMessagesFaxesMockTest extends TestCase
         $j = $this->mock->journal()->last();
         $this->assertSame('DELETE', $j->method);
         $this->assertSame(
-            '/api/laml/2010-04-01/Accounts/test_proj/Messages/MM_D/Media/ME_D',
+            '/api/laml/2010-04-01/Accounts/' . $this->mock->project() . '/Messages/MM_D/Media/ME_D',
             $j->path
         );
     }
@@ -123,7 +121,7 @@ class CompatMessagesFaxesMockTest extends TestCase
         $j = $this->mock->journal()->last();
         $this->assertSame('POST', $j->method);
         $this->assertSame(
-            '/api/laml/2010-04-01/Accounts/test_proj/Faxes/FX_U2',
+            '/api/laml/2010-04-01/Accounts/' . $this->mock->project() . '/Faxes/FX_U2',
             $j->path
         );
         $body = $j->bodyMap();
@@ -149,7 +147,7 @@ class CompatMessagesFaxesMockTest extends TestCase
         $j = $this->mock->journal()->last();
         $this->assertSame('GET', $j->method);
         $this->assertSame(
-            '/api/laml/2010-04-01/Accounts/test_proj/Faxes/FX_LM_X/Media',
+            '/api/laml/2010-04-01/Accounts/' . $this->mock->project() . '/Faxes/FX_LM_X/Media',
             $j->path
         );
     }
@@ -171,7 +169,7 @@ class CompatMessagesFaxesMockTest extends TestCase
         $j = $this->mock->journal()->last();
         $this->assertSame('GET', $j->method);
         $this->assertSame(
-            '/api/laml/2010-04-01/Accounts/test_proj/Faxes/FX_G/Media/ME_G',
+            '/api/laml/2010-04-01/Accounts/' . $this->mock->project() . '/Faxes/FX_G/Media/ME_G',
             $j->path
         );
     }
@@ -190,7 +188,7 @@ class CompatMessagesFaxesMockTest extends TestCase
         $j = $this->mock->journal()->last();
         $this->assertSame('DELETE', $j->method);
         $this->assertSame(
-            '/api/laml/2010-04-01/Accounts/test_proj/Faxes/FX_D/Media/ME_D',
+            '/api/laml/2010-04-01/Accounts/' . $this->mock->project() . '/Faxes/FX_D/Media/ME_D',
             $j->path
         );
     }

--- a/tests/Rest/CompatMiscMockTest.php
+++ b/tests/Rest/CompatMiscMockTest.php
@@ -23,9 +23,7 @@ class CompatMiscMockTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->mock = MockTest::harness();
-        $this->mock->reset();
-        $this->client = new RestClient('test_proj', 'test_tok', $this->mock->url());
+        [$this->client, $this->mock] = MockTest::scopedClient();
     }
 
     // ----- CompatApplications.update -----------------------------------
@@ -54,7 +52,7 @@ class CompatMiscMockTest extends TestCase
         $j = $this->mock->journal()->last();
         $this->assertSame('POST', $j->method);
         $this->assertSame(
-            '/api/laml/2010-04-01/Accounts/test_proj/Applications/AP_UU',
+            '/api/laml/2010-04-01/Accounts/' . $this->mock->project() . '/Applications/AP_UU',
             $j->path
         );
         $body = $j->bodyMap();
@@ -91,7 +89,7 @@ class CompatMiscMockTest extends TestCase
         $j = $this->mock->journal()->last();
         $this->assertSame('POST', $j->method);
         $this->assertSame(
-            '/api/laml/2010-04-01/Accounts/test_proj/LamlBins/LB_UU',
+            '/api/laml/2010-04-01/Accounts/' . $this->mock->project() . '/LamlBins/LB_UU',
             $j->path
         );
         $body = $j->bodyMap();

--- a/tests/Rest/CompatPhoneNumbersMockTest.php
+++ b/tests/Rest/CompatPhoneNumbersMockTest.php
@@ -22,9 +22,7 @@ class CompatPhoneNumbersMockTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->mock = MockTest::harness();
-        $this->mock->reset();
-        $this->client = new RestClient('test_proj', 'test_tok', $this->mock->url());
+        [$this->client, $this->mock] = MockTest::scopedClient();
     }
 
     // ----- list -----------------------------------------------------------
@@ -45,7 +43,7 @@ class CompatPhoneNumbersMockTest extends TestCase
         $j = $this->mock->journal()->last();
         $this->assertSame('GET', $j->method);
         $this->assertSame(
-            '/api/laml/2010-04-01/Accounts/test_proj/IncomingPhoneNumbers',
+            '/api/laml/2010-04-01/Accounts/' . $this->mock->project() . '/IncomingPhoneNumbers',
             $j->path
         );
     }
@@ -69,7 +67,7 @@ class CompatPhoneNumbersMockTest extends TestCase
         $j = $this->mock->journal()->last();
         $this->assertSame('GET', $j->method);
         $this->assertSame(
-            '/api/laml/2010-04-01/Accounts/test_proj/IncomingPhoneNumbers/PN_GET',
+            '/api/laml/2010-04-01/Accounts/' . $this->mock->project() . '/IncomingPhoneNumbers/PN_GET',
             $j->path
         );
     }
@@ -99,7 +97,7 @@ class CompatPhoneNumbersMockTest extends TestCase
         $j = $this->mock->journal()->last();
         $this->assertSame('POST', $j->method);
         $this->assertSame(
-            '/api/laml/2010-04-01/Accounts/test_proj/IncomingPhoneNumbers/PN_UU',
+            '/api/laml/2010-04-01/Accounts/' . $this->mock->project() . '/IncomingPhoneNumbers/PN_UU',
             $j->path
         );
         $body = $j->bodyMap();
@@ -124,7 +122,7 @@ class CompatPhoneNumbersMockTest extends TestCase
         $j = $this->mock->journal()->last();
         $this->assertSame('DELETE', $j->method);
         $this->assertSame(
-            '/api/laml/2010-04-01/Accounts/test_proj/IncomingPhoneNumbers/PN_DEL',
+            '/api/laml/2010-04-01/Accounts/' . $this->mock->project() . '/IncomingPhoneNumbers/PN_DEL',
             $j->path
         );
     }
@@ -152,7 +150,7 @@ class CompatPhoneNumbersMockTest extends TestCase
         $j = $this->mock->journal()->last();
         $this->assertSame('POST', $j->method);
         $this->assertSame(
-            '/api/laml/2010-04-01/Accounts/test_proj/IncomingPhoneNumbers',
+            '/api/laml/2010-04-01/Accounts/' . $this->mock->project() . '/IncomingPhoneNumbers',
             $j->path
         );
         $body = $j->bodyMap();
@@ -184,7 +182,7 @@ class CompatPhoneNumbersMockTest extends TestCase
         $j = $this->mock->journal()->last();
         $this->assertSame('POST', $j->method);
         $this->assertSame(
-            '/api/laml/2010-04-01/Accounts/test_proj/ImportedPhoneNumbers',
+            '/api/laml/2010-04-01/Accounts/' . $this->mock->project() . '/ImportedPhoneNumbers',
             $j->path
         );
         $body = $j->bodyMap();
@@ -210,7 +208,7 @@ class CompatPhoneNumbersMockTest extends TestCase
         $j = $this->mock->journal()->last();
         $this->assertSame('GET', $j->method);
         $this->assertSame(
-            '/api/laml/2010-04-01/Accounts/test_proj/AvailablePhoneNumbers',
+            '/api/laml/2010-04-01/Accounts/' . $this->mock->project() . '/AvailablePhoneNumbers',
             $j->path
         );
     }
@@ -239,7 +237,7 @@ class CompatPhoneNumbersMockTest extends TestCase
         $j = $this->mock->journal()->last();
         $this->assertSame('GET', $j->method);
         $this->assertSame(
-            '/api/laml/2010-04-01/Accounts/test_proj/AvailablePhoneNumbers/US/TollFree',
+            '/api/laml/2010-04-01/Accounts/' . $this->mock->project() . '/AvailablePhoneNumbers/US/TollFree',
             $j->path
         );
         // The AreaCode should be on the query string, not body.

--- a/tests/Rest/CompatQueuesMockTest.php
+++ b/tests/Rest/CompatQueuesMockTest.php
@@ -22,9 +22,7 @@ class CompatQueuesMockTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->mock = MockTest::harness();
-        $this->mock->reset();
-        $this->client = new RestClient('test_proj', 'test_tok', $this->mock->url());
+        [$this->client, $this->mock] = MockTest::scopedClient();
     }
 
     // ----- update --------------------------------------------------------
@@ -52,7 +50,7 @@ class CompatQueuesMockTest extends TestCase
         $j = $this->mock->journal()->last();
         $this->assertSame('POST', $j->method);
         $this->assertSame(
-            '/api/laml/2010-04-01/Accounts/test_proj/Queues/QU_UU',
+            '/api/laml/2010-04-01/Accounts/' . $this->mock->project() . '/Queues/QU_UU',
             $j->path
         );
         $body = $j->bodyMap();
@@ -79,7 +77,7 @@ class CompatQueuesMockTest extends TestCase
         $j = $this->mock->journal()->last();
         $this->assertSame('GET', $j->method);
         $this->assertSame(
-            '/api/laml/2010-04-01/Accounts/test_proj/Queues/QU_LMX/Members',
+            '/api/laml/2010-04-01/Accounts/' . $this->mock->project() . '/Queues/QU_LMX/Members',
             $j->path
         );
     }
@@ -103,7 +101,7 @@ class CompatQueuesMockTest extends TestCase
         $j = $this->mock->journal()->last();
         $this->assertSame('GET', $j->method);
         $this->assertSame(
-            '/api/laml/2010-04-01/Accounts/test_proj/Queues/QU_GMX/Members/CA_GMX',
+            '/api/laml/2010-04-01/Accounts/' . $this->mock->project() . '/Queues/QU_GMX/Members/CA_GMX',
             $j->path
         );
     }
@@ -135,7 +133,7 @@ class CompatQueuesMockTest extends TestCase
         $j = $this->mock->journal()->last();
         $this->assertSame('POST', $j->method);
         $this->assertSame(
-            '/api/laml/2010-04-01/Accounts/test_proj/Queues/QU_DMX/Members/CA_DMX',
+            '/api/laml/2010-04-01/Accounts/' . $this->mock->project() . '/Queues/QU_DMX/Members/CA_DMX',
             $j->path
         );
         $body = $j->bodyMap();

--- a/tests/Rest/CompatRecordingsTranscriptionsMockTest.php
+++ b/tests/Rest/CompatRecordingsTranscriptionsMockTest.php
@@ -22,9 +22,7 @@ class CompatRecordingsTranscriptionsMockTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->mock = MockTest::harness();
-        $this->mock->reset();
-        $this->client = new RestClient('test_proj', 'test_tok', $this->mock->url());
+        [$this->client, $this->mock] = MockTest::scopedClient();
     }
 
     // ----- Recordings ----------------------------------------------------
@@ -45,7 +43,7 @@ class CompatRecordingsTranscriptionsMockTest extends TestCase
         $j = $this->mock->journal()->last();
         $this->assertSame('GET', $j->method);
         $this->assertSame(
-            '/api/laml/2010-04-01/Accounts/test_proj/Recordings',
+            '/api/laml/2010-04-01/Accounts/' . $this->mock->project() . '/Recordings',
             $j->path
         );
     }
@@ -67,7 +65,7 @@ class CompatRecordingsTranscriptionsMockTest extends TestCase
         $j = $this->mock->journal()->last();
         $this->assertSame('GET', $j->method);
         $this->assertSame(
-            '/api/laml/2010-04-01/Accounts/test_proj/Recordings/RE_GET',
+            '/api/laml/2010-04-01/Accounts/' . $this->mock->project() . '/Recordings/RE_GET',
             $j->path
         );
     }
@@ -86,7 +84,7 @@ class CompatRecordingsTranscriptionsMockTest extends TestCase
         $j = $this->mock->journal()->last();
         $this->assertSame('DELETE', $j->method);
         $this->assertSame(
-            '/api/laml/2010-04-01/Accounts/test_proj/Recordings/RE_DEL',
+            '/api/laml/2010-04-01/Accounts/' . $this->mock->project() . '/Recordings/RE_DEL',
             $j->path
         );
     }
@@ -109,7 +107,7 @@ class CompatRecordingsTranscriptionsMockTest extends TestCase
         $j = $this->mock->journal()->last();
         $this->assertSame('GET', $j->method);
         $this->assertSame(
-            '/api/laml/2010-04-01/Accounts/test_proj/Transcriptions',
+            '/api/laml/2010-04-01/Accounts/' . $this->mock->project() . '/Transcriptions',
             $j->path
         );
     }
@@ -131,7 +129,7 @@ class CompatRecordingsTranscriptionsMockTest extends TestCase
         $j = $this->mock->journal()->last();
         $this->assertSame('GET', $j->method);
         $this->assertSame(
-            '/api/laml/2010-04-01/Accounts/test_proj/Transcriptions/TR_GET',
+            '/api/laml/2010-04-01/Accounts/' . $this->mock->project() . '/Transcriptions/TR_GET',
             $j->path
         );
     }
@@ -150,7 +148,7 @@ class CompatRecordingsTranscriptionsMockTest extends TestCase
         $j = $this->mock->journal()->last();
         $this->assertSame('DELETE', $j->method);
         $this->assertSame(
-            '/api/laml/2010-04-01/Accounts/test_proj/Transcriptions/TR_DEL',
+            '/api/laml/2010-04-01/Accounts/' . $this->mock->project() . '/Transcriptions/TR_DEL',
             $j->path
         );
     }

--- a/tests/Rest/CompatTokensMockTest.php
+++ b/tests/Rest/CompatTokensMockTest.php
@@ -23,9 +23,7 @@ class CompatTokensMockTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->mock = MockTest::harness();
-        $this->mock->reset();
-        $this->client = new RestClient('test_proj', 'test_tok', $this->mock->url());
+        [$this->client, $this->mock] = MockTest::scopedClient();
     }
 
     // ----- create -------------------------------------------------------
@@ -47,7 +45,7 @@ class CompatTokensMockTest extends TestCase
         $j = $this->mock->journal()->last();
         $this->assertSame('POST', $j->method);
         $this->assertSame(
-            '/api/laml/2010-04-01/Accounts/test_proj/tokens',
+            '/api/laml/2010-04-01/Accounts/' . $this->mock->project() . '/tokens',
             $j->path
         );
         $body = $j->bodyMap();
@@ -76,7 +74,7 @@ class CompatTokensMockTest extends TestCase
         // CompatTokens.update uses PATCH (BaseResource.update -> http.patch).
         $this->assertSame('PATCH', $j->method);
         $this->assertSame(
-            '/api/laml/2010-04-01/Accounts/test_proj/tokens/TK_UU',
+            '/api/laml/2010-04-01/Accounts/' . $this->mock->project() . '/tokens/TK_UU',
             $j->path
         );
         $body = $j->bodyMap();
@@ -100,7 +98,7 @@ class CompatTokensMockTest extends TestCase
         $j = $this->mock->journal()->last();
         $this->assertSame('DELETE', $j->method);
         $this->assertSame(
-            '/api/laml/2010-04-01/Accounts/test_proj/tokens/TK_DEL',
+            '/api/laml/2010-04-01/Accounts/' . $this->mock->project() . '/tokens/TK_DEL',
             $j->path
         );
     }

--- a/tests/Rest/FabricMockTest.php
+++ b/tests/Rest/FabricMockTest.php
@@ -24,9 +24,7 @@ class FabricMockTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->mock = MockTest::harness();
-        $this->mock->reset();
-        $this->client = new RestClient('test_proj', 'test_tok', $this->mock->url());
+        [$this->client, $this->mock] = MockTest::scopedClient();
     }
 
     // ----- fabric.addresses (read-only) -------------------------------

--- a/tests/Rest/LogsMockTest.php
+++ b/tests/Rest/LogsMockTest.php
@@ -22,9 +22,7 @@ class LogsMockTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->mock = MockTest::harness();
-        $this->mock->reset();
-        $this->client = new RestClient('test_proj', 'test_tok', $this->mock->url());
+        [$this->client, $this->mock] = MockTest::scopedClient();
     }
 
     // ----- message logs -----------------------------------------------

--- a/tests/Rest/MockTest.php
+++ b/tests/Rest/MockTest.php
@@ -52,19 +52,29 @@ class MockTest extends TestCase
      */
     public function testHarnessIsReachable(): void
     {
-        $h = self::harness();
-        $h->reset();
-        $this->assertSame(self::resolvePort(), $h->port());
-        $this->assertStringStartsWith('http://127.0.0.1:', $h->url());
-        // Hitting /__mock__/health via the harness returns at least one
-        // entry of the mock's introspection — sanity-check journal/scenarios
-        // are wired up.
-        $this->assertSame([], $h->journal()->all());
+        // Use a SCOPED harness so this sentinel is parallel-safe: it neither
+        // wipes the shared journal (a global reset would race a concurrent
+        // test) nor asserts on the global journal (other workers' requests
+        // are in it). A brand-new scope starts empty by construction.
+        [$client, $mock, $project] = self::scopedClient();
+        $this->assertSame(self::resolvePort(), $mock->port());
+        $this->assertStringStartsWith('http://127.0.0.1:', $mock->url());
+        $this->assertStringStartsWith('test_proj_', $project);
+        // This client made no request yet, so its auth-scoped journal view is
+        // empty — proving journal scoping is wired without touching shared state.
+        $this->assertSame([], $mock->journal()->all());
+        // A scoped reset is a no-op on the shared journal (verified: it returns
+        // without HTTP), so calling it can't disturb a concurrent test.
+        $mock->reset();
+        $this->assertSame([], $mock->journal()->all());
     }
 
     /**
      * Return a freshly reset RestClient pointed at the local mock server.
      * Resets the journal + scenarios before returning.
+     *
+     * Legacy/unscoped helper — kept for callers that drive the shared mock
+     * serially. Parallel-safe tests should use {@link scopedClient()} instead.
      */
     public static function client(): RestClient
     {
@@ -75,6 +85,45 @@ class MockTest extends TestCase
             'test_tok',
             $h->url()
         );
+    }
+
+    /**
+     * Build a RestClient plus a per-test {@link Harness} scoped to THIS
+     * client's requests, so the test reads only its own journal entries and
+     * consumes only its own scenario overrides — making the shared mock safe
+     * under file/process parallelism with no SDK change and no mock change.
+     *
+     * Isolation key: each client gets a unique RANDOM project
+     * (``test_proj_<12 hex>``), so its
+     * ``Authorization: Basic base64(project:token)`` header is unique. The
+     * random suffix (not a counter) keeps it collision-free across paratest
+     * workers AND separate processes hitting one shared mock. The harness
+     * filters the shared global journal by that header (client-side) and the
+     * mock_signalwire scenario store scopes overrides by it (server-side).
+     *
+     * Tests that assert on the AccountSid in a LAML path must read it from
+     * ``$mock->project()`` rather than hard-coding ``test_proj``.
+     *
+     * @return array{0: RestClient, 1: Harness, 2: string}  [client, mock, project]
+     */
+    public static function scopedClient(): array
+    {
+        $h = self::harness();
+        // Unique per-test project => unique Basic-Auth header => journal
+        // filterable per client. Random (not a counter) so concurrent
+        // workers/processes can't collide on the same project name.
+        $project = 'test_proj_' . bin2hex(random_bytes(6));
+        $token = 'test_tok';
+        $client = new RestClient($project, $token, $h->url());
+
+        // Per-call harness view scoped to this client's auth header. No reset
+        // is needed: this client starts with zero entries in the (auth-filtered)
+        // view, and its scenario overrides live under its own header.
+        $authHeader = 'Basic ' . base64_encode($project . ':' . $token);
+        $mock = new Harness($h->url(), $h->port());
+        $mock->scopeTo($authHeader, $project);
+
+        return [$client, $mock, $project];
     }
 
     /**
@@ -97,56 +146,80 @@ class MockTest extends TestCase
         $port = self::resolvePort();
         $base = 'http://127.0.0.1:' . $port;
 
-        if (self::probeHealth($base)) {
+        // Probe with retries BEFORE deciding to spawn. Under heavy parallel
+        // load (paratest with many workers) the single-threaded mock can be
+        // slow to answer a health probe; a single short probe would falsely
+        // conclude "not running" and spawn a REDUNDANT server on the same
+        // port, leaving requests hitting inconsistent instances. Retrying over
+        // a few seconds reuses a busy-but-alive server so exactly one server is
+        // ever used under parallelism.
+        if (self::probeHealthWithRetries($base)) {
             self::$sharedHarness = new Harness($base, $port);
             return self::$sharedHarness;
         }
 
-        // Spawn a subprocess. Detach stdout/stderr to /dev/null so PHPUnit
-        // doesn't hang waiting on the child's pipes.
-        try {
-            self::$mockProcess = self::spawnMockServer($port);
-        } catch (\Throwable $e) {
-            self::$startupFailure = $e;
-            throw new \RuntimeException(
-                'MockTest: failed to spawn `python -m mock_signalwire`: ' . $e->getMessage()
-                . ' (set MOCK_SIGNALWIRE_PORT to use a pre-running instance)',
-                0,
-                $e
-            );
+        // Serialize spawning across parallel paratest workers with a
+        // cross-process file lock so AT MOST ONE worker ever spawns a server on
+        // this port. After acquiring the lock we re-probe: another worker may
+        // have spawned it while we waited. We deliberately do NOT register a
+        // per-worker shutdown hook to kill the server — under parallelism the
+        // worker that spawned it usually exits first, and killing the shared
+        // server would yank it out from under still-running workers. The mock
+        // is reused across runs (probe-and-reuse) and torn down by the
+        // run-ci.sh lifecycle trap; a leaked idle server between local runs is
+        // harmless (the next run reuses it).
+        $lock = @fopen(sys_get_temp_dir() . '/sw_mock_signalwire_' . $port . '.lock', 'c');
+        if ($lock !== false) {
+            @flock($lock, LOCK_EX);
         }
-
-        $deadline = microtime(true) + self::STARTUP_TIMEOUT_SEC;
-        while (microtime(true) < $deadline) {
+        try {
+            // Re-probe under the lock — another worker may have spawned it.
             if (self::probeHealth($base)) {
                 self::$sharedHarness = new Harness($base, $port);
-                // Register a shutdown hook so the child is cleaned up when
-                // PHPUnit exits.
-                $proc = self::$mockProcess;
-                register_shutdown_function(static function () use ($proc): void {
-                    if (is_resource($proc)) {
-                        @proc_terminate($proc);
-                        @proc_close($proc);
-                    }
-                });
                 return self::$sharedHarness;
             }
-            usleep(150_000);
+            // Spawn a subprocess. Detach stdout/stderr to /dev/null so PHPUnit
+            // doesn't hang waiting on the child's pipes.
+            try {
+                self::$mockProcess = self::spawnMockServer($port);
+            } catch (\Throwable $e) {
+                self::$startupFailure = $e;
+                throw new \RuntimeException(
+                    'MockTest: failed to spawn `python -m mock_signalwire`: ' . $e->getMessage()
+                    . ' (set MOCK_SIGNALWIRE_PORT to use a pre-running instance)',
+                    0,
+                    $e
+                );
+            }
+
+            $deadline = microtime(true) + self::STARTUP_TIMEOUT_SEC;
+            while (microtime(true) < $deadline) {
+                if (self::probeHealth($base)) {
+                    self::$sharedHarness = new Harness($base, $port);
+                    return self::$sharedHarness;
+                }
+                usleep(150_000);
+            }
+            // Timed out — kill the child and give up.
+            if (is_resource(self::$mockProcess)) {
+                @proc_terminate(self::$mockProcess);
+                @proc_close(self::$mockProcess);
+                self::$mockProcess = null;
+            }
+            $err = new \RuntimeException(
+                'MockTest: `python -m mock_signalwire` did not become ready within '
+                . self::STARTUP_TIMEOUT_SEC . 's on port ' . $port
+                . ' (clone porting-sdk next to signalwire-php so tests can find '
+                . 'porting-sdk/test_harness/mock_signalwire/, or pip install the mock_signalwire package)'
+            );
+            self::$startupFailure = $err;
+            throw $err;
+        } finally {
+            if ($lock !== false) {
+                @flock($lock, LOCK_UN);
+                @fclose($lock);
+            }
         }
-        // Timed out — kill the child and give up.
-        if (is_resource(self::$mockProcess)) {
-            @proc_terminate(self::$mockProcess);
-            @proc_close(self::$mockProcess);
-            self::$mockProcess = null;
-        }
-        $err = new \RuntimeException(
-            'MockTest: `python -m mock_signalwire` did not become ready within '
-            . self::STARTUP_TIMEOUT_SEC . 's on port ' . $port
-            . ' (clone porting-sdk next to signalwire-php so tests can find '
-            . 'porting-sdk/test_harness/mock_signalwire/, or pip install the mock_signalwire package)'
-        );
-        self::$startupFailure = $err;
-        throw $err;
     }
 
     private static function resolvePort(): int
@@ -266,8 +339,8 @@ class MockTest extends TestCase
         $ch = curl_init($base . '/__mock__/health');
         curl_setopt_array($ch, [
             CURLOPT_RETURNTRANSFER => true,
-            CURLOPT_TIMEOUT => 2,
-            CURLOPT_CONNECTTIMEOUT => 2,
+            CURLOPT_TIMEOUT => 10,
+            CURLOPT_CONNECTTIMEOUT => 5,
         ]);
         $body = curl_exec($ch);
         $code = (int) curl_getinfo($ch, CURLINFO_HTTP_CODE);
@@ -276,6 +349,23 @@ class MockTest extends TestCase
             return false;
         }
         return str_contains($body, '"specs_loaded"');
+    }
+
+    /**
+     * Probe repeatedly for up to ~10s before concluding the server is down.
+     * Reuses a busy-but-alive server under parallel load so no worker ever
+     * spawns a redundant second server on an occupied port.
+     */
+    private static function probeHealthWithRetries(string $base): bool
+    {
+        $deadline = microtime(true) + 10.0;
+        do {
+            if (self::probeHealth($base)) {
+                return true;
+            }
+            usleep(200_000);
+        } while (microtime(true) < $deadline);
+        return false;
     }
 }
 
@@ -290,12 +380,42 @@ final class Harness
     private Journal $journal;
     private Scenarios $scenarios;
 
+    /**
+     * The unique random project this harness's client authenticates with
+     * (``test_proj_<hex>``). Tests that assert on the AccountSid embedded in
+     * a LAML path read it from here instead of hard-coding ``test_proj``.
+     * Empty on an unscoped/raw harness.
+     */
+    private string $project = '';
+
     public function __construct(string $url, int $port)
     {
         $this->url = $url;
         $this->port = $port;
         $this->journal = new Journal($url);
         $this->scenarios = new Scenarios($url);
+    }
+
+    /**
+     * Scope this harness to one client, identified by its ``Authorization``
+     * header. After scoping: journal()/last() return only that client's
+     * requests, reset() becomes a no-op (the shared journal is never wiped —
+     * a global wipe would race a concurrent test), and scenario overrides are
+     * tagged with the header so a concurrent test can't consume them. REST is
+     * pure request/response with no handshake, so the auth header is the
+     * session key.
+     */
+    public function scopeTo(string $authHeader, string $project): void
+    {
+        $this->project = $project;
+        $this->journal->scopeTo($authHeader);
+        $this->scenarios->scopeTo($authHeader);
+    }
+
+    /** The unique random project for a scoped harness ('' when unscoped). */
+    public function project(): string
+    {
+        return $this->project;
     }
 
     public function url(): string
@@ -319,7 +439,10 @@ final class Harness
     }
 
     /**
-     * Clear journal + scenarios on the mock server.
+     * Clear journal + scenarios on the mock server. A scoped harness leaves
+     * the shared journal alone (it only ever reads its own entries, identified
+     * by auth header, so there is nothing to clear and a global wipe would
+     * race a concurrent test). Unscoped harnesses do the legacy global reset.
      */
     public function reset(): void
     {
@@ -336,13 +459,29 @@ final class Journal
 {
     private string $base;
 
+    /**
+     * When set, all()/last() return only the requests THIS test's client made,
+     * identified by its ``Authorization`` header (Basic project:token, with a
+     * per-test random project). Empty => unscoped (legacy view; returns every
+     * entry — only correct under serial execution).
+     */
+    private string $authHeader = '';
+
     public function __construct(string $base)
     {
         $this->base = $base;
     }
 
+    /** Scope journal reads to one client's Authorization header. */
+    public function scopeTo(string $authHeader): void
+    {
+        $this->authHeader = $authHeader;
+    }
+
     /**
      * Return every entry recorded since the last reset, in arrival order.
+     * Scoped to this harness's auth header when set (so a parallel test never
+     * sees another test's requests); unscoped harnesses see the whole journal.
      *
      * @return list<JournalEntry>
      */
@@ -355,14 +494,20 @@ final class Journal
         }
         $entries = [];
         foreach ($decoded as $row) {
-            $entries[] = JournalEntry::fromArray($row);
+            $entry = JournalEntry::fromArray($row);
+            if ($this->authHeader !== ''
+                && ($entry->headers['authorization'] ?? null) !== $this->authHeader) {
+                continue;
+            }
+            $entries[] = $entry;
         }
         return $entries;
     }
 
     /**
-     * Return the most recent journal entry. Throws when the journal is empty —
-     * every test that exercises the SDK should produce at least one entry.
+     * Return the most recent journal entry for THIS client. Throws when the
+     * (scoped) journal is empty — every test that exercises the SDK should
+     * produce at least one entry.
      */
     public function last(): JournalEntry
     {
@@ -375,8 +520,17 @@ final class Journal
         return $entries[count($entries) - 1];
     }
 
+    /**
+     * Clear the journal on the mock server. A scoped journal leaves the shared
+     * journal alone (it only ever reads its own entries, identified by auth
+     * header, so there is nothing to clear and a global wipe would race a
+     * concurrent test). Unscoped journals do the legacy global reset.
+     */
     public function reset(): void
     {
+        if ($this->authHeader !== '') {
+            return;
+        }
         MockHttp::post($this->base . '/__mock__/journal/reset');
     }
 }
@@ -456,15 +610,29 @@ final class Scenarios
 {
     private string $base;
 
+    /**
+     * When set, scenario overrides are scoped to THIS client's auth header
+     * (REST's session key), so a concurrent test can't consume them and a
+     * stale one can't bleed across tests. Empty => shared/unscoped bucket.
+     */
+    private string $authHeader = '';
+
     public function __construct(string $base)
     {
         $this->base = $base;
     }
 
+    /** Scope scenario overrides to one client's Authorization header. */
+    public function scopeTo(string $authHeader): void
+    {
+        $this->authHeader = $authHeader;
+    }
+
     /**
      * Stage a response override for the named operation. The status + body
      * returned here will be served the next time the route is hit;
-     * subsequent hits fall back to spec synthesis.
+     * subsequent hits fall back to spec synthesis. Scoped to this harness's
+     * auth header (server-side, via ``?session_id=``) when set.
      *
      * @param array<string,mixed> $body
      */
@@ -474,11 +642,29 @@ final class Scenarios
             ['status' => $status, 'response' => $body],
             JSON_THROW_ON_ERROR
         );
-        MockHttp::postJson($this->base . '/__mock__/scenarios/' . rawurlencode($operationId), $payload);
+        $q = $this->authHeader !== ''
+            ? '?session_id=' . rawurlencode($this->authHeader)
+            : '';
+        MockHttp::postJson(
+            $this->base . '/__mock__/scenarios/' . rawurlencode($operationId) . $q,
+            $payload
+        );
     }
 
+    /**
+     * Clear scenario overrides. A scoped harness clears only its own bucket
+     * (server-side, via ``?session_id=``) so it never disturbs a concurrent
+     * test; unscoped harnesses clear everything (legacy global reset).
+     */
     public function reset(): void
     {
+        if ($this->authHeader !== '') {
+            MockHttp::post(
+                $this->base . '/__mock__/scenarios/reset?session_id='
+                . rawurlencode($this->authHeader)
+            );
+            return;
+        }
         MockHttp::post($this->base . '/__mock__/scenarios/reset');
     }
 }

--- a/tests/Rest/PaginationMockTest.php
+++ b/tests/Rest/PaginationMockTest.php
@@ -33,9 +33,7 @@ class PaginationMockTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->mock = MockTest::harness();
-        $this->mock->reset();
-        $this->client = new RestClient('test_proj', 'test_tok', $this->mock->url());
+        [$this->client, $this->mock] = MockTest::scopedClient();
     }
 
     #[Test]

--- a/tests/Rest/RegistryMockTest.php
+++ b/tests/Rest/RegistryMockTest.php
@@ -25,9 +25,7 @@ class RegistryMockTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->mock = MockTest::harness();
-        $this->mock->reset();
-        $this->client = new RestClient('test_proj', 'test_tok', $this->mock->url());
+        [$this->client, $this->mock] = MockTest::scopedClient();
     }
 
     // ----- brands ----------------------------------------------------

--- a/tests/Rest/SmallNamespacesMockTest.php
+++ b/tests/Rest/SmallNamespacesMockTest.php
@@ -31,9 +31,7 @@ class SmallNamespacesMockTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->mock = MockTest::harness();
-        $this->mock->reset();
-        $this->client = new RestClient('test_proj', 'test_tok', $this->mock->url());
+        [$this->client, $this->mock] = MockTest::scopedClient();
     }
 
     // ----- addresses --------------------------------------------------

--- a/tests/Rest/VideoMockTest.php
+++ b/tests/Rest/VideoMockTest.php
@@ -22,9 +22,7 @@ class VideoMockTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->mock = MockTest::harness();
-        $this->mock->reset();
-        $this->client = new RestClient('test_proj', 'test_tok', $this->mock->url());
+        [$this->client, $this->mock] = MockTest::scopedClient();
     }
 
     // ----- Rooms — streams sub-resource -------------------------------


### PR DESCRIPTION
## Summary

Session-isolate the RELAY and REST mock-backed test suites so the full suite runs safely under file/process parallelism (paratest) against a single shared mock server, with zero cross-test interference and fully deterministic results.

## How isolation works

**RELAY** — keyed on the connect-handshake session. The SDK captures the server-assigned id from the `ConnectResult` `sessionid` key into the existing public `Client::$sessionId`. A per-test scoped `RelayHarness` threads `?session_id=<id>` onto every control-plane call (journal/reset, scenarios arm/dial/reset, inbound_call + scenario_play stamping). New `scopedClient()` helper boots a connected client + a harness scoped to its session; a fresh session starts with an empty scoped journal, so no global reset is needed.

**REST** — keyed on the `Authorization` header. Each test uses a random project `test_proj_<12 hex>`, producing a unique Basic-auth header. Client-side journal reads filter by lowercase `authorization` == this test's header; scoped `reset()` is a no-op (the shared journal is never wiped); scenarios scope server-side via `?session_id=<urlencoded auth header>`. LAML-path assertions read the per-test project.

## Harness / CI

- `run-ci.sh` pre-spawns each mock once, waits for health, exports fixed ports, and tears them down via an `EXIT/INT/TERM` trap. The TEST gate now runs `paratest` (WrapperRunner, `-p 8`).
- The per-test harness probe-and-reuse path (retries + cross-process spawn lock; no per-worker kill hook) is the safety net so workers can't yank the shared server out from under each other.
- Added `brianium/paratest` to `require-dev`.

## Surface decision

`Client::$sessionId` is a **pre-existing** public read-only member (already present on `origin/main`); only the key it reads changed (`session_id` -> `sessionid`). This introduces **no new public surface** — the DRIFT and SURFACE-FRESH gates stay at **0**, and `PORT_ADDITIONS.md` needs no new entry.

## Verification

- `bash scripts/run-ci.sh`: all gates green (TEST, SIGNATURES, DRIFT, SURFACE-FRESH, NO-CHEAT, EMISSION) — drift 0.
- Full suite green and **deterministic across 5 parallel runs** under ~3x `yes` CPU load (including `-p 10`): **1289 tests, 4261 assertions, 0 failures, 2 skips**.
- No stray mock processes (`lsof` on :9778/:8778/:8768 clean) after runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ab1ghK8PCd2PzW79nzsAqT
