### PR TITLE
test+ci: dynamic free ports + fail-loud for mocks

### DIFF
--- a/scripts/run-ci.sh
+++ b/scripts/run-ci.sh
@@ -64,14 +64,39 @@ PORTING_SDK_DIR="$(resolve_porting_sdk)" || {
 # every worker just probes-and-reuses (never spawns, never registers a kill
 # hook), and tear them down in a trap. This mirrors the dotnet lifecycle in
 # MOCK_TEST_HARNESS.md.
-MOCK_SIGNALWIRE_PORT="${MOCK_SIGNALWIRE_PORT:-8768}"
-MOCK_RELAY_PORT="${MOCK_RELAY_PORT:-8778}"
-MOCK_RELAY_HTTP_PORT="${MOCK_RELAY_HTTP_PORT:-9778}"
-export MOCK_SIGNALWIRE_PORT MOCK_RELAY_PORT MOCK_RELAY_HTTP_PORT
-
 PARALLEL_PROCS="${PARATEST_PROCS:-8}"
 MOCK_PIDS=""
 PYTHON_BIN="${MOCK_SIGNALWIRE_PYTHON:-$(command -v python3 || command -v python || echo python3)}"
+
+# pick_free_port — ask the OS for an unused TCP port by binding :0 and reading
+# back the assigned port, then closing the socket. There is an inherent (small)
+# TOCTOU window between close and the mock's own bind, but the mock spawns
+# immediately after and its health-poll fails loud if the bind lost a race, so a
+# transient collision surfaces as a clear "did not become ready" rather than a
+# silent hang on a wrong/occupied port. Replaces the old hardcoded
+# 8768/8778/9778/8788 defaults so parallel runs (CI matrix, multiple local
+# checkouts) never collide on a fixed port.
+pick_free_port() {
+    "$PYTHON_BIN" -c 'import socket
+s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+s.bind(("127.0.0.1", 0))
+print(s.getsockname()[1])
+s.close()'
+}
+
+# Mock ports for the TEST gate: honor an explicit env override, else pick a free
+# port dynamically. Exported so every paratest worker probes-and-reuses the one
+# server this script spawns (see spawn_mocks) rather than spawning its own. A
+# failed pick aborts the run loudly instead of silently falling back to a fixed
+# port that might be occupied.
+MOCK_SIGNALWIRE_PORT="${MOCK_SIGNALWIRE_PORT:-$(pick_free_port)}"
+MOCK_RELAY_PORT="${MOCK_RELAY_PORT:-$(pick_free_port)}"
+MOCK_RELAY_HTTP_PORT="${MOCK_RELAY_HTTP_PORT:-$(pick_free_port)}"
+if [ -z "$MOCK_SIGNALWIRE_PORT" ] || [ -z "$MOCK_RELAY_PORT" ] || [ -z "$MOCK_RELAY_HTTP_PORT" ]; then
+    echo "FATAL: could not allocate a free port for the mock servers" >&2
+    exit 2
+fi
+export MOCK_SIGNALWIRE_PORT MOCK_RELAY_PORT MOCK_RELAY_HTTP_PORT
 
 probe_mock() {  # $1 = url, $2 = needle
     curl -fsS --max-time 2 "$1" 2>/dev/null | grep -q "$2"
@@ -218,7 +243,9 @@ run_gate "NO-CHEAT" "audit_no_cheat_tests" \
 # tests/Rest suite SERIALLY (phpunit, one process) so all traffic lands in one
 # journal, then checks that journal. Same shape as python's/go's/java's gate.
 rest_coverage_gate() {
-    local port=8788
+    local port
+    port="$(pick_free_port)" || return 1
+    [ -n "$port" ] || { echo "FATAL: could not allocate a free port for the REST-coverage mock" >&2; return 1; }
     local mock_pkg_parent="$PORTING_SDK_DIR/test_harness/mock_signalwire"
     PYTHONPATH="$mock_pkg_parent${PYTHONPATH:+:$PYTHONPATH}" \
         "$PYTHON_BIN" -m mock_signalwire --host 127.0.0.1 --port "$port" \

--- a/tests/Relay/MockTest.php
+++ b/tests/Relay/MockTest.php
@@ -34,6 +34,10 @@ class MockTest extends TestCase
     public const DEFAULT_HTTP_PORT = 9778;
     private const STARTUP_TIMEOUT_SEC = 30;
 
+    /** Process-cached dynamically picked ws/http ports (null until resolved). */
+    private static ?int $dynamicWsPort = null;
+    private static ?int $dynamicHttpPort = null;
+
     private static ?RelayHarness $sharedHarness = null;
     private static ?\Throwable $startupFailure = null;
     /** @var resource|null cached subprocess handle; null if we're reusing an external server. */
@@ -295,7 +299,13 @@ class MockTest extends TestCase
                 return $p;
             }
         }
-        return self::DEFAULT_WS_PORT;
+        // No env override: pick a free port dynamically. Cached for the life of
+        // the process so every harness() call agrees on one ws port (and the
+        // per-port lock file, keyed on the http port, stays consistent).
+        if (self::$dynamicWsPort === null) {
+            self::$dynamicWsPort = self::pickFreePort(self::DEFAULT_WS_PORT);
+        }
+        return self::$dynamicWsPort;
     }
 
     private static function resolveHttpPort(): int
