### PR TITLE
feat(security): port the 3 security_utils (filter_sensitive_headers, redact_url, is_valid_hostname)

### DIFF
--- a/PORT_ADDITIONS.md
+++ b/PORT_ADDITIONS.md
@@ -574,3 +574,7 @@ signalwire.core.agent_base.AgentBase.get_signing_key: php_accessor: AgentBase ex
 signalwire.core.security.webhook_validator.WebhookValidator: php_idiom_class_wrapper: static class containing validator functions (Python keeps them at module level)
 signalwire.core.security.webhook_validator.WebhookValidator.validate_request: php_idiom_class_wrapper: see WebhookValidator class entry
 signalwire.core.security.webhook_validator.WebhookValidator.validate_webhook_signature: php_idiom_class_wrapper: see WebhookValidator class entry
+signalwire.core.security.security_utils.SecurityUtils: php_idiom_class_wrapper: static class hosting the security hygiene helpers (Python keeps filter_sensitive_headers/redact_url/is_valid_hostname at module level); static methods projected to module-level free functions via FREE_FUNCTION_PROJECTIONS
+signalwire.core.security.security_utils.SecurityUtils.filter_sensitive_headers: php_idiom_class_wrapper: see SecurityUtils class entry
+signalwire.core.security.security_utils.SecurityUtils.redact_url: php_idiom_class_wrapper: see SecurityUtils class entry
+signalwire.core.security.security_utils.SecurityUtils.is_valid_hostname: php_idiom_class_wrapper: see SecurityUtils class entry

--- a/PORT_OMISSIONS.md
+++ b/PORT_OMISSIONS.md
@@ -927,3 +927,6 @@ signalwire.web.web_service.WebService.start: Python's WebService abstraction is 
 signalwire.web.web_service.WebService.stop: Python's WebService abstraction is not a PHP idiom — PHP uses AgentBase's built-in HTTP server (or php -S / FPM behind nginx).
 signalwire.core.security.webhook_validator.validate_webhook_signature: idiomatic_divergence: implemented as static method on the WebhookValidator class (language idiom); see PORT_ADDITIONS.md
 signalwire.core.security.webhook_validator.validate_request: idiomatic_divergence: implemented as static method on the WebhookValidator class (language idiom); see PORT_ADDITIONS.md
+signalwire.core.security.security_utils.filter_sensitive_headers: idiomatic_divergence: implemented as static method SecurityUtils::filterSensitiveHeaders (language idiom); see PORT_ADDITIONS.md
+signalwire.core.security.security_utils.redact_url: idiomatic_divergence: implemented as static method SecurityUtils::redactUrl (language idiom); see PORT_ADDITIONS.md
+signalwire.core.security.security_utils.is_valid_hostname: idiomatic_divergence: implemented as static method SecurityUtils::isValidHostname (language idiom); see PORT_ADDITIONS.md

--- a/port_signatures.json
+++ b/port_signatures.json
@@ -4732,6 +4732,40 @@
         }
       }
     },
