### PR TITLE
fix(rest): remove invented fabric routes + add SPEC-PARITY gate

### DIFF
--- a/PORT_ADDITIONS.md
+++ b/PORT_ADDITIONS.md
@@ -413,22 +413,16 @@ signalwire.rest.namespaces.fabric.FabricAddresses.get_base_path: PHP-idiom-gette
 signalwire.rest.namespaces.fabric.FabricNamespace.addresses: PHP exposes a single FabricNamespace class with sub-resource accessors; Python splits into per-resource classes.
 signalwire.rest.namespaces.fabric.FabricNamespace.ai_agents: PHP exposes a single FabricNamespace class with sub-resource accessors; Python splits into per-resource classes.
 signalwire.rest.namespaces.fabric.FabricNamespace.call_flows: PHP exposes a single FabricNamespace class with sub-resource accessors; Python splits into per-resource classes.
-signalwire.rest.namespaces.fabric.FabricNamespace.call_queues: PHP exposes a single FabricNamespace class with sub-resource accessors; Python splits into per-resource classes.
 signalwire.rest.namespaces.fabric.FabricNamespace.conference_rooms: PHP exposes a single FabricNamespace class with sub-resource accessors; Python splits into per-resource classes.
-signalwire.rest.namespaces.fabric.FabricNamespace.conversations: PHP exposes a single FabricNamespace class with sub-resource accessors; Python splits into per-resource classes.
 signalwire.rest.namespaces.fabric.FabricNamespace.cxml_applications: PHP-namespace-accessor: explicit 'cxml_applications()' method on FabricNamespace returning the corresponding sub-resource; Python uses snake_case attribute access
 signalwire.rest.namespaces.fabric.FabricNamespace.cxml_scripts: PHP-namespace-accessor: explicit 'cxml_scripts()' method on FabricNamespace returning the corresponding sub-resource; Python uses snake_case attribute access
 signalwire.rest.namespaces.fabric.FabricNamespace.cxml_webhooks: PHP-namespace-accessor: explicit 'cxml_webhooks()' method on FabricNamespace returning the corresponding sub-resource; Python uses snake_case attribute access
-signalwire.rest.namespaces.fabric.FabricNamespace.dial_plans: PHP exposes a single FabricNamespace class with sub-resource accessors; Python splits into per-resource classes.
-signalwire.rest.namespaces.fabric.FabricNamespace.freeclimb_apps: PHP exposes a single FabricNamespace class with sub-resource accessors; Python splits into per-resource classes.
 signalwire.rest.namespaces.fabric.FabricNamespace.freeswitch_connectors: PHP-namespace-accessor: explicit 'freeswitch_connectors()' method on FabricNamespace returning the corresponding sub-resource; Python uses snake_case attribute access
 signalwire.rest.namespaces.fabric.FabricNamespace.get_client: PHP exposes a single FabricNamespace class with sub-resource accessors; Python splits into per-resource classes.
-signalwire.rest.namespaces.fabric.FabricNamespace.phone_numbers: PHP exposes a single FabricNamespace class with sub-resource accessors; Python splits into per-resource classes.
 signalwire.rest.namespaces.fabric.FabricNamespace.relay_applications: PHP-namespace-accessor: explicit 'relay_applications()' method on FabricNamespace returning the corresponding sub-resource; Python uses snake_case attribute access
 signalwire.rest.namespaces.fabric.FabricNamespace.resources: PHP-namespace-accessor: explicit 'resources()' method on FabricNamespace returning the corresponding sub-resource; Python uses snake_case attribute access
 signalwire.rest.namespaces.fabric.FabricNamespace.sip_endpoints: PHP exposes a single FabricNamespace class with sub-resource accessors; Python splits into per-resource classes.
 signalwire.rest.namespaces.fabric.FabricNamespace.sip_gateways: PHP-namespace-accessor: explicit 'sip_gateways()' method on FabricNamespace returning the corresponding sub-resource; Python uses snake_case attribute access
-signalwire.rest.namespaces.fabric.FabricNamespace.sip_profiles: PHP exposes a single FabricNamespace class with sub-resource accessors; Python splits into per-resource classes.
 signalwire.rest.namespaces.fabric.FabricNamespace.subscribers: PHP exposes a single FabricNamespace class with sub-resource accessors; Python splits into per-resource classes.
 signalwire.rest.namespaces.fabric.FabricNamespace.swml_scripts: PHP exposes a single FabricNamespace class with sub-resource accessors; Python splits into per-resource classes.
 signalwire.rest.namespaces.fabric.FabricNamespace.swml_webhooks: PHP-namespace-accessor: explicit 'swml_webhooks()' method on FabricNamespace returning the corresponding sub-resource; Python uses snake_case attribute access

--- a/PORT_SIGNATURE_OMISSIONS.md
+++ b/PORT_SIGNATURE_OMISSIONS.md
@@ -297,6 +297,7 @@ signalwire.rest.namespaces.logs.FaxLogs.list: PHP-idiom-kwargs: PHP has no **kwa
 signalwire.rest.namespaces.logs.MessageLogs.list: PHP-idiom-kwargs: PHP has no **kwargs syntax — Python's variadic kwargs translate to PHP's 'array $params' / 'array $kwargs' positional argument
 signalwire.rest.namespaces.logs.VoiceLogs.list: PHP-idiom-kwargs: PHP has no **kwargs syntax — Python's variadic kwargs translate to PHP's 'array $params' / 'array $kwargs' positional argument
 signalwire.rest.namespaces.logs.VoiceLogs.list_events: PHP-idiom-kwargs: PHP has no **kwargs syntax — Python's variadic kwargs translate to PHP's 'array $params' / 'array $kwargs' positional argument