@@ -307,7 +317,35 @@ class MockTest extends TestCase
                 return $p;
             }
         }
-        return self::DEFAULT_HTTP_PORT;
+        if (self::$dynamicHttpPort === null) {
+            self::$dynamicHttpPort = self::pickFreePort(self::DEFAULT_HTTP_PORT);
+        }
+        return self::$dynamicHttpPort;
+    }
+
+    /**
+     * Ask the OS for a free TCP port by binding to :0 on loopback, reading
+     * back the assigned port, then closing the socket. Falls back to the
+     * supplied default if the bind fails (the subsequent spawn + health-poll
+     * then fails loud rather than hanging silently).
+     */
+    private static function pickFreePort(int $fallback): int
+    {
+        $sock = @stream_socket_server('tcp://127.0.0.1:0', $errno, $errstr);
+        if ($sock === false) {
+            return $fallback;
+        }
+        $name = stream_socket_get_name($sock, false);
+        fclose($sock);
+        if (!is_string($name)) {
+            return $fallback;
+        }
+        $pos = strrpos($name, ':');
+        if ($pos === false) {
+            return $fallback;
+        }
+        $port = (int) substr($name, $pos + 1);
+        return $port > 0 ? $port : $fallback;
     }
 
     /**

--- a/tests/Rest/MockTest.php
+++ b/tests/Rest/MockTest.php
@@ -41,6 +41,9 @@ class MockTest extends TestCase
     private const STARTUP_TIMEOUT_SEC = 30;
     private const HTTP_TIMEOUT_SEC = 5;
 
+    /** Process-cached dynamically picked port (null until first resolved). */
+    private static ?int $dynamicPort = null;
+
     private static ?Harness $sharedHarness = null;
     private static ?\Throwable $startupFailure = null;
     /** @var resource|null cached subprocess handle; null if we're reusing an external server. */
@@ -231,7 +234,39 @@ class MockTest extends TestCase
                 return $p;
             }
         }
-        return self::DEFAULT_PORT;
+        // No env override: pick a free port dynamically so concurrent runs
+        // never collide on a fixed default. Cached for the life of the process
+        // so every harness() call in this worker agrees on one port (and the
+        // per-port lock file stays consistent across the probe/spawn dance).
+        if (self::$dynamicPort === null) {
+            self::$dynamicPort = self::pickFreePort(self::DEFAULT_PORT);
+        }
+        return self::$dynamicPort;
+    }
+
+    /**
+     * Ask the OS for a free TCP port by binding to :0 on loopback, reading
+     * back the assigned port, then closing the socket. Falls back to the
+     * supplied default if the bind fails for any reason (the subsequent
+     * spawn + health-poll then fails loud rather than hanging silently).
+     */
+    private static function pickFreePort(int $fallback): int
+    {
+        $sock = @stream_socket_server('tcp://127.0.0.1:0', $errno, $errstr);
+        if ($sock === false) {
+            return $fallback;
+        }
+        $name = stream_socket_get_name($sock, false);
+        fclose($sock);
+        if (!is_string($name)) {
+            return $fallback;
+        }
+        $pos = strrpos($name, ':');
+        if ($pos === false) {
+            return $fallback;
+        }
+        $port = (int) substr($name, $pos + 1);
+        return $port > 0 ? $port : $fallback;
     }
 
     /**


### PR DESCRIPTION
Replace hardcoded mock port(s) in the CI gate and per-test harness(es) with OS-assigned free ports (bind `127.0.0.1:0`), and add a fail-loud guard so a dead/never-healthy mock fails the gate instead of hanging silently. `MOCK_SIGNALWIRE_PORT`/`MOCK_RELAY_*` overrides preserved. Fixes the fixed-port collisions (incl. ts/ruby↔8769, java/perl↔8770) that caused CI hangs under concurrent runs / leftover mocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HhzeysbfURBuHL5Sn7Sjau