+    "signalwire.core.security.security_utils": {
+      "functions": {
+        "filter_sensitive_headers": {
+          "params": [
+            {
+              "name": "headers",
+              "type": "any",
+              "required": true
+            }
+          ],
+          "returns": "any"
+        },
+        "is_valid_hostname": {
+          "params": [
+            {
+              "name": "host",
+              "type": "string",
+              "required": true
+            }
+          ],
+          "returns": "bool"
+        },
+        "redact_url": {
+          "params": [
+            {
+              "name": "url",
+              "type": "string",
+              "required": true
+            }
+          ],
+          "returns": "string"
+        }
+      }
+    },
     "signalwire.core.security.session_manager": {
       "classes": {
         "SessionManager": {

--- a/port_surface.json
+++ b/port_surface.json
@@ -1,6 +1,6 @@
 {
   "version": "1",
-  "generated_from": "signalwire-php @ 94ef3cffbf7674f8c1f40599e3dd6a89206ec865",
+  "generated_from": "signalwire-php @ d856179d8cf661a1b2e26b653691d3909374e45b",
   "modules": {
     "signalwire": {
       "classes": {
@@ -450,6 +450,16 @@
           "run",
           "serve",
           "set_dynamic_config_callback"
+        ]
+      },
+      "functions": []
+    },
+    "signalwire.core.security.security_utils": {
+      "classes": {
+        "SecurityUtils": [
+          "filter_sensitive_headers",
+          "is_valid_hostname",
+          "redact_url"
         ]
       },
       "functions": []

--- a/scripts/enumerate_signatures.py
+++ b/scripts/enumerate_signatures.py
@@ -191,6 +191,16 @@ FREE_FUNCTION_PROJECTIONS: dict[tuple[str, str], tuple[str, str]] = {
         ("signalwire.core.security.webhook_validator", "validate_webhook_signature"),
     ("SignalWire\\Security\\WebhookValidator", "validateRequest"):
         ("signalwire.core.security.webhook_validator", "validate_request"),
+    # Security hygiene helpers — Python ships them as module-level free
+    # functions (signalwire.core.security.security_utils); PHP groups the
+    # three static methods on a SecurityUtils final class for PSR-4 + IDE
+    # discoverability. Project to the Python canonical snake_case names.
+    ("SignalWire\\Security\\SecurityUtils", "filterSensitiveHeaders"):
+        ("signalwire.core.security.security_utils", "filter_sensitive_headers"),
+    ("SignalWire\\Security\\SecurityUtils", "redactUrl"):
+        ("signalwire.core.security.security_utils", "redact_url"),
+    ("SignalWire\\Security\\SecurityUtils", "isValidHostname"):
+        ("signalwire.core.security.security_utils", "is_valid_hostname"),
 }
 
 

--- a/scripts/enumerate_surface.py
+++ b/scripts/enumerate_surface.py
@@ -96,6 +96,7 @@ CLASS_MODULE_MAP: dict[str, str] = {
     "SessionManager": "signalwire.core.security.session_manager",
     "WebhookValidator": "signalwire.core.security.webhook_validator",
     "WebhookMiddleware": "signalwire.core.security.webhook_middleware",
+    "SecurityUtils": "signalwire.core.security.security_utils",
 
     # core/skills
     "SkillBase": "signalwire.core.skill_base",

--- a/src/SignalWire/Security/SecurityUtils.php
+++ b/src/SignalWire/Security/SecurityUtils.php
@@ -1,0 +1,131 @@
+<?php
+
+/*
+ * Copyright (c) 2025 SignalWire
+ *
+ * Licensed under the MIT License.
+ * See LICENSE file in the project root for full license information.
+ */
+
+declare(strict_types=1);
+
+namespace SignalWire\Security;
+
+/**
+ * Standalone security hygiene utilities.
+ *
+ * Mirrors the Python reference
+ * signalwire.core.security.security_utils (filter_sensitive_headers,
+ * redact_url, is_valid_hostname) and the TypeScript SDK's SecurityUtils
+ * (filterSensitiveHeaders, redactUrl, isValidHostname): keep credentials
+ * out of user callbacks and logs, plus a reusable hostname sanity check.
+ *
+ * Python ships these as three module-level free functions. PHP groups the
+ * three static methods on this final class for cohesion and IDE/PSR-4
+ * discoverability; scripts/enumerate_signatures.py projects each static
+ * method onto the canonical Python module-level free function via
+ * FREE_FUNCTION_PROJECTIONS, so the cross-language surface treats
+ * SecurityUtils::filterSensitiveHeaders as
+ * signalwire.core.security.security_utils.filter_sensitive_headers, etc.
+ *
+ * Public API:
+ *
+ *     SecurityUtils::filterSensitiveHeaders($headers): array
+ *     SecurityUtils::redactUrl($url): string
+ *     SecurityUtils::isValidHostname($host): bool
+ */
+final class SecurityUtils
+{
+    /**
+     * Header names whose values are credentials/secrets and must never be
+     * handed to user callbacks or written to logs. Compared case-insensitively.
+     *
+     * @var list<string>
+     */
+    private const SENSITIVE_HEADERS = [
+        'authorization',
+        'cookie',
+        'x-api-key',
+        'proxy-authorization',
+        'set-cookie',
+    ];
+
+    /**
+     * URL userinfo credentials: `://user:secret@host` -> `://user:****@host`.
+     * Mirrors the Python regex `://([^:@/]+):([^@/]+)@`.
+     */
+    private const URL_CREDENTIALS_RE = '#://([^:@/]+):([^@/]+)@#';
+
+    /**
+     * Hostnames must not contain whitespace, slashes, backslashes, or control
+     * characters. Mirrors the Python char class `[\s/\\\x00-\x1f\x7f]`.
+     */
+    private const HOSTNAME_REJECT_RE = '#[\s/\\\\\x00-\x1f\x7f]#';
+
+    /**
+     * Return a copy of $headers with sensitive (credential-bearing) headers
+     * removed, so request headers can be safely passed to user callbacks /
+     * logs.
+     *
+     * The sensitivity check is case-insensitive; non-sensitive keys are
+     * preserved exactly as given (original casing). An empty array (or any
+     * empty/falsy input) yields an empty array.
+     *
+     * @param array<string, mixed> $headers Map of header name -> value.
+     *
+     * @return array<string, mixed> A new map containing only the
+     *                               non-sensitive headers.
+     */
+    public static function filterSensitiveHeaders(array $headers): array
+    {
+        if ($headers === []) {
+            return [];
+        }
+        $filtered = [];
+        foreach ($headers as $key => $value) {
+            if (!in_array(strtolower($key), self::SENSITIVE_HEADERS, true)) {
+                $filtered[$key] = $value;
+            }
+        }
+        return $filtered;
+    }
+
+    /**
+     * Mask the password in a URL's userinfo before logging.
+     *
+     * `https://user:secret@host/path` -> `https://user:****@host/path`.
+     * A URL with no embedded credentials is returned unchanged.
+     *
+     * @param string $url The URL string.
+     *
+     * @return string The URL with any `:password@` replaced by `:****@`.
+     */
+    public static function redactUrl(string $url): string
+    {
+        $result = preg_replace(self::URL_CREDENTIALS_RE, '://$1:****@', $url);
+        // preg_replace returns null only on a regex/engine error; the pattern
+        // is a compile-time constant, so fall back to the original input.
+        return $result ?? $url;
+    }
+
+    /**
+     * Standalone hostname sanity check: reject empty hosts and any host
+     * containing whitespace, slashes, backslashes, or control characters.
+     *
+     * This is the reusable character-level check, independent of the fuller
+     * {@see \SignalWire\Utils\UrlValidator::validateUrl} (which also does
+     * scheme checks, DNS resolution, and private-IP blocking).
+     *
+     * @param string $host The hostname string.
+     *
+     * @return bool True if the hostname is non-empty and contains no
+     *              whitespace/slashes/control characters; false otherwise.
+     */
+    public static function isValidHostname(string $host): bool
+    {
+        if ($host === '') {
+            return false;
+        }
+        return preg_match(self::HOSTNAME_REJECT_RE, $host) === 0;
+    }
+}

--- a/tests/Security/SecurityUtilsTest.php
+++ b/tests/Security/SecurityUtilsTest.php
@@ -1,0 +1,144 @@
+<?php
+
+/*
+ * Copyright (c) 2025 SignalWire
+ *
+ * Licensed under the MIT License.
+ * See LICENSE file in the project root for full license information.
+ */
+
+declare(strict_types=1);
+
+namespace SignalWire\Tests\Security;
+
+use PHPUnit\Framework\TestCase;
+use SignalWire\Security\SecurityUtils;
+
+/**
+ * Parity tests for SecurityUtils. Mirrors the Python reference at
+ * signalwire-python/signalwire/signalwire/core/security/security_utils.py
+ * (filter_sensitive_headers, redact_url, is_valid_hostname).
+ */
+class SecurityUtilsTest extends TestCase
+{
+    // --- filterSensitiveHeaders ----------------------------------------
+
+    public function testFilterRemovesSensitiveHeadersCaseInsensitively(): void
+    {
+        $headers = [
+            'Authorization' => 'Bearer abc',
+            'Cookie' => 'session=1',
+            'X-API-Key' => 'k',
+            'Proxy-Authorization' => 'Basic x',
+            'Set-Cookie' => 'a=b',
+            'Content-Type' => 'application/json',
+            'X-Request-Id' => 'r-123',
+        ];
+
+        $filtered = SecurityUtils::filterSensitiveHeaders($headers);
+
+        // All five sensitive keys removed regardless of casing.
+        $this->assertArrayNotHasKey('Authorization', $filtered);
+        $this->assertArrayNotHasKey('Cookie', $filtered);
+        $this->assertArrayNotHasKey('X-API-Key', $filtered);
+        $this->assertArrayNotHasKey('Proxy-Authorization', $filtered);
+        $this->assertArrayNotHasKey('Set-Cookie', $filtered);
+
+        // Non-sensitive keys preserved with original casing + values.
+        $this->assertSame(
+            ['Content-Type' => 'application/json', 'X-Request-Id' => 'r-123'],
+            $filtered
+        );
+    }
+
+    public function testFilterEmptyInputReturnsEmptyArray(): void
+    {
+        $this->assertSame([], SecurityUtils::filterSensitiveHeaders([]));
+    }
+
+    public function testFilterReturnsNewArrayAndDoesNotMutateInput(): void
+    {
+        $headers = ['authorization' => 'secret', 'x-trace' => '1'];
+        $filtered = SecurityUtils::filterSensitiveHeaders($headers);
+
+        $this->assertSame(['x-trace' => '1'], $filtered);
+        // Original untouched.
+        $this->assertArrayHasKey('authorization', $headers);
+    }
+
+    public function testFilterPreservesNonSensitiveKeysAsGiven(): void
+    {
+        // A header that merely contains a sensitive substring is NOT removed.
+        $headers = ['X-Authorization-Info' => 'meta', 'cookie-jar' => 'kept'];
+        $this->assertSame($headers, SecurityUtils::filterSensitiveHeaders($headers));
+    }
+
+    // --- redactUrl ------------------------------------------------------
+
+    public function testRedactMasksPasswordInUserinfo(): void
+    {
+        $this->assertSame(
+            'https://user:****@host/path',
+            SecurityUtils::redactUrl('https://user:secret@host/path')
+        );
+    }
+
+    public function testRedactUrlWithoutCredentialsUnchanged(): void
+    {
+        $this->assertSame(
+            'https://host/path?q=1',
+            SecurityUtils::redactUrl('https://host/path?q=1')
+        );
+    }
+
+    public function testRedactUrlWithUserButNoPasswordUnchanged(): void
+    {
+        $this->assertSame(
+            'https://user@host/path',
+            SecurityUtils::redactUrl('https://user@host/path')
+        );
+    }
+
+    public function testRedactPreservesUsername(): void
+    {
+        $this->assertSame(
+            'sip://alice:****@example.com',
+            SecurityUtils::redactUrl('sip://alice:hunter2@example.com')
+        );
+    }
+
+    // --- isValidHostname ------------------------------------------------
+
+    public function testValidHostnameAccepted(): void
+    {
+        $this->assertTrue(SecurityUtils::isValidHostname('example.com'));
+        $this->assertTrue(SecurityUtils::isValidHostname('sub.example.co.uk'));
+        $this->assertTrue(SecurityUtils::isValidHostname('localhost'));
+        $this->assertTrue(SecurityUtils::isValidHostname('192.168.1.1'));
+    }
+
+    public function testEmptyHostnameRejected(): void
+    {
+        $this->assertFalse(SecurityUtils::isValidHostname(''));
+    }
+
+    public function testHostnameWithWhitespaceRejected(): void
+    {
+        $this->assertFalse(SecurityUtils::isValidHostname('exa mple.com'));
+        $this->assertFalse(SecurityUtils::isValidHostname("host\tname"));
+        $this->assertFalse(SecurityUtils::isValidHostname("host\nname"));
+    }
+
+    public function testHostnameWithSlashesRejected(): void
+    {
+        $this->assertFalse(SecurityUtils::isValidHostname('example.com/path'));
+        $this->assertFalse(SecurityUtils::isValidHostname('example.com\\evil'));
+    }
+
+    public function testHostnameWithControlCharsRejected(): void
+    {
+        $this->assertFalse(SecurityUtils::isValidHostname("host\x00name"));
+        $this->assertFalse(SecurityUtils::isValidHostname("host\x1fname"));
+        $this->assertFalse(SecurityUtils::isValidHostname("host\x7fname"));
+    }
+}


### PR DESCRIPTION
## What

Ports the 3 new Python `security_utils` free functions to the PHP SDK, clearing the DRIFT gate after the Python reference added module `signalwire.core.security.security_utils`:

- `filter_sensitive_headers` — drop credential-bearing headers (case-insensitive set: `authorization`, `cookie`, `x-api-key`, `proxy-authorization`, `set-cookie`) before headers reach user callbacks/logs.
- `redact_url` — mask the password in a URL's userinfo (`://user:secret@` → `://user:****@`); URLs without embedded credentials returned unchanged.
- `is_valid_hostname` — reject empty hosts and any host containing whitespace, slashes, backslashes, or control chars (`[\s/\\\x00-\x1f\x7f]`).

## How (PHP idiom)

- New `final class SignalWire\Security\SecurityUtils` in **its own file** (PSR-4 file-per-class so the surface class enumerator sees it) with three static methods — same idiom as the existing `WebhookValidator` and `UrlValidator` free-function hosts.
- `scripts/enumerate_signatures.py`: `FREE_FUNCTION_PROJECTIONS` lift the three static methods onto the canonical module-level Python free functions, so the signature DRIFT gate treats them as free functions (no class shell emitted).
- `scripts/enumerate_surface.py`: map `SecurityUtils` → `signalwire.core.security.security_utils`.
- `PORT_ADDITIONS.md` / `PORT_OMISSIONS.md`: reconcile the PHP class-host idiom vs Python's module-level functions for the SURFACE-DIFF gate (mirrors the existing `WebhookValidator`/`UrlValidator` reconciliation).
- PHPUnit tests with real assertions per function (`tests/Security/SecurityUtilsTest.php`).
- Regenerated `port_signatures.json` + `port_surface.json`.

## Verification

`bash scripts/run-ci.sh` → **CI PASS** (all 11 gates: TEST, SIGNATURES, DRIFT, SURFACE-FRESH, NO-CHEAT, EMISSION, FMT, LINT, DOC-AUDIT, SURFACE-DIFF, SKILL-CONTRACT).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HhzeysbfURBuHL5Sn7Sjau