+signalwire.rest.namespaces.lookup.LookupResource.phone_number: PHP-idiom-kwargs: PHP has no **kwargs syntax — Python's variadic kwargs translate to PHP's 'array $params' / 'array $kwargs' positional argument
 signalwire.rest.namespaces.mfa.MfaResource.call: PHP-idiom-kwargs: PHP has no **kwargs syntax — Python's variadic kwargs translate to PHP's 'array $params' / 'array $kwargs' positional argument
 signalwire.rest.namespaces.mfa.MfaResource.sms: PHP-idiom-kwargs: PHP has no **kwargs syntax — Python's variadic kwargs translate to PHP's 'array $params' / 'array $kwargs' positional argument
 signalwire.rest.namespaces.mfa.MfaResource.verify: PHP-idiom-kwargs: PHP has no **kwargs syntax — Python's variadic kwargs translate to PHP's 'array $params' / 'array $kwargs' positional argument

--- a/port_signatures.json
+++ b/port_signatures.json
@@ -10699,7 +10699,7 @@
                   "kind": "self"
                 }
               ],
-              "returns": "class:signalwire.rest._base.CrudResource"
+              "returns": "class:signalwire.rest.namespaces.lookup.LookupResource"
             },
             "mfa": {
               "params": [
@@ -13656,15 +13656,6 @@
               ],
               "returns": "class:signalwire.rest.namespaces.fabric.CallFlowsResource"
             },
-            "call_queues": {
-              "params": [
-                {
-                  "name": "self",
-                  "kind": "self"
-                }
-              ],
-              "returns": "class:signalwire.rest._base.CrudResource"
-            },
             "conference_rooms": {
               "params": [
                 {
@@ -13673,15 +13664,6 @@
                 }
               ],
               "returns": "class:signalwire.rest.namespaces.fabric.ConferenceRoomsResource"
-            },
-            "conversations": {
-              "params": [
-                {
-                  "name": "self",
-                  "kind": "self"
-                }
-              ],
-              "returns": "class:signalwire.rest._base.CrudResource"
             },
             "cxml_applications": {
               "params": [
@@ -13710,24 +13692,6 @@
               ],
               "returns": "class:signalwire.rest._base.CrudWithAddresses"
             },
-            "dial_plans": {
-              "params": [
-                {
-                  "name": "self",
-                  "kind": "self"
-                }
-              ],
-              "returns": "class:signalwire.rest._base.CrudResource"
-            },
-            "freeclimb_apps": {
-              "params": [
-                {
-                  "name": "self",
-                  "kind": "self"
-                }
-              ],
-              "returns": "class:signalwire.rest._base.CrudResource"
-            },
             "freeswitch_connectors": {
               "params": [
                 {
@@ -13745,15 +13709,6 @@
                 }
               ],
               "returns": "class:signalwire.rest._base.HttpClient"
-            },
-            "phone_numbers": {
-              "params": [
-                {
-                  "name": "self",
-                  "kind": "self"
-                }
-              ],
-              "returns": "class:signalwire.rest._base.CrudResource"
             },
             "relay_applications": {
               "params": [
@@ -13790,15 +13745,6 @@
                 }
               ],
               "returns": "class:signalwire.rest._base.CrudWithAddresses"
