### PR TITLE
fix(agent): behavior parity bundle (#190/#191/#185/#182)

### DIFF
--- a/src/SignalWire/Agent/AgentBase.php
+++ b/src/SignalWire/Agent/AgentBase.php
@@ -279,6 +279,9 @@ class AgentBase extends Service
      */
     public function promptAddSubsection(string $parentTitle, string $title, string $body): self
     {
+        $this->usePom = true;
+
+        $found = false;
         foreach ($this->pomSections as &$section) {
             if ($section['title'] === $parentTitle) {
                 if (!isset($section['subsections'])) {
@@ -288,10 +291,26 @@ class AgentBase extends Service
                     'title' => $title,
                     'body'  => $body,
                 ];
+                $found = true;
                 break;
             }
         }
         unset($section);
+
+        // Auto-create the parent section when missing (matching the
+        // TypeScript reference, which calls addSection(parentTitle)).
+        if (!$found) {
+            $this->pomSections[] = [
+                'title'       => $parentTitle,
+                'subsections' => [
+                    [
+                        'title' => $title,
+                        'body'  => $body,
+                    ],
+                ],
+            ];
+        }
+
         return $this;
     }
 
@@ -300,6 +319,9 @@ class AgentBase extends Service
      */
     public function promptAddToSection(string $title, ?string $body = null, array $bullets = []): self
     {
+        $this->usePom = true;
+
+        $found = false;
         foreach ($this->pomSections as &$section) {
             if ($section['title'] === $title) {
                 if ($body !== null) {
@@ -311,10 +333,25 @@ class AgentBase extends Service
                     }
                     $section['bullets'] = array_merge($section['bullets'], $bullets);
                 }
+                $found = true;
                 break;
             }
         }
         unset($section);
+
+        // Auto-create the section when missing (matching the TypeScript
+        // reference, which calls addSection(title) before appending).
+        if (!$found) {
+            $section = ['title' => $title];
+            if ($body !== null) {
+                $section['body'] = $body;
+            }
+            if (!empty($bullets)) {
+                $section['bullets'] = $bullets;
+            }
+            $this->pomSections[] = $section;
+        }
+
         return $this;
     }
 
@@ -602,9 +639,17 @@ class AgentBase extends Service
         return $this;
     }
 
+    /**
+     * Merge $data into global_data. Despite the name this does NOT replace
+     * the existing object: existing keys are preserved and incoming keys
+     * overwrite only on collision. This mirrors updateGlobalData() and the
+     * TypeScript reference (safeAssign) — skills and other callers each
+     * contribute keys, so a replacing setGlobalData would silently clobber
+     * their contributions.
+     */
     public function setGlobalData(array $data): self
     {
-        $this->globalData = $data;
+        $this->globalData = array_merge($this->globalData, $data);
         return $this;
     }
 
@@ -743,9 +788,37 @@ class AgentBase extends Service
         return $this;
     }
 
+    /**
+     * Replace the entire list of function includes.
+     *
+     * Each include must have a truthy ``url`` and an array ``functions``
+     * field; entries missing either are dropped (matching the TypeScript
+     * reference's filter), and each dropped entry is warned so a malformed
+     * include is caught at registration time rather than silently vanishing.
+     */
     public function setFunctionIncludes(array $includes): self
     {
-        $this->functionIncludes = $includes;
+        $valid = [];
+        foreach ($includes as $include) {
+            if (
+                is_array($include)
+                && !empty($include['url'])
+                && isset($include['functions'])
+                && is_array($include['functions'])
+            ) {
+                $valid[] = $include;
+                continue;
+            }
+            $urlLabel = (is_array($include) && isset($include['url']) && is_string($include['url']))
+                ? $include['url']
+                : '(no url)';
+            $this->logger->warn(
+                "invalid_function_include: '{$urlLabel}'. setFunctionIncludes "
+                . 'requires each entry to have a non-empty url and an array '
+                . 'functions field; this entry was dropped.'
+            );
+        }
+        $this->functionIncludes = $valid;
         return $this;
     }
 
