### PR TITLE
ci(rest): enforce gap budget on REST-COVERAGE

### DIFF
--- a/scripts/run-ci.sh
+++ b/scripts/run-ci.sh
@@ -244,7 +244,8 @@ rest_coverage_gate() {
         --mock-url "http://127.0.0.1:$port" \
         --spec-root "$PORTING_SDK_DIR/rest-apis" \
         --allowlist "$PORTING_SDK_DIR/REST_COVERAGE_BASELINE.md" \
-        --allowlist "$PORT_ROOT/REST_COVERAGE_GAPS.md"
+        --allowlist "$PORT_ROOT/REST_COVERAGE_GAPS.md" \
+        --gap-baseline "$PORTING_SDK_DIR/REST_COVERAGE_GAP_BASELINE.md"
 }
 run_gate "REST-COVERAGE" "every implemented REST route covered success+error (parity + allowlist)" \
     rest_coverage_gate


### PR DESCRIPTION
The REST-COVERAGE gate now passes `--gap-baseline porting-sdk/REST_COVERAGE_GAP_BASELINE.md`.

porting-sdk's `rest_coverage.py` gained a **gap budget**: with `--gap-baseline`, the checker fails if this port allowlists any accepted-gap `endpoint_id` that isn't in the sanctioned baseline (the 21 universal+per-port gaps). So a **new** coverage gap can no longer be shelved silently in this port's `REST_COVERAGE_GAPS.md` — it must be added to the baseline in a reviewed porting-sdk PR first.

This port's `REST_COVERAGE_GAPS.md` (18 sdk-gaps) is already a clean subset of the baseline, so the gate stays green. Rolled across all 10 ports; the reference (python) landed it in signalwire-python#35.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HhzeysbfURBuHL5Sn7Sjau