-            },
-            "sip_profiles": {
-              "params": [
-                {
-                  "name": "self",
-                  "kind": "self"
-                }
-              ],
-              "returns": "class:signalwire.rest._base.CrudResource"
             },
             "subscribers": {
               "params": [
@@ -14551,6 +14497,48 @@
                 },
                 {
                   "name": "log_id",
+                  "type": "string",
+                  "required": true
+                },
+                {
+                  "name": "params",
+                  "type": "any",
+                  "required": false,
+                  "default": []
+                }
+              ],
+              "returns": "any"
+            }
+          }
+        }
+      }
+    },
+    "signalwire.rest.namespaces.lookup": {
+      "classes": {
+        "LookupResource": {
+          "methods": {
+            "__init__": {
+              "params": [
+                {
+                  "name": "self",
+                  "kind": "self"
+                },
+                {
+                  "name": "http",
+                  "type": "class:signalwire.rest._base.HttpClient",
+                  "required": true
+                }
+              ],
+              "returns": "void"
+            },
+            "phone_number": {
+              "params": [
+                {
+                  "name": "self",
+                  "kind": "self"
+                },
+                {
+                  "name": "e164",
                   "type": "string",
                   "required": true
                 },

--- a/port_surface.json
+++ b/port_surface.json
@@ -1,6 +1,6 @@
 {
   "version": "1",
-  "generated_from": "signalwire-php @ 18d8ffe52f288c8b68da9de608bf0076827171cf",
+  "generated_from": "signalwire-php @ cc535eb6a93671ef725c7aaddac9fdfa26353fc4",
   "modules": {
     "signalwire": {
       "classes": {
@@ -1261,22 +1261,16 @@
           "addresses",
           "ai_agents",
           "call_flows",
-          "call_queues",
           "conference_rooms",
-          "conversations",
           "cxml_applications",
           "cxml_scripts",
           "cxml_webhooks",
-          "dial_plans",
-          "freeclimb_apps",
           "freeswitch_connectors",
           "get_client",
-          "phone_numbers",
           "relay_applications",
           "resources",
           "sip_endpoints",
           "sip_gateways",
-          "sip_profiles",
           "subscribers",
           "swml_scripts",
           "swml_webhooks",
@@ -1354,6 +1348,15 @@
           "get_base_path",
           "list",
           "list_events"
+        ]
+      },
+      "functions": []
+    },
+    "signalwire.rest.namespaces.lookup": {
+      "classes": {
+        "LookupResource": [
+          "__init__",
+          "phone_number"
         ]
       },
       "functions": []

--- a/scripts/enumerate_surface.py
+++ b/scripts/enumerate_surface.py
@@ -205,6 +205,7 @@ CLASS_MODULE_MAP: dict[str, str] = {
     "AddressesResource": "signalwire.rest.namespaces.addresses",
     "Recordings": "signalwire.rest.namespaces.recordings",
     "RecordingsResource": "signalwire.rest.namespaces.recordings",
+    "LookupResource": "signalwire.rest.namespaces.lookup",
 
     # Fabric helper classes — all collapse onto signalwire.rest.namespaces.fabric
     "FabricSubscribers": "signalwire.rest.namespaces.fabric",

--- a/scripts/route_registry.php
+++ b/scripts/route_registry.php
@@ -1,0 +1,435 @@
+<?php
+
+/**
+ * route_registry.php — enumerate the REST routes the PHP SDK IMPLEMENTS.
+ *
+ * This is "Set B" for the cross-port SPEC-PARITY gate: the routes the live
+ * RestClient actually dispatches, captured from the REAL code path — not parsed
+ * from source (an AST scraper would have to re-implement the CrudResource /
+ * BaseResource base-path machinery and would drift) and not read from the test
+ * journal (which only sees routes that happen to be tested, the exact blind spot
+ * the gate closes).
+ *
+ * How: construct RestClient, then swap its private HttpClient for a recording
+ * subclass that overrides get/post/put/patch/delete to capture (verb, path) and
+ * return [] instead of doing network I/O. Every route — CRUD-base, Calling
+ * command, FabricTokens.createSubscriberToken, etc. — funnels through one of
+ * those five verb methods. We then walk every namespace accessor on the client,
+ * recurse into every sub-resource accessor, and invoke every route method (one
+ * that returns array) with sentinel arguments. The path-param sentinel "{id}"
+ * is one URL segment (no slash) so the captured path is already a template
+ * comparable to the spec's path_template.
+ *
+ * Classification by reflection (structural, not a per-method skip list):
+ *   - method returning an SDK class (not HttpClient), 0 required params
+ *       → NAMESPACE/SUB-RESOURCE accessor: recurse into it.
+ *   - method returning `array`
+ *       → ROUTE method: invoke with sentinels, capture the HTTP call(s).
+ *   - method returning HttpClient / string / bool / int / void / self
+ *       → infra getter (getHttp/getBasePath/getProjectId/...): not a route,
+ *         not a sub-resource — excluded structurally.
+ *
+ * A route method that cannot be invoked, or that issues no HTTP request, is NOT
+ * silently dropped — a dropped route would turn a real divergence into a false
+ * "PHP matches the spec" pass. Such methods are hard errors (recorded in
+ * `errors`, non-zero exit) unless listed in REGISTRY_SKIP with a reason.
+ *
+ * Output: JSON {"routes":[{"method","path_template","via"}],"skipped":[...],
+ * "errors":[...]} on stdout. Exit 1 if any uninvokable / no-HTTP, un-skip-listed
+ * route method (Set B incomplete). Mirrors python_route_registry.py /
+ * route-registry.ts.
+ *
+ * Run: php scripts/route_registry.php
+ */
+
+declare(strict_types=1);
+
+require __DIR__ . '/../vendor/autoload.php';
+
+use SignalWire\REST\HttpClient;
+use SignalWire\REST\RestClient;
+
+// Path-param sentinel — one segment, no slash; already in {id} template form so
+// the captured path lines up with the spec's path_template.
+const SENTINEL = '{id}';
+
+// Methods that do NOT map to a single canonical REST route, keyed by
+// "<namespace>.<resource>.<method>" or a "<namespace>.<resource>.*" wildcard.
+// Every entry needs a reason; a method that merely throws / issues no HTTP is an
+// ERROR, not an implicit skip — add it here (justified) or fix the harness.
+const REGISTRY_SKIP = [
+    // cXML applications expose the CRUD surface but create is unsupported
+    // (throws BadMethodCallException) — there is no POST /cxml_applications
+    // canonical route. Mirrors python's fabric.cxml_applications.create.
+    'fabric.cxmlApplications.create' => 'no create route — throws BadMethodCallException by design',
+];
+
+/**
+ * Recording HttpClient: capture (verb, path) and return an empty array instead
+ * of doing any network I/O. Subclasses the real client so every resource that
+ * holds an HttpClient treats it identically.
+ */
+final class RecordingHttpClient extends HttpClient
+{
+    /**
+     * Captured (verb, path) pairs since the last reset(). Private so the only
+     * way to mutate it is through the verb methods / reset() below; callers read
+     * it via calls(), whose declared return type tells PHPStan the slice can be
+     * non-empty. (Exposing it as a public property would let a caller do
+     * `$client->calls = []`, whose literal-[] narrowing PHPStan then can't see
+     * an opaque Reflection invoke widen again — producing a bogus "always 0".)
+     *
+     * @var list<array{string,string}>
+     */
+    private array $calls = [];
+
+    public function __construct()
+    {
+        // Bypass the real constructor (no auth/curl setup needed) — we never
+        // touch the network. Parent properties stay unset; they are unused
+        // because we override every verb method below.
+    }
+
+    /** Drop all captured calls (start a fresh recording window). */
+    public function reset(): void
+    {
+        $this->calls = [];
+    }
+
+    /**
+     * The calls captured since the last reset().
+     *
+     * @return list<array{string,string}>
+     */
+    public function calls(): array
+    {
+        return $this->calls;
+    }
+
+    /** @param array<string,string> $params @return array<string,mixed> */
+    public function get(string $path, array $params = []): array
+    {
+        $this->calls[] = ['GET', $path];
+        return [];
+    }
+
+    /** @param array<string,mixed> $data @return array<string,mixed> */
+    public function post(string $path, array $data = []): array
+    {
+        $this->calls[] = ['POST', $path];
+        return [];
+    }
+
+    /** @param array<string,mixed> $data @return array<string,mixed> */
+    public function put(string $path, array $data = []): array
+    {
+        $this->calls[] = ['PUT', $path];
+        return [];
+    }
+
+    /** @param array<string,mixed> $data @return array<string,mixed> */
+    public function patch(string $path, array $data = []): array
+    {
+        $this->calls[] = ['PATCH', $path];
+        return [];
+    }
+
+    /** @return array<string,mixed> */
+    public function delete(string $path): array
+    {
+        $this->calls[] = ['DELETE', $path];
+        return [];
+    }
+
+    /** @param array<string,string> $params @return \Generator<int,array<string,mixed>> */
+    public function listAll(string $path, array $params = []): \Generator
+    {
+        $this->calls[] = ['GET', $path];
+        yield [];
+    }
+}
+
+/**
+ * Walks the live RestClient and records every implemented route.
+ */
+final class RouteRegistry
+{
+    private RecordingHttpClient $http;
+
+    /** @var array<int,array{method:string,path_template:string,via:string}> */
+    private array $routes = [];
+    /** @var array<int,array{key:string,reason:string}> */
+    private array $skipped = [];
+    /** @var array<int,array{key:string,error:string}> */
+    private array $errors = [];
+
+    /** @var array<int,bool> object hashes already visited (cycle guard). */
+    private array $seen = [];
+
+    public function __construct(RecordingHttpClient $http)
+    {
+        $this->http = $http;
+    }
+
+    /**
+     * @return array{routes:array<int,array{method:string,path_template:string,via:array<int,string>}>,skipped:array<int,array{key:string,reason:string}>,errors:array<int,array{key:string,error:string}>}
+     */
+    public function build(RestClient $client): array
+    {
+        // Top-level namespace accessors on the client (fabric(), calling(), ...).
+        foreach ($this->resourceAccessors($client) as [$name, $obj]) {
+            $this->handle($name, $name, $obj);
+        }
+
+        // De-dup identical (method, path); collect every `via` accessor key.
+        /** @var array<string,array{method:string,path_template:string,via:array<int,string>}> $byRoute */
+        $byRoute = [];
+        foreach ($this->routes as $r) {
+            $k = $r['method'] . ' ' . $r['path_template'];
+            if (isset($byRoute[$k])) {
+                $byRoute[$k]['via'][] = $r['via'];
+            } else {
+                $byRoute[$k] = [
+                    'method' => $r['method'],
+                    'path_template' => $r['path_template'],
+                    'via' => [$r['via']],
+                ];
+            }
+        }
+        $deduped = array_values($byRoute);
+        usort($deduped, static function ($a, $b) {
+            return ($a['path_template'] . $a['method']) <=> ($b['path_template'] . $b['method']);
+        });
+
+        return [
+            'routes' => $deduped,
+            'skipped' => $this->skipped,
+            'errors' => $this->errors,
+        ];
+    }
+
+    /**
+     * Handle one resource node: invoke its route methods and recurse into its
+     * sub-resource accessors.
+     */
+    private function handle(string $nsName, string $resName, object $res): void
+    {
+        $hash = spl_object_id($res);
+        if (isset($this->seen[$hash])) {
+            return;
+        }
+        $this->seen[$hash] = true;
+
+        $rc = new ReflectionClass($res);
+        foreach ($rc->getMethods(ReflectionMethod::IS_PUBLIC) as $m) {
+            if ($m->isStatic() || $m->isConstructor() || $m->isDestructor()) {
+                continue;
+            }
+            $name = $m->getName();
+            if (str_starts_with($name, '__')) {
+                continue;
+            }
+
+            $key = "{$nsName}.{$resName}.{$name}";
+            $reason = $this->skipReason($key);
+            if ($reason !== null) {
+                $this->skipped[] = ['key' => $key, 'reason' => $reason];
+                continue;
+            }
+
+            $kind = $this->classify($m);
+            if ($kind === 'accessor') {
+                // Sub-resource / namespace traversal — recurse, don't record.
+                try {
+                    $sub = $m->invoke($res);
+                } catch (\Throwable $e) {
+                    $this->errors[] = [
+                        'key' => $key,
+                        'error' => get_class($e) . ': ' . $e->getMessage(),
+                    ];
+                    continue;
+                }
+                if (is_object($sub)) {
+                    $this->handle($nsName, $name, $sub);
+                }
+                continue;
+            }
+            if ($kind === 'infra') {
+                // getHttp/getBasePath/getProjectId/... — neither a route nor a
+                // sub-resource; not part of the dispatched-route surface.
+                continue;
+            }
+
+            // kind === 'route': invoke with sentinels and capture the HTTP call.
+            $this->http->reset();
+            try {
+                $args = $this->sentinelArgs($m);
+                $m->invokeArgs($res, $args);
+            } catch (\Throwable $e) {
+                $this->errors[] = [
+                    'key' => $key,
+                    'error' => get_class($e) . ': ' . $e->getMessage(),
+                ];
+                continue;
+            }
+            $calls = $this->http->calls();
+            if (count($calls) === 0) {
+                $this->errors[] = [
+                    'key' => $key,
+                    'error' => 'invoked but issued no HTTP request '
+                        . '(client-side helper? add to REGISTRY_SKIP with a reason)',
+                ];
+                continue;
+            }
+            foreach ($calls as [$verb, $path]) {
+                $this->routes[] = [
+                    'method' => $verb,
+                    'path_template' => $path,
+                    'via' => $key,
+                ];
+            }
+        }
+    }
+
+    /**
+     * Public, non-static, 0-required-arg methods on $obj whose return type is an
+     * SDK resource/namespace class (not HttpClient) — the namespace accessors.
+     *
+     * @return array<int,array{0:string,1:object}>
+     */
+    private function resourceAccessors(object $obj): array
+    {
+        $out = [];
+        $rc = new ReflectionClass($obj);
+        foreach ($rc->getMethods(ReflectionMethod::IS_PUBLIC) as $m) {
+            if ($m->isStatic() || $m->isConstructor() || $m->isDestructor()) {
+                continue;
+            }
+            if (str_starts_with($m->getName(), '__')) {
+                continue;
+            }
+            if ($this->classify($m) !== 'accessor') {
+                continue;
+            }
+            try {
+                $sub = $m->invoke($obj);
+            } catch (\Throwable $e) {
+                $this->errors[] = [
+                    'key' => $rc->getShortName() . '.' . $m->getName(),
+                    'error' => get_class($e) . ': ' . $e->getMessage(),
+                ];
+                continue;
+            }
+            if (is_object($sub)) {
+                $out[] = [$m->getName(), $sub];
+            }
+        }
+        return $out;
+    }
+
+    /**
+     * Classify a method by its return type:
+     *   'accessor' — returns an SDK class (not HttpClient): a sub-resource.
+     *   'route'    — returns array: a dispatched REST route.
+     *   'infra'    — returns HttpClient / scalar / void / self: a getter.
+     */
+    private function classify(ReflectionMethod $m): string
+    {
+        $rt = $m->getReturnType();
+        if ($rt instanceof ReflectionNamedType) {
+            $tn = $rt->getName();
+            if ($tn === 'array') {
+                // A 0-required-arg array method is still a route (e.g. list()).
+                return 'route';
+            }
+            if (in_array($tn, ['string', 'int', 'bool', 'float', 'void', 'mixed', 'self', 'static', 'never'], true)) {
+                return 'infra';
+            }
+            // A class return type. HttpClient is infra; any other SDK class is a
+            // sub-resource accessor — but only if it needs no arguments to reach.
+            if (is_a($tn, HttpClient::class, true)) {
+                return 'infra';
+            }
+            if ($this->hasNoRequiredParams($m)) {
+                return 'accessor';
+            }
+            // A class-returning method that needs args is neither — treat as infra
+            // (no such method exists on the REST surface today; defensive).
+            return 'infra';
+        }
+        // No declared return type — fall back to infra (none on REST surface).
+        return 'infra';
+    }
+
+    private function hasNoRequiredParams(ReflectionMethod $m): bool
+    {
+        foreach ($m->getParameters() as $p) {
+            if (!$p->isOptional()) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Build sentinel arguments for a route method: required `string` → "{id}",
+     * required `array` → []. Optional / variadic params get nothing.
+     *
+     * @return array<int,mixed>
+     */
+    private function sentinelArgs(ReflectionMethod $m): array
+    {
+        $args = [];
+        foreach ($m->getParameters() as $p) {
+            if ($p->isOptional() || $p->isVariadic()) {
+                continue;
+            }
+            $t = $p->getType();
+            if ($t instanceof ReflectionNamedType && $t->getName() === 'array') {
+                $args[] = [];
+            } else {
+                // string (resource id / sid) and everything else → the path sentinel.
+                $args[] = SENTINEL;
+            }
+        }
+        return $args;
+    }
+
+    private function skipReason(string $key): ?string
+    {
+        if (isset(REGISTRY_SKIP[$key])) {
+            return REGISTRY_SKIP[$key];
+        }
+        $pos = strrpos($key, '.');
+        if ($pos !== false) {
+            $wildcard = substr($key, 0, $pos) . '.*';
+            if (isset(REGISTRY_SKIP[$wildcard])) {
+                return REGISTRY_SKIP[$wildcard];
+            }
+        }
+        return null;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+$client = new RestClient('p', 't', 'example.signalwire.com');
+
+// Swap the client's private HttpClient for the recorder. RestClient builds its
+// own HttpClient in __construct (and caches namespace objects lazily, all still
+// null at this point), so re-pointing the private $http here means every
+// namespace accessor wires its resources to the recorder. Mirrors python's
+// HttpClient monkeypatch / ts's fetchImpl injection.
+$recorder = new RecordingHttpClient();
+$ref = new ReflectionProperty(RestClient::class, 'http');
+$ref->setAccessible(true);
+$ref->setValue($client, $recorder);
+
+$registry = new RouteRegistry($recorder);
+$out = $registry->build($client);
+
+echo json_encode($out, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES), "\n";
+
+exit(count($out['errors']) > 0 ? 1 : 0);

--- a/scripts/run-ci.sh
+++ b/scripts/run-ci.sh
@@ -250,6 +250,35 @@ rest_coverage_gate() {
 run_gate "REST-COVERAGE" "every implemented REST route covered success+error (parity + allowlist)" \
     rest_coverage_gate
 
+# Gate 5c: SPEC-PARITY — the routes the SDK actually IMPLEMENTS must equal the
+# canonical spec route set, modulo porting-sdk/SPEC_IMPLEMENTATION_GAPS.md. This
+# is the spec-first guard REST-COVERAGE can't give: REST-COVERAGE only proves
+# *tested* routes match the spec, so a route the SDK implements that the spec
+# doesn't define (or a canonical route never implemented) slips past it. Set B is
+# built by scripts/route_registry.php — it drives the live RestClient through a
+# recording HttpClient (records (method, path), returns []) and reflects over
+# every namespace/sub-resource public method, invoking each with sentinel args,
+# so it sees every dispatched route whether or not it's tested. The shared
+# porting-sdk diff consumes that JSON via --registry-json.
+spec_parity_gate() {
+    local mock_pkg_parent="$PORTING_SDK_DIR/test_harness/mock_signalwire"
+    export PYTHONPATH="$mock_pkg_parent${PYTHONPATH:+:$PYTHONPATH}"
+    local registry
+    registry="$(mktemp)"
+    # SIGNALWIRE_LOG_MODE=off so the SDK logger doesn't pollute stdout JSON.
+    SIGNALWIRE_LOG_MODE=off php "$PORT_ROOT/scripts/route_registry.php" >"$registry" 2>/dev/null || {
+        rm -f "$registry"; return 1
+    }
+    "$PYTHON_BIN" "$PORTING_SDK_DIR/scripts/diff_spec_implementation.py" \
+        --registry-json "$registry" \
+        --gaps "$PORTING_SDK_DIR/SPEC_IMPLEMENTATION_GAPS.md"
+    local rc=$?
+    rm -f "$registry"
+    return $rc
+}
+run_gate "SPEC-PARITY" "implemented routes == canonical spec (modulo SPEC_IMPLEMENTATION_GAPS.md)" \
+    spec_parity_gate
+
 # Gate 6: emission — byte-compare the native FunctionResult serialisation against
 # Python's to_dict() across the shared corpus. Pure serialisation: no mock
 # servers, no network. The dump command runs with cwd = the port root.

--- a/src/SignalWire/REST/Namespaces/Fabric.php
+++ b/src/SignalWire/REST/Namespaces/Fabric.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace SignalWire\REST\Namespaces;
 
-use SignalWire\REST\CrudResource;
 use SignalWire\REST\CrudWithAddresses;
 use SignalWire\REST\HttpClient;
 
@@ -51,14 +50,6 @@ class Fabric
     private ?CrudWithAddresses $aiAgents = null;
     private ?CrudWithAddresses $sipGateways = null;
     private ?CrudWithAddresses $cxmlWebhooks = null;
-
-    // Legacy/back-compat aliases
-    private ?CrudResource $conversations = null;
-    private ?CrudResource $dialPlans = null;
-    private ?CrudResource $freeclimbApps = null;
-    private ?CrudResource $callQueues = null;
-    private ?CrudResource $sipProfiles = null;
-    private ?CrudResource $phoneNumbers = null;
 
     // Special resources
     private ?FabricGenericResources $resources = null;
@@ -181,56 +172,6 @@ class Fabric
             $this->cxmlWebhooks = new CrudWithAddresses($this->client, self::BASE . '/cxml_webhooks');
         }
         return $this->cxmlWebhooks;
-    }
-
-    // ---- Legacy/back-compat aliases ---------------------------------
-
-    public function conversations(): CrudResource
-    {
-        if ($this->conversations === null) {
-            $this->conversations = new CrudResource($this->client, self::BASE . '/conversations');
-        }
-        return $this->conversations;
-    }
-
-    public function dialPlans(): CrudResource
-    {
-        if ($this->dialPlans === null) {
-            $this->dialPlans = new CrudResource($this->client, self::BASE . '/dial_plans');
-        }
-        return $this->dialPlans;
-    }
-
-    public function freeclimbApps(): CrudResource
-    {
-        if ($this->freeclimbApps === null) {
-            $this->freeclimbApps = new CrudResource($this->client, self::BASE . '/freeclimb_apps');
-        }
-        return $this->freeclimbApps;
-    }
-
-    public function callQueues(): CrudResource
-    {
-        if ($this->callQueues === null) {
-            $this->callQueues = new CrudResource($this->client, self::BASE . '/call_queues');
-        }
-        return $this->callQueues;
-    }
-
-    public function sipProfiles(): CrudResource
-    {
-        if ($this->sipProfiles === null) {
-            $this->sipProfiles = new CrudResource($this->client, self::BASE . '/sip_profiles');
-        }
-        return $this->sipProfiles;
-    }
-
-    public function phoneNumbers(): CrudResource
-    {
-        if ($this->phoneNumbers === null) {
-            $this->phoneNumbers = new CrudResource($this->client, self::BASE . '/phone_numbers');
-        }
-        return $this->phoneNumbers;
     }
 
     // ---- Special resources ------------------------------------------

--- a/src/SignalWire/REST/Namespaces/LookupResource.php
+++ b/src/SignalWire/REST/Namespaces/LookupResource.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SignalWire\REST\Namespaces;
+
+use SignalWire\REST\BaseResource;
+use SignalWire\REST\HttpClient;
+
+/**
+ * Phone Number Lookup namespace.
+ *
+ * Mirrors the Python reference (`signalwire.rest.namespaces.lookup`): a single
+ * lookup operation, NOT a CRUD resource. The only canonical route is
+ * `GET /api/relay/rest/lookup/phone_number/{e164}` (`relay-rest.lookup_phone_number`).
+ */
+class LookupResource extends BaseResource
+{
+    public function __construct(HttpClient $http)
+    {
+        parent::__construct($http, '/api/relay/rest/lookup');
+    }
+
+    /**
+     * Look up carrier / CNAM data for an E.164 phone number.
+     *
+     * @param array<string, mixed> $params Optional query parameters.
+     * @return array<string, mixed>
+     */
+    public function phoneNumber(string $e164, array $params = []): array
+    {
+        return $this->http->get($this->path('phone_number', $e164), $params);
+    }
+}

--- a/src/SignalWire/REST/RestClient.php
+++ b/src/SignalWire/REST/RestClient.php
@@ -12,6 +12,7 @@ use SignalWire\REST\Namespaces\Datasphere;
 use SignalWire\REST\Namespaces\Fabric;
 use SignalWire\REST\Namespaces\ImportedNumbers;
 use SignalWire\REST\Namespaces\Logs;
+use SignalWire\REST\Namespaces\LookupResource;
 use SignalWire\REST\Namespaces\Mfa;
 use SignalWire\REST\Namespaces\NumberGroups;
 use SignalWire\REST\Namespaces\PhoneNumbersResource;
@@ -55,7 +56,7 @@ class RestClient
     private ?NumberGroups $numberGroups = null;
     private ?VerifiedCallersResource $verifiedCallers = null;
     private ?SipProfile $sipProfile = null;
-    private ?CrudResource $lookup = null;
+    private ?LookupResource $lookup = null;
     private ?ShortCodes $shortCodes = null;
     private ?ImportedNumbers $importedNumbers = null;
     private ?Mfa $mfa = null;
@@ -254,11 +255,11 @@ class RestClient
         return $this->sipProfile;
     }
 
-    /** Phone number lookup. */
-    public function lookup(): CrudResource
+    /** Phone number lookup (single lookup operation; mirrors Python's LookupResource). */
+    public function lookup(): LookupResource
     {
         if ($this->lookup === null) {
-            $this->lookup = new CrudResource($this->http, '/api/relay/rest/lookup/phone_number');
+            $this->lookup = new LookupResource($this->http);
         }
         return $this->lookup;
     }

--- a/tests/Rest/RelayRestCoverageMockTest.php
+++ b/tests/Rest/RelayRestCoverageMockTest.php
@@ -1486,7 +1486,7 @@ class RelayRestCoverageMockTest extends TestCase
     #[Test]
     public function lookupPhoneNumberSuccess(): void
     {
-        $body = $this->client->lookup()->get('+15551230000');
+        $body = $this->client->lookup()->phoneNumber('+15551230000');
         $this->assertIsArray($body);
         $j = $this->assertSuccess('GET', self::LOOKUP . '/+15551230000', 'relay-rest.lookup_phone_number');
         $this->assertSame('GET', $j->method);
@@ -1497,7 +1497,7 @@ class RelayRestCoverageMockTest extends TestCase
     {
         $this->mock->scenarios()->set('relay-rest.lookup_phone_number', 404, ['error' => 'nope']);
         try {
-            $this->client->lookup()->get('+19999999999');
+            $this->client->lookup()->phoneNumber('+19999999999');
             $this->fail('expected SignalWireRestError');
         } catch (SignalWireRestError $e) {
             $this->assertSame(404, $e->getStatusCode());

--- a/tests/RestClientTest.php
+++ b/tests/RestClientTest.php
@@ -297,7 +297,7 @@ class RestClientTest extends TestCase
         $this->assertSame('/api/relay/rest/number_groups', $client->numberGroups()->getBasePath());
         $this->assertSame('/api/relay/rest/verified_caller_ids', $client->verifiedCallers()->getBasePath());
         $this->assertSame('/api/relay/rest/sip_profile', $client->sipProfile()->getBasePath());
-        $this->assertSame('/api/relay/rest/lookup/phone_number', $client->lookup()->getBasePath());
+        $this->assertSame('/api/relay/rest/lookup', $client->lookup()->getBasePath());
         $this->assertSame('/api/relay/rest/short_codes', $client->shortCodes()->getBasePath());
         $this->assertSame('/api/relay/rest/imported_phone_numbers', $client->importedNumbers()->getBasePath());
         $this->assertSame('/api/relay/rest/mfa', $client->mfa()->getBasePath());
@@ -351,14 +351,8 @@ class RestClientTest extends TestCase
         $this->assertInstanceOf(CrudResource::class, $fabric->sipEndpoints());
         $this->assertInstanceOf(CrudResource::class, $fabric->callFlows());
         $this->assertInstanceOf(CrudResource::class, $fabric->swmlScripts());
-        $this->assertInstanceOf(CrudResource::class, $fabric->conversations());
         $this->assertInstanceOf(CrudResource::class, $fabric->conferenceRooms());
-        $this->assertInstanceOf(CrudResource::class, $fabric->dialPlans());
-        $this->assertInstanceOf(CrudResource::class, $fabric->freeclimbApps());
-        $this->assertInstanceOf(CrudResource::class, $fabric->callQueues());
         $this->assertInstanceOf(CrudResource::class, $fabric->aiAgents());
-        $this->assertInstanceOf(CrudResource::class, $fabric->sipProfiles());
-        $this->assertInstanceOf(CrudResource::class, $fabric->phoneNumbers());
 
         // The special resources have their own classes (read-only fabric
         // addresses, generic resources, token endpoints).
@@ -380,14 +374,8 @@ class RestClientTest extends TestCase
         $this->assertSame('/api/fabric/addresses', $fabric->addresses()->getBasePath());
         $this->assertSame('/api/fabric/resources/call_flows', $fabric->callFlows()->getBasePath());
         $this->assertSame('/api/fabric/resources/swml_scripts', $fabric->swmlScripts()->getBasePath());
-        $this->assertSame('/api/fabric/resources/conversations', $fabric->conversations()->getBasePath());
         $this->assertSame('/api/fabric/resources/conference_rooms', $fabric->conferenceRooms()->getBasePath());
-        $this->assertSame('/api/fabric/resources/dial_plans', $fabric->dialPlans()->getBasePath());
-        $this->assertSame('/api/fabric/resources/freeclimb_apps', $fabric->freeclimbApps()->getBasePath());
-        $this->assertSame('/api/fabric/resources/call_queues', $fabric->callQueues()->getBasePath());
         $this->assertSame('/api/fabric/resources/ai_agents', $fabric->aiAgents()->getBasePath());
-        $this->assertSame('/api/fabric/resources/sip_profiles', $fabric->sipProfiles()->getBasePath());
-        $this->assertSame('/api/fabric/resources/phone_numbers', $fabric->phoneNumbers()->getBasePath());
         // Generic resources collection.
         $this->assertSame('/api/fabric/resources', $fabric->resources()->getBasePath());
         // Tokens namespace (sits under /api/fabric, not /api/fabric/resources).


### PR DESCRIPTION
## Summary

Seven REST "routes" the PHP SDK exposed were **invented port surface**: they existed in neither the Python reference SDK nor the canonical REST spec. They were backed only by construction-style tests in the PHP suite, never by the spec. The new **SPEC-PARITY** gate (which diffs the routes the SDK *actually dispatches* against the canonical spec route set) caught them.

The seven:

- 6 fabric alias accessors on `Fabric` — `conversations`, `dialPlans`, `freeclimbApps`, `callQueues`, `sipProfiles`, and a fabric-level `phoneNumbers` (none defined in Python or the spec).
- A bogus full-CRUD `lookup` resource — Python's `lookup` is a **single-method** namespace (`GET /api/relay/rest/lookup/phone_number/{e164}`), not a CRUD resource.

## Fix (deletion, not allowlisting)

- Removed the 6 fabric alias accessors (fields + methods) from `Fabric.php`.
- Replaced the invented CRUD `lookup` with a single-method `LookupResource` (`phoneNumber($e164)`) matching Python's shape; repointed `RestClient::lookup()`.
- Removed the deleted accessors' assertions from `RestClientTest.php`; changed the lookup coverage calls to `->lookup()->phoneNumber(...)`.
- Removed the 6 stale fabric-alias entries from `PORT_ADDITIONS.md`.
- Reconciled the oracle bookkeeping: mapped `LookupResource` → `signalwire.rest.namespaces.lookup` in the surface enumerator's `CLASS_MODULE_MAP`, regenerated `port_surface.json` / `port_signatures.json`, and added the `PHP-idiom-kwargs` signature-omission entry for `lookup.LookupResource.phone_number` (Python's `**params` ↔ PHP's trailing `array $params`).

None of the deleted surface was re-added and no `--divergence-allow` / spec-gap allowlisting was used — the registry diff confirms **286/307 routes, 0 divergences**.

## SPEC-PARITY gate

Wired into `scripts/run-ci.sh`: builds Set B via `scripts/route_registry.php` (drives the live `RestClient` through a recording `HttpClient` and reflects over every namespace/sub-resource route method) and feeds it to porting-sdk's `diff_spec_implementation.py --registry-json`. Depends on porting-sdk's `--registry-json` support (porting-sdk #45, merged).

All gates pass locally: `==> CI PASS` (TEST, SIGNATURES, DRIFT, SURFACE-FRESH, NO-CHEAT, REST-COVERAGE, SPEC-PARITY, EMISSION, FMT, LINT, DOC-AUDIT, SURFACE-DIFF, SKILL-CONTRACT).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HhzeysbfURBuHL5Sn7Sjau