@@ -1068,7 +1141,15 @@ class AgentBase extends Service
         if ($this->usePom && !empty($this->pomSections)) {
             $prompt['pom'] = $this->pomSections;
         } else {
-            $prompt['text'] = $this->promptText;
+            $text = $this->promptText;
+            // When contexts are active and no prompt text was set, fall back to
+            // the default prompt (matching the TypeScript reference, which uses
+            // `prompt || \`You are ${this.name}, a helpful AI assistant.\``
+            // in its contexts branch) rather than emitting an empty text.
+            if ($text === '' && $this->contextBuilder !== null) {
+                $text = "You are {$this->name}, a helpful AI assistant.";
+            }
+            $prompt['text'] = $text;
         }
         if (!empty($this->promptLlmParams)) {
             $prompt = array_merge($prompt, $this->promptLlmParams);

--- a/tests/AgentBaseTest.php
+++ b/tests/AgentBaseTest.php
@@ -565,9 +565,9 @@ class AgentBaseTest extends TestCase
     public function testSetFunctionIncludes(): void
     {
         $agent = $this->makeAgent();
-        $agent->addFunctionInclude(['url' => 'https://first.com']);
+        $agent->addFunctionInclude(['url' => 'https://first.com', 'functions' => ['x']]);
         $agent->setFunctionIncludes([
-            ['url' => 'https://replaced.com'],
+            ['url' => 'https://replaced.com', 'functions' => ['y']],
         ]);
 
         $ai = $this->extractAiVerb($agent->renderSwml());
@@ -1244,6 +1244,175 @@ class AgentBaseTest extends TestCase
         $found = $pom->findSection('Inner');
         $this->assertNotNull($found, 'getPom() must return a usable PromptObjectModel');
         $this->assertSame('ib', $found->body);
+    }
+
+    // ------------------------------------------------------------------
+    // Behavior-parity bundle (#190 / #191 / #185 / #182)
+    // ------------------------------------------------------------------
+
+    // #190 — setGlobalData must MERGE (matching the TS reference, which calls
+    // safeAssign), not replace. Skills and other callers each contribute keys,
+    // so a replacing setGlobalData would silently clobber their contributions.
+    public function testSetGlobalDataMerges(): void
+    {
+        $agent = $this->makeAgent();
+        $agent->setGlobalData(['a' => 1]);
+        $agent->setGlobalData(['b' => 2]);
+
+        $ai = $this->extractAiVerb($agent->renderSwml());
+        $this->assertSame(['a' => 1, 'b' => 2], $ai['global_data']);
+    }
+
+    public function testSetGlobalDataOverwritesOnCollision(): void
+    {
+        $agent = $this->makeAgent();
+        $agent->setGlobalData(['k' => 'first', 'keep' => 'x']);
+        $agent->setGlobalData(['k' => 'second']);
+
+        $ai = $this->extractAiVerb($agent->renderSwml());
+        $this->assertSame(['k' => 'second', 'keep' => 'x'], $ai['global_data']);
+    }
+
+    // #191 — setFunctionIncludes must DROP entries that lack a truthy url or an
+    // array functions field (matching the TS reference's filter), and warn for
+    // each dropped entry so the typo is caught at registration time.
+    public function testSetFunctionIncludesDropsInvalidEntries(): void
+    {
+        $agent = $this->makeAgent();
+        $agent->setFunctionIncludes([
+            ['url' => 'https://valid.com', 'functions' => ['a']],
+            ['url' => 'https://no-functions.com'],          // missing functions -> drop
+            ['functions' => ['b']],                          // missing url -> drop
+            ['url' => 'https://bad-functions.com', 'functions' => 'notarray'], // functions not array -> drop
+        ]);
+
+        $ai = $this->extractAiVerb($agent->renderSwml());
+        $this->assertCount(1, $ai['SWAIG']['includes']);
+        $this->assertSame('https://valid.com', $ai['SWAIG']['includes'][0]['url']);
+    }
+
+    public function testSetFunctionIncludesKeepsAllValidEntries(): void
+    {
+        $agent = $this->makeAgent();
+        $agent->setFunctionIncludes([
+            ['url' => 'https://a.com', 'functions' => ['a']],
+            ['url' => 'https://b.com', 'functions' => []],
+        ]);
+
+        $ai = $this->extractAiVerb($agent->renderSwml());
+        $this->assertCount(2, $ai['SWAIG']['includes']);
+    }
+
+    public function testSetFunctionIncludesWarnsPerDroppedEntry(): void
+    {
+        // The Logger writes to stderr, which cannot be intercepted from inside
+        // the PHPUnit process — spawn a child PHP process to inspect what
+        // setFunctionIncludes() logged (same pattern as LoggerTest).
+        $autoload = dirname(__DIR__) . '/vendor/autoload.php';
+        $script = <<<PHP
+            <?php
+            require '{$autoload}';
+            \$agent = new \\SignalWire\\Agent\\AgentBase(
+                name: 'child',
+                basicAuthUser: 'u',
+                basicAuthPassword: 'p',
+            );
+            \$agent->setFunctionIncludes([
+                ['url' => 'https://valid.com', 'functions' => ['a']],
+                ['url' => 'https://no-functions.com'],
+                ['functions' => ['b']],
+            ]);
+            PHP;
+        $tmp = \tempnam(\sys_get_temp_dir(), 'sw_fi_test_') . '.php';
+        \file_put_contents($tmp, $script);
+        try {
+            $cmd = \escapeshellcmd(PHP_BINARY) . ' ' . \escapeshellarg($tmp);
+            $descriptors = [0 => ['pipe', 'r'], 1 => ['pipe', 'w'], 2 => ['pipe', 'w']];
+            $proc = \proc_open($cmd, $descriptors, $pipes, dirname(__DIR__));
+            $this->assertIsResource($proc);
+            \fclose($pipes[0]);
+            $stdout = \stream_get_contents($pipes[1]);
+            $stderr = \stream_get_contents($pipes[2]);
+            \fclose($pipes[1]);
+            \fclose($pipes[2]);
+            \proc_close($proc);
+
+            // Two invalid entries -> two WARN lines, naming the dropped url.
+            $this->assertSame(2, \substr_count($stderr, 'invalid_function_include'), 'stderr was: ' . $stderr);
+            $this->assertStringContainsString('https://no-functions.com', $stderr);
+            $this->assertSame('', $stdout, 'Logger leaked into stdout');
+        } finally {
+            @\unlink($tmp);
+        }
+    }
+
+    // #185 — when contexts are active and the prompt text is empty, the AI verb
+    // must fall back to the default prompt (matching the TS reference's exact
+    // string), never an empty text.
+    public function testEmptyPromptWithContextsFallsBack(): void
+    {
+        $agent = $this->makeAgent(['use_pom' => false, 'name' => 'Aria']);
+        $agent->defineContexts()
+            ->addContext('default')
+            ->addStep('start')
+            ->setText('Begin.');
+
+        $ai = $this->extractAiVerb($agent->renderSwml());
+        $this->assertSame('You are Aria, a helpful AI assistant.', $ai['prompt']['text']);
+    }
+
+    public function testEmptyPromptWithoutContextsStaysEmpty(): void
+    {
+        // Without contexts the TS reference emits the prompt text as-is (no
+        // fallback), so an unset prompt remains an empty string.
+        $agent = $this->makeAgent(['use_pom' => false]);
+
+        $ai = $this->extractAiVerb($agent->renderSwml());
+        $this->assertSame('', $ai['prompt']['text']);
+    }
+
+    public function testNonEmptyPromptWithContextsIsUnchanged(): void
+    {
+        $agent = $this->makeAgent(['use_pom' => false, 'name' => 'Aria']);
+        $agent->setPromptText('Custom prompt.');
+        $agent->defineContexts()
+            ->addContext('default')
+            ->addStep('start')
+            ->setText('Begin.');
+
+        $ai = $this->extractAiVerb($agent->renderSwml());
+        $this->assertSame('Custom prompt.', $ai['prompt']['text']);
+    }
+
+    // #182 — promptAddToSection / promptAddSubsection must AUTO-CREATE the
+    // (parent) section when it is missing, matching the TS reference, instead
+    // of silently no-op'ing.
+    public function testPromptAddToSectionAutoCreatesMissingSection(): void
+    {
+        $agent = $this->makeAgent();
+        $agent->promptAddToSection('Rules', 'Body text.', ['bullet one']);
+
+        $prompt = $agent->getPrompt();
+        $this->assertIsArray($prompt);
+        $this->assertCount(1, $prompt);
+        $this->assertSame('Rules', $prompt[0]['title']);
+        $this->assertSame('Body text.', $prompt[0]['body']);
+        $this->assertSame(['bullet one'], $prompt[0]['bullets']);
+    }
+
+    public function testPromptAddSubsectionAutoCreatesMissingParent(): void
+    {
+        $agent = $this->makeAgent();
+        $agent->promptAddSubsection('Main', 'Detail', 'Detail body.');
+
+        $prompt = $agent->getPrompt();
+        $this->assertIsArray($prompt);
+        $this->assertCount(1, $prompt);
+        $this->assertSame('Main', $prompt[0]['title']);
+        $this->assertArrayHasKey('subsections', $prompt[0]);
+        $this->assertCount(1, $prompt[0]['subsections']);
+        $this->assertSame('Detail', $prompt[0]['subsections'][0]['title']);
+        $this->assertSame('Detail body.', $prompt[0]['subsections'][0]['body']);
     }
 
     // ------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Four `AgentBase` behavior fixes, each verified against the **TypeScript reference** (the clean port) and proven by a fails-before / passes-after regression test. Only these four behaviors change; surface, signatures, and emission are neutral.

| # | Method | Before (php bug) | After (matches TS) |
|---|--------|------------------|--------------------|
| **#190** | `setGlobalData` | replaced `globalData` wholesale | **merges** via `array_merge` (mirrors `updateGlobalData()` / TS `safeAssign`) |
| **#191** | `setFunctionIncludes` | kept every entry, even malformed | **drops** entries lacking a truthy `url` or array `functions`, **warns per drop** |
| **#185** | `buildAiVerb` prompt | empty prompt text emitted as `""` even with contexts active | falls back to `"You are {name}, a helpful AI assistant."` when contexts active and text empty (TS contexts branch) |
| **#182** | `promptAddToSection` / `promptAddSubsection` | silent no-op when (parent) section missing | **auto-create** the (parent) section (TS `PomBuilder.addToSection` / `addSubsection`) |

## Reference confirmation (TypeScript)

- **#190** — `AgentBase.ts` `setGlobalData` -> `safeAssign(this.globalData, data)` (shallow merge, overwrite on collision). php now mirrors `updateGlobalData`.
- **#191** — `AgentBase.ts` `setFunctionIncludes` -> `includes.filter((inc) => inc.url && Array.isArray(inc.functions))`. php applies the same predicate; the per-drop warn follows the file's existing `setInternalFillers` warn idiom so malformed includes surface at registration time.
- **#185** — `AgentBase.ts` `renderSwml` contexts branch: ``text: prompt || `You are ${this.name}, a helpful AI assistant.` ``. The non-contexts branch emits `prompt` as-is, so the php fallback is gated on `contextBuilder !== null`, leaving the no-contexts path wire-neutral.
- **#182** — `PomBuilder.ts` `addToSection` / `addSubsection` each call `addSection(...)` when the (parent) title is absent before appending.

## Tests (fails-before / passes-after)

New tests in `tests/AgentBaseTest.php`:
- `testSetGlobalDataMerges`, `testSetGlobalDataOverwritesOnCollision`
- `testSetFunctionIncludesDropsInvalidEntries`, `testSetFunctionIncludesKeepsAllValidEntries`, `testSetFunctionIncludesWarnsPerDroppedEntry` (child-process stderr capture, same pattern as `LoggerTest`)
- `testEmptyPromptWithContextsFallsBack`, `testEmptyPromptWithoutContextsStaysEmpty`, `testNonEmptyPromptWithContextsIsUnchanged`
- `testPromptAddToSectionAutoCreatesMissingSection`, `testPromptAddSubsectionAutoCreatesMissingParent`

The pre-existing `testSetFunctionIncludes` encoded the buggy keep-everything behavior (a url-only include) and was updated to supply valid entries, since dropping invalid entries is now the correct behavior.

## Verification

`bash scripts/run-ci.sh` — all 13 gates PASS (TEST, SIGNATURES, DRIFT, SURFACE-FRESH, NO-CHEAT, REST-COVERAGE, SPEC-PARITY, EMISSION, FMT, LINT, DOC-AUDIT, SURFACE-DIFF, SKILL-CONTRACT). New code is clean at phpstan level 9 (the whole-file level-9 findings are all pre-existing `missingType.iterableValue` on unchanged signatures; the project gate runs level 5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HhzeysbfURBuHL5Sn7Sjau
