### PR TITLE
docs: audit and fix README for API accuracy and structural parity

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ vendor/bin/swaig-test examples/simple_agent.php --exec get_time
 - **SIP routing** -- route SIP calls to agents based on usernames
 - **Session state** -- persistent conversation state with global data and post-prompt summaries
 - **Security** -- auto-generated basic auth, function-specific HMAC tokens, SSL support
-- **Serverless** -- native PHP/CGI support, plus Lambda and Cloud Functions adapters
+- **Serverless** -- auto-detects CGI/FastCGI, AWS Lambda, Google Cloud Functions, and Azure Functions
 
 ### Agent Examples
 
@@ -117,12 +117,12 @@ require 'vendor/autoload.php';
 
 use SignalWire\Relay\Client;
 
-$client = new Client(
-    project:  $_ENV['SIGNALWIRE_PROJECT_ID'],
-    token:    $_ENV['SIGNALWIRE_API_TOKEN'],
-    host:     $_ENV['SIGNALWIRE_SPACE'] ?? 'relay.signalwire.com',
-    contexts: ['default'],
-);
+$client = new Client([
+    'project'  => $_ENV['SIGNALWIRE_PROJECT_ID'],
+    'token'    => $_ENV['SIGNALWIRE_API_TOKEN'],
+    'host'     => $_ENV['SIGNALWIRE_SPACE'] ?? 'relay.signalwire.com',
+    'contexts' => ['default'],
+]);
 
 $client->onCall(function ($call) {
     $call->answer();
@@ -133,8 +133,7 @@ $client->onCall(function ($call) {
     $call->hangup();
 });
 
-$client->connectWs();
-$client->authenticate();
+$client->connect();  // opens the WebSocket and authenticates
 $client->run();
 ```
 
@@ -158,18 +157,18 @@ require 'vendor/autoload.php';
 use SignalWire\REST\RestClient;
 
 $client = new RestClient(
-    project: $_ENV['SIGNALWIRE_PROJECT_ID'],
-    token:   $_ENV['SIGNALWIRE_API_TOKEN'],
-    host:    $_ENV['SIGNALWIRE_SPACE'],
+    projectId: $_ENV['SIGNALWIRE_PROJECT_ID'],
+    token:     $_ENV['SIGNALWIRE_API_TOKEN'],
+    space:     $_ENV['SIGNALWIRE_SPACE'],
 );
 
-$client->fabric->aiAgents->create(name: 'Support Bot', prompt: ['text' => 'You are helpful.']);
-$client->calling->play($callId, play: [['type' => 'tts', 'text' => 'Hello!']]);
-$client->phoneNumbers->search(areaCode: '512');
-$client->datasphere->documents->search(queryString: 'billing policy');
+$client->fabric()->aiAgents()->create(['name' => 'Support Bot', 'prompt' => ['text' => 'You are helpful.']]);
+$client->calling()->play($callId, params: ['play' => [['type' => 'tts', 'text' => 'Hello!']]]);
+$client->phoneNumbers()->search(['areaCode' => '512']);
+$client->datasphere()->documents()->search(['queryString' => 'billing policy']);
 ```
 
-- 21 namespaced API surfaces: Fabric (13 resource types), Calling (37 commands), Video, Datasphere, Compat (Twilio-compatible), Phone Numbers, SIP, Queues, Recordings, and more
+- 21 namespaced API surfaces: Fabric (16 resource types), Calling (37 commands), Video, Datasphere, Compat (Twilio-compatible), Phone Numbers, SIP, Queues, Recordings, and more
 - Lightweight HTTP via cURL with connection reuse
 - Array returns -- raw data, no wrapper objects
 
@@ -183,7 +182,7 @@ See the **[REST documentation](rest/README.md)** for the full guide, API referen
 composer require signalwire/sdk
 ```
 
-Requires PHP 8.1+ with the `json`, `openssl`, and `mbstring` extensions.
+Requires PHP 8.2+ with the `json`, `mbstring`, and `openssl` extensions.
 
 ## Documentation
 
@@ -209,16 +208,19 @@ Guides are also available in the [`docs/`](docs/) directory:
 
 - [Skills System](docs/skills_system.md) -- built-in skills and the modular framework
 - [Third-Party Skills](docs/third_party_skills.md) -- creating and publishing custom skills
+- [MCP Gateway](docs/mcp_gateway_reference.md) -- Model Context Protocol integration
 
 ### Deployment
 
 - [CLI Guide](docs/cli_guide.md) -- `swaig-test` command reference
+- [Cloud Functions](docs/cloud_functions_guide.md) -- Lambda, Google Cloud Functions, Azure deployment
 - [Configuration](docs/configuration.md) -- environment variables, SSL, proxy setup
 - [Security](docs/security.md) -- authentication and security model
 
 ### Reference
 
 - [API Reference](docs/api_reference.md) -- complete class and method reference
+- [Web Service](docs/web_service.md) -- HTTP server and endpoint details
 - [Skills Parameter Schema](docs/skills_parameter_schema.md) -- skill parameter definitions
 
 ## Environment Variables

--- a/docs/agent_guide.md
+++ b/docs/agent_guide.md
@@ -118,7 +118,7 @@ $agent->defineTool(
     handler: function (array $args, array $rawData): FunctionResult {
         $location = $args['location'] ?? 'Unknown';
         $result = new FunctionResult("It's sunny and 72F in {$location}.");
-        $result->addAction('set_global_data', ['weather_location' => $location]);
+        $result->updateGlobalData(['weather_location' => $location]);
         return $result;
     },
 );

--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -40,7 +40,7 @@ new AgentBase(
 
 | Method | Description |
 |--------|-------------|
-| `defineTool(string $name, string $description, array $parameters, callable $handler)` | Define a SWAIG function with handler |
+| `defineTool(string $name, string $description, array $parameters, callable $handler, bool $secure = false)` | Define a SWAIG function with handler |
 | `registerSwaigFunction(array $def)` | Register a raw SWAIG function definition |
 | `setNativeFunctions(array $names)` | Enable built-in SWML functions |
 
@@ -105,8 +105,8 @@ new FunctionResult(string $response = null, bool $postProcess = false)
 
 | Method | Description |
 |--------|-------------|
-| `connect(string $destination, bool $final = true, string $fromAddr = null)` | Transfer call |
-| `sendSms(string $toNumber, string $fromNumber, string $body, array $media = [])` | Send SMS |
+| `connect(string $destination, bool $final = true, string $from = '')` | Transfer call |
+| `sendSms(string $toNumber, string $fromNumber, ?string $body = null, array $media = [], array $tags = [], ?string $region = null)` | Send SMS |
 | `hangup()` | Terminate call |
 | `hold(int $timeout = 300)` | Put call on hold |
 | `stop()` | Stop agent execution |
@@ -154,7 +154,7 @@ new FunctionResult(string $response = null, bool $postProcess = false)
 
 | Method | Description |
 |--------|-------------|
-| `addAction(string $name, mixed $data)` | Add a raw action |
+| `addAction(array $action)` | Add a raw action (single `['name' => $data]` pair) |
 | `addActions(array $actions)` | Add multiple raw actions |
 
 All action methods return `$this` for method chaining.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -103,14 +103,14 @@ The REST client (`SignalWire\REST\RestClient`) provides synchronous HTTP access 
 use SignalWire\REST\RestClient;
 
 $client = new RestClient(
-    project: $_ENV['SIGNALWIRE_PROJECT_ID'],
-    token:   $_ENV['SIGNALWIRE_API_TOKEN'],
-    host:    $_ENV['SIGNALWIRE_SPACE'],
+    $_ENV['SIGNALWIRE_PROJECT_ID'],
+    $_ENV['SIGNALWIRE_API_TOKEN'],
+    $_ENV['SIGNALWIRE_SPACE'],
 );
 
-$client->fabric->aiAgents->create(name: 'Bot', prompt: ['text' => 'You are helpful.']);
-$client->phoneNumbers->search(areaCode: '512');
-$client->calling->dial(from: '+15559876543', to: '+15551234567', url: 'https://example.com/handler');
+$client->fabric()->aiAgents()->create(['name' => 'Bot', 'prompt' => ['text' => 'You are helpful.']]);
+$client->phoneNumbers()->search(['area_code' => '512']);
+$client->calling()->dial(['from' => '+15559876543', 'to' => '+15551234567', 'url' => 'https://example.com/handler']);
 ```
 
 ## RELAY Client
@@ -120,19 +120,20 @@ The RELAY client (`SignalWire\Relay\Client`) provides real-time call control ove
 ```php
 use SignalWire\Relay\Client;
 
-$client = new Client(
-    project:  $_ENV['SIGNALWIRE_PROJECT_ID'],
-    token:    $_ENV['SIGNALWIRE_API_TOKEN'],
-    host:     $_ENV['SIGNALWIRE_SPACE'] ?? 'relay.signalwire.com',
-    contexts: ['default'],
-);
+$client = new Client([
+    'project'  => $_ENV['SIGNALWIRE_PROJECT_ID'],
+    'token'    => $_ENV['SIGNALWIRE_API_TOKEN'],
+    'host'     => $_ENV['SIGNALWIRE_SPACE'] ?? 'relay.signalwire.com',
+    'contexts' => ['default'],
+]);
 
 $client->onCall(function ($call) {
     $call->answer();
-    $call->play(media: [['type' => 'tts', 'params' => ['text' => 'Hello!']]]);
+    $call->play([['type' => 'tts', 'params' => ['text' => 'Hello!']]]);
     $call->hangup();
 });
 
+$client->connect();
 $client->run();
 ```
 

--- a/docs/cloud_functions_guide.md
+++ b/docs/cloud_functions_guide.md
@@ -27,6 +27,7 @@ The agent automatically detects Google Cloud Functions environment using these v
 require 'vendor/autoload.php';
 
 use SignalWire\Agent\AgentBase;
+use SignalWire\Serverless\Adapter;
 
 // Create agent instance
 $agent = new AgentBase(
@@ -36,9 +37,14 @@ $agent = new AgentBase(
 
 $agent->promptAddSection('Role', 'You are a helpful assistant running in Google Cloud Functions.');
 
-// Handle the serverless request
-return $agent->handleServerlessRequest($_SERVER, file_get_contents('php://input'));
+// Handle the request. Adapter::handleGcf() reads the request from the PHP
+// superglobals, calls $agent->handleRequest(), and emits the response.
+Adapter::handleGcf($agent);
 ```
+
+> `Adapter::serve($agent)` auto-detects the execution mode (`gcf`, `azure`,
+> `lambda`, `cgi`, or `server`) and dispatches to the right handler, so a single
+> entry point can run unchanged across platforms.
 
 2. **Create `composer.json`**:
 ```json
@@ -65,11 +71,11 @@ Set these environment variables for your function:
 ```bash
 # SignalWire credentials
 export SIGNALWIRE_PROJECT_ID="your-project-id"
-export SIGNALWIRE_TOKEN="your-token"
+export SIGNALWIRE_API_TOKEN="your-token"
 
-# Agent configuration
-export AGENT_USERNAME="your-username"
-export AGENT_PASSWORD="your-password"
+# Agent HTTP Basic Auth
+export SWML_BASIC_AUTH_USER="your-username"
+export SWML_BASIC_AUTH_PASSWORD="your-password"
 
 # Optional: Custom region/project settings
 export FUNCTION_REGION="us-central1"
@@ -115,13 +121,15 @@ my-agent-function/
 require __DIR__ . '/../vendor/autoload.php';
 
 use SignalWire\Agent\AgentBase;
+use SignalWire\Serverless\Adapter;
 
 $agent = new AgentBase(
     name: 'my-agent',
 );
 
-// Handle the Azure Functions request
-return $agent->handleServerlessRequest($_SERVER, file_get_contents('php://input'));
+// $request is the Azure Functions HTTP request array (method, url, headers, body).
+// handleAzure() returns an Azure-compatible {status, headers, body} response.
+return Adapter::handleAzure($agent, $request);
 ```
 
 3. **Create `agent/function.json`**:
@@ -165,9 +173,9 @@ Set these in your Azure Function App settings:
 
 ```bash
 SIGNALWIRE_PROJECT_ID="your-project-id"
-SIGNALWIRE_TOKEN="your-token"
-AGENT_USERNAME="your-username"
-AGENT_PASSWORD="your-password"
+SIGNALWIRE_API_TOKEN="your-token"
+SWML_BASIC_AUTH_USER="your-username"
+SWML_BASIC_AUTH_PASSWORD="your-password"
 ```
 
 ### URL Format
@@ -184,9 +192,9 @@ Both platforms support HTTP Basic Authentication:
 ### Automatic Authentication
 ```php
 $agent = new AgentBase(
-    name:     'my-agent',
-    username: 'your-username',
-    password: 'your-password',
+    name:              'my-agent',
+    basicAuthUser:     'your-username',
+    basicAuthPassword: 'your-password',
 );
 ```
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -104,20 +104,20 @@ $agent = new AgentBase(
     recordCall: true,
 );
 
-// REST client
+// REST client (positional: projectId, token, space)
 $client = new RestClient(
-    project: $_ENV['SIGNALWIRE_PROJECT_ID'],
-    token:   $_ENV['SIGNALWIRE_API_TOKEN'],
-    host:    $_ENV['SIGNALWIRE_SPACE'],
+    $_ENV['SIGNALWIRE_PROJECT_ID'],
+    $_ENV['SIGNALWIRE_API_TOKEN'],
+    $_ENV['SIGNALWIRE_SPACE'],
 );
 
-// RELAY client
-$relay = new Client(
-    project:  $_ENV['SIGNALWIRE_PROJECT_ID'],
-    token:    $_ENV['SIGNALWIRE_API_TOKEN'],
-    host:     $_ENV['SIGNALWIRE_SPACE'] ?? 'relay.signalwire.com',
-    contexts: ['default'],
-);
+// RELAY client (single options array)
+$relay = new Client([
+    'project'  => $_ENV['SIGNALWIRE_PROJECT_ID'],
+    'token'    => $_ENV['SIGNALWIRE_API_TOKEN'],
+    'host'     => $_ENV['SIGNALWIRE_SPACE'] ?? 'relay.signalwire.com',
+    'contexts' => ['default'],
+]);
 ```
 
 ## AI Model Configuration

--- a/docs/contexts_guide.md
+++ b/docs/contexts_guide.md
@@ -17,79 +17,78 @@ $agent = new AgentBase(name: 'sales-flow', route: '/sales');
 // Base prompt (always present)
 $agent->promptAddSection('Instructions', 'Follow the structured sales workflow.');
 
-// Define contexts
+// Define contexts (fluent API)
 $ctx = $agent->defineContexts();
 
-$ctx->addContext('sales', [
-    'system_prompt' => 'You are Franklin, a friendly computer sales consultant.',
-    'consolidate'   => true,
-    'steps' => [
-        [
-            'name'        => 'greeting',
-            'prompt'      => 'Greet the customer and ask what they need.',
-            'criteria'    => 'Customer has stated their general needs.',
-            'valid_steps' => ['needs_assessment'],
-        ],
-        [
-            'name'           => 'needs_assessment',
-            'prompt'         => 'Ask about budget, use case, and requirements.',
-            'criteria'       => 'Budget and use case are known.',
-            'valid_steps'    => ['recommendation'],
-            'valid_contexts' => ['support'],
-        ],
-        [
-            'name'           => 'recommendation',
-            'prompt'         => 'Recommend a computer based on requirements.',
-            'criteria'       => 'Customer has received a recommendation.',
-            'valid_contexts' => ['support'],
-        ],
-    ],
-]);
+$sales = $ctx->addContext('sales')
+    ->setSystemPrompt('You are Franklin, a friendly computer sales consultant.')
+    ->setConsolidate(true);
 
-$ctx->addContext('support', [
-    'system_prompt' => 'You are Rachael, a technical support specialist.',
-    'full_reset'    => true,
-    'steps' => [
-        [
-            'name'           => 'diagnose',
-            'prompt'         => 'Help with technical questions or issues.',
-            'criteria'       => 'Issue identified or question answered.',
-            'valid_contexts' => ['sales'],
-        ],
-    ],
-]);
+$sales->addStep(
+    'greeting',
+    task: 'Greet the customer and ask what they need.',
+    criteria: 'Customer has stated their general needs.',
+    valid_steps: ['needs_assessment'],
+);
+
+$sales->addStep(
+    'needs_assessment',
+    task: 'Ask about budget, use case, and requirements.',
+    criteria: 'Budget and use case are known.',
+    valid_steps: ['recommendation'],
+)->setValidContexts(['support']);
+
+$sales->addStep(
+    'recommendation',
+    task: 'Recommend a computer based on requirements.',
+    criteria: 'Customer has received a recommendation.',
+)->setValidContexts(['support']);
+
+$support = $ctx->addContext('support')
+    ->setSystemPrompt('You are Rachael, a technical support specialist.')
+    ->setFullReset(true);
+
+$support->addStep(
+    'diagnose',
+    task: 'Help with technical questions or issues.',
+    criteria: 'Issue identified or question answered.',
+)->setValidContexts(['sales']);
 
 $agent->addLanguage(name: 'English', code: 'en-US', voice: 'inworld.Mark');
 $agent->setParams(['ai_model' => 'gpt-4.1-nano']);
 $agent->run();
 ```
 
-## Context Entry Parameters
+## Context Configuration Methods
 
-| Parameter | Type | Description |
-|-----------|------|-------------|
-| `system_prompt` | string | Override the system prompt when entering this context |
-| `consolidate` | bool | Summarize conversation history when entering (reduces token usage) |
-| `full_reset` | bool | Clear conversation history entirely when entering |
-| `steps` | array | Ordered list of step definitions |
+A `Context` returned by `$ctx->addContext($name)` is configured with chainable
+setters:
+
+| Method | Description |
+|--------|-------------|
+| `setSystemPrompt(string)` | Override the system prompt when entering this context |
+| `setConsolidate(bool)` | Summarize conversation history when entering (reduces token usage) |
+| `setFullReset(bool)` | Clear conversation history entirely when entering |
+| `addStep(string $name, ...)` | Add an ordered step; returns the `Step` for further chaining |
 
 ### consolidate vs full_reset
 
-- `consolidate: true` -- The AI summarizes the conversation so far into a compact form. The new context starts with context, but the full verbatim history is discarded.
-- `full_reset: true` -- The conversation history is wiped entirely. The new context starts fresh with no memory of the previous context.
+- `setConsolidate(true)` -- The AI summarizes the conversation so far into a compact form. The new context starts with that summary, but the full verbatim history is discarded.
+- `setFullReset(true)` -- The conversation history is wiped entirely. The new context starts fresh with no memory of the previous context.
 - Both false (default) -- Full conversation history carries over.
 
 ## Step Definition
 
-Each step is an associative array:
+`addStep()` accepts the step name plus optional named parameters, and the
+returned `Step` exposes further setters:
 
-| Key | Type | Required | Description |
-|-----|------|----------|-------------|
-| `name` | string | Yes | Unique step identifier |
-| `prompt` | string | Yes | Instructions for the AI in this step |
-| `criteria` | string | No | Completion criteria for advancing |
-| `valid_steps` | array | No | Steps the AI can move to next |
-| `valid_contexts` | array | No | Contexts the AI can switch to |
+| `addStep()` parameter / `Step` setter | Description |
+|---------------------------------------|-------------|
+| `$name` (required) | Unique step identifier |
+| `task:` / `setText(string)` | Instructions for the AI in this step |
+| `criteria:` / `setStepCriteria(string)` | Completion criteria for advancing |
+| `valid_steps:` / `setValidSteps(array)` | Steps the AI can move to next |
+| `setValidContexts(array)` | Contexts the AI can switch to |
 
 ## Navigation
 
@@ -125,34 +124,27 @@ $agent->defineTool(
 Contexts enable different AI personalities:
 
 ```php
-$ctx->addContext('greeter', [
-    'system_prompt' => 'You are a cheerful receptionist named Sam.',
-    'steps' => [
-        [
-            'name'           => 'welcome',
-            'prompt'         => 'Welcome the caller and ask how you can help.',
-            'criteria'       => 'Caller has stated their need.',
-            'valid_contexts' => ['sales', 'support'],
-        ],
-    ],
-]);
+$ctx->addContext('greeter')
+    ->setSystemPrompt('You are a cheerful receptionist named Sam.')
+    ->addStep(
+        'welcome',
+        task: 'Welcome the caller and ask how you can help.',
+        criteria: 'Caller has stated their need.',
+    )->setValidContexts(['sales', 'support']);
 
-$ctx->addContext('sales', [
-    'system_prompt' => 'You are Alex, a knowledgeable sales advisor.',
-    'consolidate'   => true,
-    'steps' => [
-        [
-            'name'   => 'qualify',
-            'prompt' => 'Understand the customer needs and recommend solutions.',
-        ],
-    ],
-]);
+$ctx->addContext('sales')
+    ->setSystemPrompt('You are Alex, a knowledgeable sales advisor.')
+    ->setConsolidate(true)
+    ->addStep(
+        'qualify',
+        task: 'Understand the customer needs and recommend solutions.',
+    );
 ```
 
 ## Best Practices
 
 1. Always define a base prompt on the agent -- contexts augment it, not replace it
-2. Use `consolidate: true` for natural transitions where context matters
-3. Use `full_reset: true` for clean handoffs to a different persona
+2. Use `setConsolidate(true)` for natural transitions where context matters
+3. Use `setFullReset(true)` for clean handoffs to a different persona
 4. Keep step criteria specific and measurable
 5. Limit valid_steps and valid_contexts to prevent the AI from jumping randomly

--- a/docs/security.md
+++ b/docs/security.md
@@ -130,9 +130,9 @@ The REST client authenticates with project credentials:
 use SignalWire\REST\RestClient;
 
 $client = new RestClient(
-    project: $_ENV['SIGNALWIRE_PROJECT_ID'],
-    token:   $_ENV['SIGNALWIRE_API_TOKEN'],
-    host:    $_ENV['SIGNALWIRE_SPACE'],
+    $_ENV['SIGNALWIRE_PROJECT_ID'],
+    $_ENV['SIGNALWIRE_API_TOKEN'],
+    $_ENV['SIGNALWIRE_SPACE'],
 );
 ```
 
@@ -145,14 +145,14 @@ The RELAY client authenticates over WebSocket:
 ```php
 use SignalWire\Relay\Client;
 
-$client = new Client(
-    project: $_ENV['SIGNALWIRE_PROJECT_ID'],
-    token:   $_ENV['SIGNALWIRE_API_TOKEN'],
-    host:    $_ENV['SIGNALWIRE_SPACE'] ?? 'relay.signalwire.com',
-);
+$client = new Client([
+    'project' => $_ENV['SIGNALWIRE_PROJECT_ID'],
+    'token'   => $_ENV['SIGNALWIRE_API_TOKEN'],
+    'host'    => $_ENV['SIGNALWIRE_SPACE'] ?? 'relay.signalwire.com',
+]);
 ```
 
-The WebSocket connection uses TLS by default. Authentication happens via the Blade protocol after connection.
+The WebSocket connection uses TLS by default. Authentication runs as part of `connect()`.
 
 ## Best Practices
 

--- a/docs/swaig_reference.md
+++ b/docs/swaig_reference.md
@@ -164,7 +164,7 @@ $result = (new FunctionResult('Transferring you to billing.'))
 ### Low-Level
 
 ```php
-$result->addAction('custom_action', ['param' => 'value']);
+$result->addAction(['custom_action' => ['param' => 'value']]);
 $result->addActions([['say' => 'Hello'], ['hold' => 300]]);
 $resultArray = $result->toArray();
 ```

--- a/docs/web_service.md
+++ b/docs/web_service.md
@@ -1,515 +1,150 @@
-# WebService Documentation
+# Web Service & HTTP Serving
 
-The `WebService` class provides static file serving capabilities for the SignalWire AI Agents SDK. It follows the same architectural pattern as other services, allowing it to run as a standalone service or alongside your AI agents.
+The PHP SDK serves agents over HTTP through two classes:
 
-## Table of Contents
-- [Overview](#overview)
-- [Installation](#installation)
-- [Quick Start](#quick-start)
-- [Configuration](#configuration)
-- [Security Features](#security-features)
-- [HTTPS/SSL Support](#httpsssl-support)
-- [API Endpoints](#api-endpoints)
-- [Usage Examples](#usage-examples)
-- [Deployment Patterns](#deployment-patterns)
+- `SignalWire\Agent\AgentBase` (and its base `SignalWire\SWML\Service`) — serves a
+  single agent: the SWML document on `GET`, SWAIG function calls on `POST`, with
+  HTTP Basic Auth and security headers built in.
+- `SignalWire\Server\AgentServer` — hosts multiple agents on one process, each at
+  its own route, and can also serve static files.
 
-## Overview
+> There is no standalone `WebService` class in the PHP port. Static-file serving
+> is provided by `AgentServer::serveStatic()`.
 
-WebService is designed to serve static files with configurable security features. It is ideal for:
-- Serving agent documentation and API specs
-- Hosting static assets (images, CSS, JavaScript)
-- Serving generated reports and exports
-- Providing configuration files and templates
-- Hosting agent UI components
+## Serving a Single Agent
 
-### Key Features
-- **Multiple directory mounting** - Serve different directories at different URL paths
-- **Security-first design** - Authentication, CORS, security headers, file filtering
-- **HTTPS support** - Full SSL/TLS support with PEM files
-- **Directory browsing** - Optional HTML directory listings
-- **MIME type handling** - Automatic content-type detection
-- **Path traversal protection** - Prevents access outside designated directories
-- **File filtering** - Allow/block specific file extensions
-
-## Installation
-
-WebService is included in the core SignalWire AI Agents SDK:
-
-```bash
-composer require signalwire/signalwire-agents
-```
-
-## Quick Start
+`AgentBase` extends `Service`, which exposes `serve()`, `run()`, and
+`handleRequest()`.
 
 ```php
 <?php
-require 'vendor/autoload.php';
-
-use SignalWire\Service\WebService;
-
-// Create a service to serve files
-$service = new WebService(
-    port: 8002,
-    directories: [
-        '/docs'   => './documentation',
-        '/assets' => './static/assets',
-    ]
-);
-
-// Start the service
-$service->start();
-// Service available at http://localhost:8002
-// Basic Auth: dev:w00t (auto-generated)
-```
-
-## Configuration
-
-WebService can be configured through multiple methods (in order of priority):
-
-### 1. Constructor Parameters
-
-```php
-$service = new WebService(
-    port:                    8002,
-    directories:             [
-        '/docs'   => './documentation',
-        '/assets' => './static',
-    ],
-    basicAuth:               ['admin', 'secret'],
-    enableDirectoryBrowsing: true,
-    allowedExtensions:       ['.html', '.css', '.js'],
-    blockedExtensions:       ['.env', '.key'],
-    maxFileSize:             100 * 1024 * 1024, // 100 MB
-    enableCors:              true,
-);
-```
-
-### 2. Environment Variables
-
-```bash
-# Basic authentication
-export SWML_BASIC_AUTH_USER="admin"
-export SWML_BASIC_AUTH_PASS="secretpassword"
-
-# SSL/HTTPS configuration
-export SWML_SSL_ENABLED=true
-export SWML_SSL_CERT="/path/to/cert.pem"
-export SWML_SSL_KEY="/path/to/key.pem"
-
-# Security settings
-export SWML_ALLOWED_HOSTS="example.com,*.example.com"
-export SWML_CORS_ORIGINS="https://app.example.com"
-```
-
-### 3. Configuration File
-
-Create a `web.json` or `swml_web.json` file:
-
-```json
-{
-    "service": {
-        "port": 8002,
-        "directories": {
-            "/docs": "./documentation",
-            "/api": "./api-specs",
-            "/reports": "./generated/reports"
-        },
-        "enable_directory_browsing": true,
-        "max_file_size": 52428800,
-        "allowed_extensions": [".html", ".css", ".js", ".json", ".pdf"],
-        "blocked_extensions": [".env", ".key", ".pem"]
-    },
-    "security": {
-        "basic_auth": {
-            "username": "admin",
-            "password": "secure123"
-        },
-        "ssl_enabled": true,
-        "ssl_cert": "/etc/ssl/certs/server.crt",
-        "ssl_key": "/etc/ssl/private/server.key",
-        "allowed_hosts": ["*"],
-        "cors_origins": ["*"]
-    }
-}
-```
-
-## Security Features
-
-### Basic Authentication
-
-WebService implements HTTP Basic Authentication. Credentials can be set via:
-
-1. **Constructor**: `basicAuth: ['username', 'password']`
-2. **Environment**: `SWML_BASIC_AUTH_USER` and `SWML_BASIC_AUTH_PASS`
-3. **Config file**: `security.basic_auth` section
-4. **Auto-generated**: If not specified, generates random credentials
-
-### File Security
-
-#### Default Blocked Extensions/Files
-- `.env`, `.git`, `.gitignore`
-- `.key`, `.pem`, `.crt`
-- `.php` (server-side scripts), `__pycache__`
-- `.DS_Store`, `.swp`
-
-#### Path Traversal Protection
-WebService prevents access outside designated directories:
-```
-# These attempts will be blocked:
-# GET /docs/../../../etc/passwd
-# GET /docs/./././../config.json
-```
-
-#### File Size Limits
-Default maximum file size is 100 MB. Configure with:
-```php
-$service = new WebService(maxFileSize: 50 * 1024 * 1024); // 50 MB
-```
-
-### Security Headers
-
-Automatically adds security headers to all responses:
-- `X-Content-Type-Options: nosniff`
-- `X-Frame-Options: DENY`
-- `X-XSS-Protection: 1; mode=block`
-- `Strict-Transport-Security` (when HTTPS is enabled)
-
-## HTTPS/SSL Support
-
-WebService provides multiple ways to enable HTTPS:
-
-### Method 1: Environment Variables
-
-```bash
-# Using file paths
-export SWML_SSL_CERT="/path/to/cert.pem"
-export SWML_SSL_KEY="/path/to/key.pem"
-```
-
-### Method 2: Direct Parameters
-
-```php
-$service = new WebService(directories: ['/docs' => './docs']);
-$service->start(
-    sslCert: '/path/to/cert.pem',
-    sslKey:  '/path/to/key.pem',
-);
-// Service available at https://localhost:8002
-```
-
-### Method 3: Configuration File
-
-```json
-{
-    "security": {
-        "ssl_enabled": true,
-        "ssl_cert": "/etc/ssl/certs/server.crt",
-        "ssl_key": "/etc/ssl/private/server.key"
-    }
-}
-```
-
-### Generating Self-Signed Certificates
-
-For development/testing:
-
-```bash
-# Generate a self-signed certificate
-openssl req -x509 -newkey rsa:4096 -keyout key.pem -out cert.pem \
-    -days 365 -nodes -subj "/CN=localhost"
-
-# Use with WebService
-export SWML_SSL_CERT="cert.pem"
-export SWML_SSL_KEY="key.pem"
-```
-
-## API Endpoints
-
-### GET /health
-Health check endpoint (no authentication required)
-
-**Response:**
-```json
-{
-    "status": "healthy",
-    "directories": ["/docs", "/assets"],
-    "ssl_enabled": false,
-    "auth_required": true,
-    "directory_browsing": true
-}
-```
-
-### GET /
-Root endpoint showing available directories
-
-**Response:** HTML page listing all mounted directories
-
-### GET /{route}/{file_path}
-Serve files from mounted directories
-
-**Parameters:**
-- `route`: The mounted directory route (e.g., `/docs`)
-- `file_path`: Path to file within the directory
-
-**Response:**
-- File content with appropriate MIME type
-- 404 if file not found
-- 403 if file type blocked or directory browsing disabled
-
-## Usage Examples
-
-### Basic File Serving
-
-```php
-use SignalWire\Service\WebService;
-
-// Serve documentation
-$service = new WebService(
-    directories: [
-        '/docs' => './documentation',
-        '/api'  => './api-specs',
-    ]
-);
-$service->start();
-
-// Files accessible at:
-// http://localhost:8002/docs/index.html
-// http://localhost:8002/api/swagger.json
-```
-
-### With Directory Browsing
-
-```php
-$service = new WebService(
-    directories:             ['/files' => './public'],
-    enableDirectoryBrowsing: true,
-);
-$service->start();
-
-// Browse files at: http://localhost:8002/files/
-```
-
-### Restricted File Types
-
-```php
-// Only serve web assets
-$service = new WebService(
-    directories:             ['/web' => './www'],
-    allowedExtensions:       ['.html', '.css', '.js', '.png', '.jpg', '.woff2'],
-    enableDirectoryBrowsing: false,
-);
-```
-
-### Dynamic Directory Management
-
-```php
-$service = new WebService();
-
-// Add directories after initialisation
-$service->addDirectory('/docs', './documentation');
-$service->addDirectory('/reports', './generated/reports');
-
-// Remove a directory
-$service->removeDirectory('/reports');
-
-$service->start();
-```
-
-### With Custom Authentication
-
-```php
-$service = new WebService(
-    directories: ['/private' => './sensitive-docs'],
-    basicAuth:   ['admin', 'super-secret-password'],
-);
-$service->start();
-```
-
-## Deployment Patterns
-
-### Standalone Service
-
-Run WebService as a dedicated static file server:
-
-```php
-<?php
-// web_server.php
-require 'vendor/autoload.php';
-
-use SignalWire\Service\WebService;
-
-$service = new WebService(
-    port:        8002,
-    directories: [
-        '/docs'      => '/var/www/docs',
-        '/assets'    => '/var/www/assets',
-        '/downloads' => '/var/www/downloads',
-    ]
-);
-$service->start();
-```
-
-### Alongside AI Agents
-
-Run WebService alongside your AI agents on different ports:
-
-```php
-<?php
-// main.php
 require 'vendor/autoload.php';
 
 use SignalWire\Agent\AgentBase;
-use SignalWire\Service\WebService;
 
-// Start WebService in the background
-$web = new WebService(
-    port:        8002,
-    directories: ['/docs' => './agent-docs'],
+$agent = new AgentBase(
+    name:  'My Agent',
+    route: '/agent',
+    port:  3000,
 );
-// Start web service (non-blocking in a real setup)
-$web->start();
 
-// Run your agent
-$agent = new AgentBase(name: 'My Agent', route: '/agent', port: 3000);
-$agent->promptAddSection('Documentation', 'User docs available at https://example.com:8002/docs/');
+$agent->promptAddSection('Role', 'You are a helpful assistant.');
+
+// Blocks, serving the built-in PHP HTTP server on host:port.
 $agent->run();
 ```
 
-### Docker Deployment
+### Service Methods
 
-```dockerfile
-FROM php:8.2-cli
+| Method | Description |
+|--------|-------------|
+| `serve(): void` | Auto-detect the execution mode (server / CGI / serverless) and serve. |
+| `run(): void` | Run the built-in blocking HTTP server loop. |
+| `handleRequest(string $method, string $path, array $headers = [], ?string $body = null): array` | Handle one request; returns `[status, headers, body]`. Useful for embedding in another framework or a custom front controller. |
+| `dispatchFromGlobals(): void` | Handle the current request from PHP superglobals (CGI/FastCGI front controller). |
+| `renderSwml(?array $requestBody = null, array $headers = []): array` | Render the SWML document for a request. |
 
-WORKDIR /app
+### Constructor Parameters
 
-# Install Composer and dependencies
-COPY composer.json composer.lock ./
-RUN curl -sS https://getcomposer.org/installer | php && \
-    php composer.phar install --no-dev
-
-# Copy static files
-COPY ./static /app/static
-COPY ./web_config.json /app/web_config.json
-
-# Expose port
-EXPOSE 8002
-
-CMD ["php", "web_server.php"]
+```php
+new AgentBase(
+    name:              'My Agent',  // required
+    route:             '/agent',    // URL route (default '/')
+    host:              '0.0.0.0',   // bind host (default '0.0.0.0')
+    port:              3000,        // bind port (default PORT env or 3000)
+    basicAuthUser:     null,        // overrides SWML_BASIC_AUTH_USER
+    basicAuthPassword: null,        // overrides SWML_BASIC_AUTH_PASSWORD
+);
 ```
 
-### Nginx Reverse Proxy
+## Authentication
 
-For production, use Nginx as a reverse proxy:
+Every request is protected with HTTP Basic Authentication. Credentials are
+resolved in this order:
+
+1. The `basicAuthUser` / `basicAuthPassword` constructor arguments.
+2. The `SWML_BASIC_AUTH_USER` / `SWML_BASIC_AUTH_PASSWORD` environment variables.
+3. Auto-generated random credentials (the SDK logs a warning, since a
+   regenerated-per-process password is the usual cause of unexpected HTTP 401s).
+
+```php
+$agent = new AgentBase(
+    name:              'Secured Agent',
+    basicAuthUser:     'admin',
+    basicAuthPassword: 'super-secret',
+);
+
+// Inspect / validate at runtime
+[$user, $pass] = $agent->getBasicAuthCredentials();
+$ok = $agent->validateBasicAuth($user, $pass);
+```
+
+Comparisons use `hash_equals()` for timing-safe credential checks.
+
+## Hosting Multiple Agents
+
+`AgentServer` registers multiple agents, each at its own route, on a single
+process.
+
+```php
+<?php
+require 'vendor/autoload.php';
+
+use SignalWire\Agent\AgentBase;
+use SignalWire\Server\AgentServer;
+
+$server = new AgentServer(host: '0.0.0.0', port: 3000);
+
+$sales = new AgentBase(name: 'Sales', route: '/sales');
+$support = new AgentBase(name: 'Support', route: '/support');
+
+$server->register($sales);
+$server->register($support, '/support');
+
+$server->run(); // serves both agents
+```
+
+### AgentServer Methods
+
+| Method | Description |
+|--------|-------------|
+| `register(AgentBase $agent, ?string $route = null): self` | Register an agent at a route. |
+| `unregister(string $route): self` | Remove an agent. |
+| `getAgents(): array` | List registered routes. |
+| `getAgent(string $route): ?AgentBase` | Look up an agent by route. |
+| `serveStatic(string $directory, string $urlPrefix): self` | Serve static files from a directory under a URL prefix. |
+| `setupSipRouting(string $route = '/sip', bool $auto_map = true): self` | Enable central SIP-based routing. |
+| `handleRequest(string $method, string $path, array $headers = [], ?string $body = null): array` | Route one request to the matching agent. |
+| `run(): void` / `serve(): void` | Start the server. |
+
+## Serving Static Files
+
+Call `serveStatic(string $directory, string $urlPrefix)` on an `AgentServer`
+after registering your agents to mount a directory of static assets under a
+URL prefix. For example, mounting `./public` at `/assets` serves
+`./public/logo.png` at `http://localhost:3000/assets/logo.png`. The method
+throws `\RuntimeException` if the directory does not exist, and returns the
+server for chaining.
+
+## Serverless and CGI
+
+For CGI/FastCGI, Lambda, Google Cloud Functions, and Azure Functions, use
+`serve()` (which auto-detects the mode) or the `SignalWire\Serverless\Adapter`
+helpers directly. See [Cloud Functions Guide](cloud_functions_guide.md).
+
+## Deployment Behind a Reverse Proxy
+
+When the agent runs behind Nginx/Apache, set `SWML_PROXY_URL_BASE` so generated
+URLs use the external host:
+
+```bash
+export SWML_PROXY_URL_BASE="https://agents.example.com"
+```
 
 ```nginx
-server {
-    listen 80;
-    server_name static.example.com;
-
-    return 301 https://$server_name$request_uri;
-}
-
-server {
-    listen 443 ssl http2;
-    server_name static.example.com;
-
-    ssl_certificate /etc/ssl/certs/example.com.crt;
-    ssl_certificate_key /etc/ssl/private/example.com.key;
-
-    location / {
-        proxy_pass http://localhost:8002;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-
-        location ~* \.(jpg|jpeg|png|gif|ico|css|js)$ {
-            proxy_pass http://localhost:8002;
-            expires 1h;
-            add_header Cache-Control "public, immutable";
-        }
-    }
+location /agent {
+    proxy_pass http://127.0.0.1:3000;
+    proxy_set_header Host $host;
+    proxy_set_header X-Forwarded-Proto $scheme;
 }
 ```
-
-## Best Practices
-
-### Security
-1. **Always use HTTPS in production** - Protect data in transit
-2. **Change default credentials** - Never use auto-generated auth in production
-3. **Restrict file types** - Use `allowedExtensions` to whitelist safe files
-4. **Disable directory browsing** - Turn off in production environments
-5. **Use reverse proxy** - Put Nginx/Apache in front for additional security
-
-### Performance
-1. **Set appropriate cache headers** - WebService adds 1-hour cache by default
-2. **Limit file sizes** - Adjust `maxFileSize` based on your needs
-3. **Use CDN for static assets** - Offload traffic for better performance
-4. **Compress large files** - Use gzip/brotli at reverse proxy level
-
-### Organisation
-1. **Separate content types** - Use different routes for different file types
-2. **Version your assets** - Include version in path (e.g., `/assets/v1/`)
-3. **Use index.html** - Provide default files for directories
-4. **Document your structure** - Maintain clear directory organisation
-
-## API Reference
-
-### WebService Class
-
-```php
-class WebService
-{
-    public function __construct(
-        int     $port = 8002,
-        array   $directories = [],
-        ?array  $basicAuth = null,
-        ?string $configFile = null,
-        bool    $enableDirectoryBrowsing = false,
-        ?array  $allowedExtensions = null,
-        ?array  $blockedExtensions = null,
-        int     $maxFileSize = 104857600, // 100 MB
-        bool    $enableCors = true
-    );
-}
-```
-
-#### Parameters
-- `port`: Port to bind to (default: 8002)
-- `directories`: Associative array mapping URL paths to local directories
-- `basicAuth`: Array of `[username, password]` for authentication
-- `configFile`: Path to JSON configuration file
-- `enableDirectoryBrowsing`: Allow directory listing (default: false)
-- `allowedExtensions`: Array of allowed file extensions
-- `blockedExtensions`: Array of blocked file extensions
-- `maxFileSize`: Maximum file size in bytes (default: 100 MB)
-- `enableCors`: Enable CORS headers (default: true)
-
-#### Methods
-
-##### start()
-```php
-public function start(
-    string  $host = '0.0.0.0',
-    ?int    $port = null,
-    ?string $sslCert = null,
-    ?string $sslKey = null
-): void
-```
-Start the web service.
-
-##### addDirectory()
-```php
-public function addDirectory(string $route, string $directory): void
-```
-Add a new directory to serve.
-
-##### removeDirectory()
-```php
-public function removeDirectory(string $route): void
-```
-Remove a directory from being served.
-
-## Summary
-
-WebService provides a secure, configurable static file server that integrates with the SignalWire AI Agents SDK. It follows the same architectural patterns as other SDK services, making it familiar and easy to use while providing configurable security features and flexible deployment options.

--- a/relay/docs/call-methods.md
+++ b/relay/docs/call-methods.md
@@ -2,16 +2,19 @@
 
 ## Overview
 
-The `SignalWire\Relay\Call` object provides methods for controlling a live call. Methods return `Action` objects for controllable operations.
+The `SignalWire\Relay\Call` object provides methods for controlling a live call. Media methods return `Action` objects for controllable operations.
 
 ## Call Properties
 
+State and metadata are exposed as public properties, not getter methods.
+
 | Property | Type | Description |
 |----------|------|-------------|
-| `$call->callId()` | string | Unique call identifier |
-| `$call->state()` | string | Current call state |
-| `$call->device()` | array | Device information (to/from numbers) |
-| `$call->direction()` | string | `inbound` or `outbound` |
+| `$call->callId` | ?string | Unique call identifier |
+| `$call->state` | string | Current call state |
+| `$call->device` | array | Device information (to/from numbers) |
+| `$call->direction` | ?string | `inbound` or `outbound` |
+| `$call->context` | ?string | Context the call arrived on |
 
 ## Basic Control
 
@@ -35,75 +38,80 @@ $call->hangup();
 
 ### play()
 
-Play audio or TTS. Returns an `Action`.
+Play audio or TTS. Signature: `play(array $media, array $opts = []): PlayAction`.
 
 ```php
 // TTS
-$action = $call->play(media: [
+$action = $call->play([
     ['type' => 'tts', 'params' => ['text' => 'Hello!']],
 ]);
 $action->wait();
 
 // Audio file
-$action = $call->play(media: [
+$action = $call->play([
     ['type' => 'audio', 'params' => ['url' => 'https://example.com/audio.mp3']],
 ]);
 $action->wait();
 
 // Silence
-$action = $call->play(media: [
+$action = $call->play([
     ['type' => 'silence', 'params' => ['duration' => 2]],
 ]);
 ```
 
+Convenience helpers are also available: `playTts(string $text, array $opts = [])`,
+`playAudio(string $url, array $opts = [])`, `playSilence(int|float $duration, array $opts = [])`,
+and `playRingtone(string $name, array $opts = [])`.
+
 ### record()
 
-Record the call. Returns an `Action`.
+Record the call. Signature: `record(array $audio, array $opts = []): RecordAction`.
 
 ```php
-$action = $call->record(beep: true, format: 'mp3', direction: 'both');
+$action = $call->record(['format' => 'mp3', 'beep' => true, 'direction' => 'both']);
 $action->wait();
-$url = $action->url(); // Recording URL
+$url = $action->getUrl(); // Recording URL
 ```
 
 ### playAndCollect()
 
-Play audio and collect DTMF or speech input.
+Play audio and collect DTMF or speech input. Signature:
+`playAndCollect(array $media, array $collect, array $opts = []): CollectAction`.
 
 ```php
 $action = $call->playAndCollect(
-    media: [
+    [
         ['type' => 'tts', 'params' => ['text' => 'Press 1 for sales, 2 for support.']],
     ],
-    collect: [
+    [
         'digits' => ['max' => 1, 'digit_timeout' => 5.0],
         'initial_timeout' => 10.0,
     ],
 );
 
-$result = $action->wait();
-$digits = $result->params()['result']['params']['digits'] ?? '';
+$action->wait();
+$digits = $action->getCollectResult()['params']['digits'] ?? '';
 ```
 
 ## Call Connection
 
 ### connect()
 
-Connect the call to another party (bridge).
+Connect (bridge) the call to another party. Signature: `connect(array $params): array`.
 
 ```php
-$call->connect(
-    devices: [[
+$call->connect([
+    'devices' => [[
         ['type' => 'phone', 'params' => [
             'to_number'   => '+15551234567',
             'from_number' => '+15559876543',
             'timeout'     => 30,
         ]],
     ]],
-    ringback: [
+    'ringback' => [
         ['type' => 'tts', 'params' => ['text' => 'Please wait.']],
     ],
-);
+]);
 ```
 
 ### disconnect()
@@ -118,69 +126,69 @@ $call->disconnect();
 
 ### detect()
 
-Run detection (machine, fax, digit).
+Run detection (machine, fax, digit). Signature: `detect(array $detect, array $opts = []): DetectAction`.
 
 ```php
-$action = $call->detect(type: 'machine', timeout: 30);
-$result = $action->wait();
+$action = $call->detect(['type' => 'machine'], ['timeout' => 30]);
+$action->wait();
+$result = $action->getDetectResult();
 ```
 
-### detectStop()
-
-Stop a running detection.
-
-```php
-$call->detectStop();
-```
+Convenience helpers: `detectDigit(array $opts = [])`,
+`detectAnsweringMachine(array $opts = [])`, `detectFax(array $opts = [])`.
 
 ## Fax
 
 ### sendFax()
 
+Signature: `sendFax(string $document, ?string $identity = null, array $opts = []): FaxAction`.
+
 ```php
-$action = $call->sendFax(document: 'https://example.com/invoice.pdf');
+$action = $call->sendFax('https://example.com/invoice.pdf');
 $action->wait();
 ```
 
 ### receiveFax()
 
+Signature: `receiveFax(array $opts = []): FaxAction`.
+
 ```php
 $action = $call->receiveFax();
-$result = $action->wait();
-$faxUrl = $result->params()['fax']['document'] ?? '';
+$event  = $action->wait();
+$faxUrl = $event->getParams()['fax']['document'] ?? '';
 ```
 
 ## Tap
 
 ### tap()
 
-Fork call media to a WebSocket or RTP endpoint.
+Fork call media to a WebSocket or RTP endpoint. Signature:
+`tap(array $tap, array $device, array $opts = []): TapAction`.
 
 ```php
 $action = $call->tap(
-    tap:    ['type' => 'audio', 'params' => ['direction' => 'both']],
-    device: ['type' => 'ws', 'params' => ['uri' => 'wss://example.com/tap']],
+    ['type' => 'audio', 'params' => ['direction' => 'both']],
+    ['type' => 'ws', 'params' => ['uri' => 'wss://example.com/tap']],
 );
 ```
 
-### tapStop()
+### tap stop
 
-```php
-$call->tapStop();
-```
+Stop a running tap with `$action->stop()`.
 
 ## Action Objects
 
-All asynchronous methods return `Action` objects:
+All media methods return `Action` subclasses:
 
 | Method | Description |
 |--------|-------------|
-| `$action->wait($timeout)` | Block until completion or timeout |
+| `$action->wait($timeout)` | Block until completion or timeout; returns the completion `Event` (or `null`) |
 | `$action->stop()` | Stop the operation |
 | `$action->pause()` | Pause (play, record) |
 | `$action->resume()` | Resume (play, record) |
-| `$action->completed()` | Check if completed |
-| `$action->url()` | Get result URL (record) |
+| `$action->isDone()` | Whether the operation has completed |
+| `$action->getUrl()` | Get result URL (record) |
+| `$action->getResult()` | Get the raw result payload |
 
 ## Call States
 

--- a/relay/docs/client-reference.md
+++ b/relay/docs/client-reference.md
@@ -2,33 +2,45 @@
 
 ## Constructor
 
+The `Client` constructor takes a single options array (not named scalar
+arguments).
+
 ```php
 use SignalWire\Relay\Client;
 
-$client = new Client(
-    project:  string,       // SignalWire project ID (required)
-    token:    string,       // SignalWire API token (required)
-    host:     string,       // Space hostname (default: 'relay.signalwire.com')
-    contexts: array,        // Call/message contexts to subscribe to
-);
+$client = new Client([
+    'project'  => 'your-project-id',  // SignalWire project ID (required unless jwt_token)
+    'token'    => 'your-api-token',   // SignalWire API token (required unless jwt_token)
+    'host'     => 'example.signalwire.com', // Space hostname (or SIGNALWIRE_SPACE)
+    'contexts' => ['default'],        // Call/message contexts to subscribe to
+    // 'jwt_token' => '...',          // Alternative: authenticate with a JWT
+    // 'scheme'    => 'wss',          // Transport scheme (default 'wss')
+    // 'ca_file'   => '/path/ca.pem', // CA bundle for wss:// peer verification
+]);
 ```
+
+Construction throws `\InvalidArgumentException` unless either `project` + `token`
+or a non-empty `jwt_token` is supplied.
 
 ## Connection Methods
 
 | Method | Description |
 |--------|-------------|
-| `connectWs(): bool` | Establish WebSocket connection. Returns true on success. |
-| `authenticate(): void` | Authenticate with project credentials via Blade protocol. |
-| `disconnectWs(): void` | Close WebSocket connection. |
-| `run(): void` | Enter the event loop. Blocks until interrupted (Ctrl+C). |
-| `readOnce(): void` | Read and process a single WebSocket message. |
+| `connect(): void` | Open the WebSocket and run the `signalwire.connect` authentication handshake. Throws on transport or auth failure. |
+| `disconnect(): void` | Close the WebSocket connection gracefully. |
+| `run(): void` | Enter the event loop. Blocks until disconnected; auto-reconnects on transport errors. |
+| `readOnce(): void` | Read and process a single WebSocket frame. |
+| `receive(array $contexts): void` | Subscribe to additional inbound contexts. |
+| `unreceive(array $contexts): void` | Unsubscribe from contexts. |
 
 ### Connection Flow
 
+`connect()` performs both the transport handshake and authentication, so no
+separate `authenticate()` call is needed.
+
 ```php
-$client->connectWs() or die("Connection failed\n");
-$client->authenticate();
-echo "Protocol: " . $client->protocol() . "\n";
+$client->connect();
+echo "Protocol: " . $client->protocol . "\n"; // public property
 $client->run(); // Blocks here
 ```
 
@@ -36,8 +48,8 @@ $client->run(); // Blocks here
 
 | Method | Description |
 |--------|-------------|
-| `onCall(callable $callback): void` | Register handler for inbound calls |
-| `onMessage(callable $callback): void` | Register handler for inbound messages |
+| `onCall(callable $callback): self` | Register handler for inbound calls |
+| `onMessage(callable $callback): self` | Register handler for inbound messages |
 
 ### Call Handler
 
@@ -53,7 +65,7 @@ $client->onCall(function (SignalWire\Relay\Call $call) {
 
 ```php
 $client->onMessage(function (SignalWire\Relay\Message $message) {
-    echo "Message from " . $message->from() . ": " . $message->body() . "\n";
+    echo "Message from " . $message->getFromNumber() . ": " . $message->getBody() . "\n";
 });
 ```
 
@@ -61,71 +73,79 @@ $client->onMessage(function (SignalWire\Relay\Message $message) {
 
 ### dial()
 
-Place an outbound call.
+Place an outbound call. Signature: `dial(array $devices, array $opts = []): Call`.
 
 ```php
 $call = $client->dial(
-    devices: [[
+    [[
         ['type' => 'phone', 'params' => [
             'to_number'   => '+15551234567',
             'from_number' => '+15559876543',
         ]],
     ]],
-    timeout: 30,
+    ['dial_timeout' => 30.0],
 );
 ```
 
-`devices` is a nested array: outer array is serial attempts, inner array is parallel attempts.
+`$devices` is a nested array: the outer array holds parallel "legs", each inner
+array holds serial steps within a leg. Recognised `$opts` keys: `tag`,
+`dial_timeout` (seconds, default 30.0), `max_duration`; any other key is
+forwarded as a top-level dial param.
 
 ### sendMessage()
 
-Send an outbound SMS/MMS.
+Send an outbound SMS/MMS. Signature: `sendMessage(array $params): Message`.
 
 ```php
-$result = $client->sendMessage(
-    from:    '+15559876543',
-    to:      '+15551234567',
-    context: 'default',
-    body:    'Hello!',
-    media:   [],  // Optional MMS media URLs
-);
+$message = $client->sendMessage([
+    'from_number' => '+15559876543',
+    'to_number'   => '+15551234567',
+    'context'     => 'default',
+    'body'        => 'Hello!',
+    'media'       => [],  // Optional MMS media URLs
+]);
+
+echo "Message ID: " . $message->getMessageId() . "\n";
+echo "State: "      . $message->getState()     . "\n";
 ```
 
 ## Properties
 
 | Property | Description |
 |----------|-------------|
-| `$client->protocol()` | Blade protocol identifier after auth |
+| `$client->protocol` | Negotiated protocol identifier after auth (nullable) |
+| `$client->sessionId` | Server-assigned session id after auth (nullable) |
+| `$client->connected` | Whether the WebSocket is currently connected |
+| `$client->contexts` | Subscribed contexts |
 
 ## Auto-Reconnect
 
-The client automatically reconnects with exponential backoff if the WebSocket connection drops. No manual intervention is required. Reconnection behavior:
+The client automatically reconnects with exponential backoff if the WebSocket
+connection drops. No manual intervention is required. Reconnection behavior:
 
-1. First retry: immediate
+1. First retry after 1 second
 2. Subsequent retries: exponential backoff up to 30 seconds
 3. Re-authentication happens automatically after reconnect
 4. Context subscriptions are restored
 
 ## Error Handling
 
-```php
-$connected = $client->connectWs();
-if (!$connected) {
-    echo "Failed to connect to " . $_ENV['SIGNALWIRE_SPACE'] . "\n";
-    exit(1);
-}
+`connect()` throws on failure rather than returning a status flag:
 
+```php
 try {
-    $client->authenticate();
-} catch (\Exception $e) {
-    echo "Authentication failed: " . $e->getMessage() . "\n";
+    $client->connect();
+} catch (\Throwable $e) {
+    echo "Failed to connect: " . $e->getMessage() . "\n";
     exit(1);
 }
 ```
 
 ## Thread Safety
 
-The RELAY client is single-threaded. The `run()` method processes events sequentially. Long-running operations in callbacks block event processing. Keep handlers fast or offload work to background processes.
+The RELAY client is single-threaded. The `run()` method processes events
+sequentially. Long-running operations in callbacks block event processing.
+Keep handlers fast or offload work to background processes.
 
 ## Full Example
 
@@ -135,16 +155,16 @@ require 'vendor/autoload.php';
 
 use SignalWire\Relay\Client;
 
-$client = new Client(
-    project:  $_ENV['SIGNALWIRE_PROJECT_ID'] ?? die("Set SIGNALWIRE_PROJECT_ID\n"),
-    token:    $_ENV['SIGNALWIRE_API_TOKEN']  ?? die("Set SIGNALWIRE_API_TOKEN\n"),
-    host:     $_ENV['SIGNALWIRE_SPACE']      ?? 'relay.signalwire.com',
-    contexts: ['default'],
-);
+$client = new Client([
+    'project'  => $_ENV['SIGNALWIRE_PROJECT_ID'] ?? die("Set SIGNALWIRE_PROJECT_ID\n"),
+    'token'    => $_ENV['SIGNALWIRE_API_TOKEN']  ?? die("Set SIGNALWIRE_API_TOKEN\n"),
+    'host'     => $_ENV['SIGNALWIRE_SPACE']      ?? 'relay.signalwire.com',
+    'contexts' => ['default'],
+]);
 
 $client->onCall(function ($call) {
     $call->answer();
-    $action = $call->play(media: [
+    $action = $call->play([
         ['type' => 'tts', 'params' => ['text' => 'Welcome!']],
     ]);
     $action->wait();
@@ -152,11 +172,10 @@ $client->onCall(function ($call) {
 });
 
 $client->onMessage(function ($msg) {
-    echo "SMS from " . $msg->from() . ": " . $msg->body() . "\n";
+    echo "SMS from " . $msg->getFromNumber() . ": " . $msg->getBody() . "\n";
 });
 
-$client->connectWs() or die("Connection failed\n");
-$client->authenticate();
+$client->connect();
 echo "Listening for calls and messages...\n";
 $client->run();
 ```

--- a/relay/docs/events.md
+++ b/relay/docs/events.md
@@ -10,12 +10,14 @@ The RELAY client dispatches typed events for call state changes, media events, a
 
 ```php
 $client->onCall(function ($call) {
-    echo "New call: " . $call->callId() . "\n";
+    echo "New call: " . $call->callId . "\n";
     // Handle the call...
 });
 ```
 
 ### Call State Events
+
+The current state is the public `$call->state` property.
 
 | State | Description |
 |-------|-------------|
@@ -32,7 +34,7 @@ $client->onCall(function ($call) use ($client) {
     $call->answer();
 
     // Play audio
-    $action = $call->play(media: [
+    $action = $call->play([
         ['type' => 'tts', 'params' => ['text' => 'Hello!']],
     ]);
     $action->wait();
@@ -40,7 +42,7 @@ $client->onCall(function ($call) use ($client) {
     $call->hangup();
 
     // Wait for ended state
-    while ($call->state() !== 'ended') {
+    while ($call->state !== 'ended') {
         $client->readOnce();
     }
     echo "Call fully ended.\n";
@@ -53,21 +55,24 @@ $client->onCall(function ($call) use ($client) {
 
 | Method | Description |
 |--------|-------------|
-| `$event->type()` | Event type string |
-| `$event->params()` | Event parameters as array |
-| `$event->callId()` | Call ID associated with event |
+| `$event->getEventType()` | Event type string |
+| `$event->getParams()` | Event parameters as array |
+| `$event->getCallId()` | Call ID associated with event |
+| `$event->getControlId()` | Control ID of the originating action |
+| `$event->getState()` | State carried by the event (if any) |
 
 ## Action Events
 
-Actions from `play()`, `record()`, `playAndCollect()`, etc. produce completion events:
+Actions from `play()`, `record()`, `playAndCollect()`, etc. produce completion
+events. `$action->wait()` returns the completion `Event` (or `null` on timeout).
 
 ```php
-$action = $call->play(media: [
+$action = $call->play([
     ['type' => 'tts', 'params' => ['text' => 'Testing']],
 ]);
 
 $event = $action->wait();
-$resultType = $event->params()['result']['type'] ?? '';
+$resultType = $event->getParams()['result']['type'] ?? '';
 echo "Play result: {$resultType}\n";
 ```
 
@@ -75,12 +80,11 @@ echo "Play result: {$resultType}\n";
 
 ```php
 $action = $call->playAndCollect(
-    media: [['type' => 'tts', 'params' => ['text' => 'Enter your PIN.']]],
-    collect: ['digits' => ['max' => 4, 'digit_timeout' => 5.0]],
+    [['type' => 'tts', 'params' => ['text' => 'Enter your PIN.']]],
+    ['digits' => ['max' => 4, 'digit_timeout' => 5.0]],
 );
 
-$event = $action->wait();
-$result = $event->params()['result'] ?? [];
+$result = $action->getCollectResult() ?? [];
 $type   = $result['type'] ?? '';
 $digits = ($result['params'] ?? [])['digits'] ?? '';
 echo "Collected: type={$type} digits={$digits}\n";
@@ -89,18 +93,18 @@ echo "Collected: type={$type} digits={$digits}\n";
 ### Record Events
 
 ```php
-$action = $call->record(beep: true, format: 'mp3');
-$event = $action->wait();
-$url = $action->url();
+$action = $call->record(['beep' => true, 'format' => 'mp3']);
+$action->wait();
+$url = $action->getUrl();
 echo "Recording saved at: {$url}\n";
 ```
 
 ### Detect Events
 
 ```php
-$action = $call->detect(type: 'machine', timeout: 30);
-$event = $action->wait();
-$detected = $event->params()['detect']['type'] ?? '';
+$action = $call->detect(['type' => 'machine'], ['timeout' => 30]);
+$action->wait();
+$detected = $action->getDetectResult()['type'] ?? '';
 echo "Detected: {$detected}\n";
 ```
 
@@ -110,9 +114,9 @@ For inbound messaging:
 
 ```php
 $client->onMessage(function ($message) {
-    echo "From: " . $message->from() . "\n";
-    echo "Body: " . $message->body() . "\n";
-    echo "State: " . $message->state() . "\n";
+    echo "From: " . $message->getFromNumber() . "\n";
+    echo "Body: " . $message->getBody()       . "\n";
+    echo "State: ". $message->getState()      . "\n";
 });
 ```
 
@@ -122,37 +126,32 @@ $client->onMessage(function ($message) {
 |-------|-------------|
 | `received` | Inbound message received |
 | `queued` | Outbound message queued |
-| `initiated` | Outbound message initiated |
 | `sent` | Outbound message sent |
 | `delivered` | Outbound message delivered |
-| `undelivered` | Outbound message failed |
+| `undelivered` | Outbound message could not be delivered |
 | `failed` | Message failed |
 
 ## Event Constants
 
-Event type constants are defined in `SignalWire\Relay\Constants`:
+Call and message state constants are defined in `SignalWire\Relay\Constants`:
 
 ```php
 use SignalWire\Relay\Constants;
 
-// Constants::CALL_STATE_ANSWERED
-// Constants::CALL_STATE_ENDED
-// Constants::EVENT_CALL_RECEIVED
-// Constants::EVENT_MESSAGE_RECEIVED
+// Constants::CALL_STATE_ANSWERED    === 'answered'
+// Constants::CALL_STATE_ENDED       === 'ended'
+// Constants::MESSAGE_STATE_RECEIVED === 'received'
+// Constants::MESSAGE_STATE_DELIVERED === 'delivered'
 ```
 
 ## Error Events
 
-Connection and protocol errors are logged and trigger reconnection:
-
-```php
-// Set debug logging to see all events
-// export SIGNALWIRE_LOG_LEVEL=debug
-```
+Connection and protocol errors are logged and trigger reconnection. Set
+`SIGNALWIRE_LOG_LEVEL=debug` to see all WebSocket traffic.
 
 ## Best Practices
 
-1. Always check `$call->state()` before performing operations
+1. Always check `$call->state` before performing operations
 2. Use `$action->wait()` to synchronize with async operations
 3. Handle the `ended` state to clean up resources
 4. Register message handlers before calling `$client->run()`

--- a/relay/docs/getting-started.md
+++ b/relay/docs/getting-started.md
@@ -18,24 +18,28 @@ export SIGNALWIRE_SPACE=example.signalwire.com
 
 ## First Inbound Call
 
+The `Client` constructor takes a single options array. `connect()` opens the
+WebSocket *and* runs the authentication handshake — there is no separate
+connect/authenticate step.
+
 ```php
 <?php
 require 'vendor/autoload.php';
 
 use SignalWire\Relay\Client;
 
-$client = new Client(
-    project:  $_ENV['SIGNALWIRE_PROJECT_ID'],
-    token:    $_ENV['SIGNALWIRE_API_TOKEN'],
-    host:     $_ENV['SIGNALWIRE_SPACE'] ?? 'relay.signalwire.com',
-    contexts: ['default'],
-);
+$client = new Client([
+    'project'  => $_ENV['SIGNALWIRE_PROJECT_ID'],
+    'token'    => $_ENV['SIGNALWIRE_API_TOKEN'],
+    'host'     => $_ENV['SIGNALWIRE_SPACE'] ?? 'relay.signalwire.com',
+    'contexts' => ['default'],
+]);
 
 $client->onCall(function ($call) {
-    echo "Incoming call from " . $call->callId() . "\n";
+    echo "Incoming call: " . $call->callId . "\n";
     $call->answer();
 
-    $action = $call->play(media: [
+    $action = $call->play([
         ['type' => 'tts', 'params' => ['text' => 'Hello from SignalWire!']],
     ]);
     $action->wait();
@@ -44,8 +48,7 @@ $client->onCall(function ($call) {
     echo "Call ended.\n";
 });
 
-$client->connectWs() or die("Connection failed\n");
-$client->authenticate();
+$client->connect();
 
 echo "Waiting for inbound calls on context 'default' ...\n";
 $client->run();
@@ -59,55 +62,57 @@ require 'vendor/autoload.php';
 
 use SignalWire\Relay\Client;
 
-$client = new Client(
-    project: $_ENV['SIGNALWIRE_PROJECT_ID'],
-    token:   $_ENV['SIGNALWIRE_API_TOKEN'],
-    host:    $_ENV['SIGNALWIRE_SPACE'] ?? 'relay.signalwire.com',
-);
+$client = new Client([
+    'project' => $_ENV['SIGNALWIRE_PROJECT_ID'],
+    'token'   => $_ENV['SIGNALWIRE_API_TOKEN'],
+    'host'    => $_ENV['SIGNALWIRE_SPACE'] ?? 'relay.signalwire.com',
+]);
 
-$client->connectWs() or die("Connection failed\n");
-$client->authenticate();
+$client->connect();
 
 $call = $client->dial(
-    devices: [[
+    [[
         ['type' => 'phone', 'params' => [
             'to_number'   => '+15551234567',
             'from_number' => '+15559876543',
         ]],
     ]],
-    timeout: 30,
+    ['dial_timeout' => 30.0],
 );
 
 echo "Call answered -- playing TTS\n";
-$action = $call->play(media: [
+$action = $call->play([
     ['type' => 'tts', 'params' => ['text' => 'Hello from SignalWire!']],
 ]);
 $action->wait();
 
 $call->hangup();
-$client->disconnectWs();
+$client->disconnect();
 ```
 
 ## Connection Lifecycle
 
-1. `connectWs()` -- Establish WebSocket connection
-2. `authenticate()` -- Authenticate with project credentials
-3. `onCall($callback)` -- Register handler for inbound calls
-4. `run()` -- Enter event loop (blocks until interrupted)
+1. `connect()` -- Open the WebSocket and run the `signalwire.connect`
+   authentication handshake in one call.
+2. `onCall($callback)` -- Register a handler for inbound calls (call before `run()`).
+3. `run()` -- Enter the event loop (blocks until disconnected).
+4. `disconnect()` -- Close the WebSocket gracefully.
 
 ## Contexts
 
-Contexts route inbound calls to your handler. Set them in the constructor:
+Contexts route inbound calls to your handler. Set them in the options array:
 
 ```php
-$client = new Client(
-    project:  $_ENV['SIGNALWIRE_PROJECT_ID'],
-    token:    $_ENV['SIGNALWIRE_API_TOKEN'],
-    contexts: ['default', 'sales', 'support'],
-);
+$client = new Client([
+    'project'  => $_ENV['SIGNALWIRE_PROJECT_ID'],
+    'token'    => $_ENV['SIGNALWIRE_API_TOKEN'],
+    'contexts' => ['default', 'sales', 'support'],
+]);
 ```
 
-Only calls tagged with one of your contexts will be delivered.
+Only calls tagged with one of your contexts will be delivered. You can also
+subscribe dynamically after connecting with `$client->receive(['billing'])`
+and unsubscribe with `$client->unreceive(['sales'])`.
 
 ## Next Steps
 

--- a/relay/docs/messaging.md
+++ b/relay/docs/messaging.md
@@ -8,45 +8,47 @@ The RELAY client supports SMS and MMS messaging. You can send outbound messages,
 
 ### Basic SMS
 
+`sendMessage()` takes a single params array and returns a `Message` tracking
+object.
+
 ```php
 <?php
 require 'vendor/autoload.php';
 
 use SignalWire\Relay\Client;
 
-$client = new Client(
-    project:  $_ENV['SIGNALWIRE_PROJECT_ID'],
-    token:    $_ENV['SIGNALWIRE_API_TOKEN'],
-    host:     $_ENV['SIGNALWIRE_SPACE'] ?? 'relay.signalwire.com',
-    contexts: ['default'],
-);
+$client = new Client([
+    'project'  => $_ENV['SIGNALWIRE_PROJECT_ID'],
+    'token'    => $_ENV['SIGNALWIRE_API_TOKEN'],
+    'host'     => $_ENV['SIGNALWIRE_SPACE'] ?? 'relay.signalwire.com',
+    'contexts' => ['default'],
+]);
 
-$client->connectWs() or die("Connection failed\n");
-$client->authenticate();
+$client->connect();
 
-$result = $client->sendMessage(
-    from:    '+15559876543',
-    to:      '+15551234567',
-    context: 'default',
-    body:    'Hello from SignalWire PHP!',
-);
+$message = $client->sendMessage([
+    'from_number' => '+15559876543',
+    'to_number'   => '+15551234567',
+    'context'     => 'default',
+    'body'        => 'Hello from SignalWire PHP!',
+]);
 
-echo "Message ID: " . $result->messageId() . "\n";
-echo "State: " . $result->state() . "\n";
+echo "Message ID: " . $message->getMessageId() . "\n";
+echo "State: "      . $message->getState()     . "\n";
 
-$client->disconnectWs();
+$client->disconnect();
 ```
 
 ### MMS with Media
 
 ```php
-$result = $client->sendMessage(
-    from:    '+15559876543',
-    to:      '+15551234567',
-    context: 'default',
-    body:    'Check out this photo!',
-    media:   ['https://example.com/photo.jpg'],
-);
+$message = $client->sendMessage([
+    'from_number' => '+15559876543',
+    'to_number'   => '+15551234567',
+    'context'     => 'default',
+    'body'        => 'Check out this photo!',
+    'media'       => ['https://example.com/photo.jpg'],
+]);
 ```
 
 ## Receiving Messages
@@ -55,20 +57,18 @@ Register a message handler to process inbound SMS/MMS:
 
 ```php
 $client->onMessage(function ($message) {
-    echo "From: " . $message->from() . "\n";
-    echo "To: " . $message->to() . "\n";
-    echo "Body: " . $message->body() . "\n";
-    echo "State: " . $message->state() . "\n";
+    echo "From: " . $message->getFromNumber() . "\n";
+    echo "To: "   . $message->getToNumber()   . "\n";
+    echo "Body: " . $message->getBody()       . "\n";
+    echo "State: ". $message->getState()      . "\n";
 
     // Access media attachments
-    $media = $message->media();
-    foreach ($media as $url) {
+    foreach ($message->getMedia() as $url) {
         echo "Media: {$url}\n";
     }
 });
 
-$client->connectWs() or die("Connection failed\n");
-$client->authenticate();
+$client->connect();
 echo "Waiting for inbound messages...\n";
 $client->run();
 ```
@@ -79,14 +79,15 @@ $client->run();
 
 | Method | Description |
 |--------|-------------|
-| `$msg->messageId()` | Unique message identifier |
-| `$msg->from()` | Sender number |
-| `$msg->to()` | Recipient number |
-| `$msg->body()` | Message text |
-| `$msg->media()` | Array of media URLs |
-| `$msg->state()` | Current delivery state |
-| `$msg->direction()` | `inbound` or `outbound` |
-| `$msg->context()` | Context the message was received on |
+| `$msg->getMessageId()` | Unique message identifier |
+| `$msg->getFromNumber()` | Sender number |
+| `$msg->getToNumber()` | Recipient number |
+| `$msg->getBody()` | Message text |
+| `$msg->getMedia()` | Array of media URLs |
+| `$msg->getState()` | Current delivery state |
+| `$msg->getDirection()` | `inbound` or `outbound` |
+| `$msg->getContext()` | Context the message was received on |
+| `$msg->getTags()` | Message tags |
 
 ## Delivery States
 
@@ -94,7 +95,6 @@ $client->run();
 |-------|-------------|
 | `received` | Inbound message received |
 | `queued` | Outbound message queued for delivery |
-| `initiated` | Outbound message initiated |
 | `sent` | Outbound message sent to carrier |
 | `delivered` | Outbound message confirmed delivered |
 | `undelivered` | Outbound message could not be delivered |
@@ -105,14 +105,14 @@ $client->run();
 Outbound messages progress through states. The `sendMessage()` result reflects the initial state:
 
 ```php
-$result = $client->sendMessage(
-    from:    '+15559876543',
-    to:      '+15551234567',
-    context: 'default',
-    body:    'Order confirmed.',
-);
+$message = $client->sendMessage([
+    'from_number' => '+15559876543',
+    'to_number'   => '+15551234567',
+    'context'     => 'default',
+    'body'        => 'Order confirmed.',
+]);
 
-echo "Initial state: " . $result->state() . "\n";
+echo "Initial state: " . $message->getState() . "\n";
 // Typically "queued" immediately after send
 ```
 
@@ -121,11 +121,11 @@ echo "Initial state: " . $result->state() . "\n";
 Messages are routed to your handler based on context, similar to calls:
 
 ```php
-$client = new Client(
-    project:  $_ENV['SIGNALWIRE_PROJECT_ID'],
-    token:    $_ENV['SIGNALWIRE_API_TOKEN'],
-    contexts: ['default', 'notifications'],
-);
+$client = new Client([
+    'project'  => $_ENV['SIGNALWIRE_PROJECT_ID'],
+    'token'    => $_ENV['SIGNALWIRE_API_TOKEN'],
+    'contexts' => ['default', 'notifications'],
+]);
 ```
 
 ## Best Practices

--- a/rest/docs/calling.md
+++ b/rest/docs/calling.md
@@ -2,16 +2,20 @@
 
 ## Overview
 
-The `$client->calling` namespace provides REST-based call control: dial, play, record, collect, detect, AI, transcribe, tap, stream, and more. These commands operate on active calls identified by `$callId`.
+The `$client->calling()` namespace provides REST-based call control: dial, play,
+record, collect, detect, AI, transcribe, tap, stream, and more. With the
+exception of `dial()` and `update()` (which take a single params array), each
+command takes the call id as its first argument followed by a params array:
+`play(string $callId, array $params = [])`.
 
 ## Placing a Call
 
 ```php
-$call = $client->calling->dial(
-    from: '+15559876543',
-    to:   '+15551234567',
-    url:  'https://example.com/call-handler',
-);
+$call = $client->calling()->dial([
+    'from' => '+15559876543',
+    'to'   => '+15551234567',
+    'url'  => 'https://example.com/call-handler',
+]);
 $callId = $call['id'];
 ```
 
@@ -19,135 +23,131 @@ $callId = $call['id'];
 
 ```php
 // Play TTS
-$client->calling->play($callId,
-    play: [['type' => 'tts', 'text' => 'Welcome to SignalWire.']],
-);
+$client->calling()->play($callId, [
+    'play' => [['type' => 'tts', 'text' => 'Welcome to SignalWire.']],
+]);
 
 // Playback control
-$client->calling->playPause($callId);
-$client->calling->playResume($callId);
-$client->calling->playVolume($callId, volume: 2.0);
-$client->calling->playStop($callId);
+$client->calling()->playPause($callId);
+$client->calling()->playResume($callId);
+$client->calling()->playVolume($callId, ['volume' => 2.0]);
+$client->calling()->playStop($callId);
 ```
 
 ## Recording
 
 ```php
 // Start recording
-$client->calling->record($callId, beep: true, format: 'mp3');
+$client->calling()->record($callId, ['beep' => true, 'format' => 'mp3']);
 
 // Recording control
-$client->calling->recordPause($callId);
-$client->calling->recordResume($callId);
-$client->calling->recordStop($callId);
+$client->calling()->recordPause($callId);
+$client->calling()->recordResume($callId);
+$client->calling()->recordStop($callId);
 ```
 
 ## Input Collection
 
 ```php
 // Collect DTMF
-$client->calling->collect($callId,
-    digits: ['max' => 4, 'terminators' => '#'],
-    play:   [['type' => 'tts', 'text' => 'Enter your PIN followed by pound.']],
-);
+$client->calling()->collect($callId, [
+    'digits' => ['max' => 4, 'terminators' => '#'],
+    'play'   => [['type' => 'tts', 'text' => 'Enter your PIN followed by pound.']],
+]);
 
-$client->calling->collectStartInputTimers($callId);
-$client->calling->collectStop($callId);
+$client->calling()->collectStartInputTimers($callId);
+$client->calling()->collectStop($callId);
 ```
 
 ## Detection
 
 ```php
 // Answering machine detection
-$client->calling->detect($callId, type: 'machine');
-$client->calling->detectStop($callId);
+$client->calling()->detect($callId, ['type' => 'machine']);
+$client->calling()->detectStop($callId);
 ```
 
 ## Transcription
 
 ```php
-$client->calling->transcribe($callId, language: 'en-US');
-$client->calling->transcribeStop($callId);
+$client->calling()->transcribe($callId, ['language' => 'en-US']);
+$client->calling()->transcribeStop($callId);
 ```
 
 ## Live Transcription and Translation
 
 ```php
-$client->calling->liveTranscribe($callId, language: 'en-US');
-$client->calling->liveTranslate($callId, language: 'es');
+$client->calling()->liveTranscribe($callId, ['language' => 'en-US']);
+$client->calling()->liveTranslate($callId, ['language' => 'es']);
 ```
 
 ## AI Operations
 
 ```php
-$client->calling->aiMessage($callId, message: 'Customer wants to check their balance.');
-$client->calling->aiHold($callId);
-$client->calling->aiUnhold($callId);
-$client->calling->aiStop($callId);
+$client->calling()->aiMessage($callId, ['message' => 'Customer wants to check their balance.']);
+$client->calling()->aiHold($callId);
+$client->calling()->aiUnhold($callId);
+$client->calling()->aiStop($callId);
 ```
 
 ## Denoise
 
 ```php
-$client->calling->denoise($callId);
-$client->calling->denoiseStop($callId);
+$client->calling()->denoise($callId);
+$client->calling()->denoiseStop($callId);
 ```
 
 ## Tap (Media Fork)
 
 ```php
-$client->calling->tap($callId,
-    tap:    ['type' => 'audio', 'direction' => 'both'],
-    device: ['type' => 'rtp', 'addr' => '192.168.1.100', 'port' => 9000],
-);
-$client->calling->tapStop($callId);
+$client->calling()->tap($callId, [
+    'tap'    => ['type' => 'audio', 'direction' => 'both'],
+    'device' => ['type' => 'rtp', 'addr' => '192.168.1.100', 'port' => 9000],
+]);
+$client->calling()->tapStop($callId);
 ```
 
 ## Stream (WebSocket)
 
 ```php
-$client->calling->stream($callId, url: 'wss://example.com/audio-stream');
-$client->calling->streamStop($callId);
+$client->calling()->stream($callId, ['url' => 'wss://example.com/audio-stream']);
+$client->calling()->streamStop($callId);
 ```
 
-## Transfer and Connection
+## Transfer and Disconnect
 
 ```php
-$client->calling->transfer($callId, dest: '+15559999999');
-$client->calling->connect($callId,
-    devices: [['type' => 'phone', 'params' => ['to_number' => '+15551234567']]],
-);
-$client->calling->disconnect($callId);
+$client->calling()->transfer($callId, ['dest' => '+15559999999']);
+$client->calling()->disconnect($callId);
 ```
 
 ## SIP Refer
 
 ```php
-$client->calling->refer($callId, sipUri: 'sip:support@example.com');
+$client->calling()->refer($callId, ['sip_uri' => 'sip:support@example.com']);
 ```
 
 ## User Events
 
 ```php
-$client->calling->userEvent($callId,
-    eventName: 'agent_note',
-    data:      ['note' => 'VIP caller'],
-);
+$client->calling()->userEvent($callId, [
+    'event_name' => 'agent_note',
+    'data'       => ['note' => 'VIP caller'],
+]);
 ```
 
 ## Call Management
 
 ```php
-$client->calling->update(callId: $callId, metadata: ['priority' => 'high']);
-$client->calling->end($callId, reason: 'hangup');
+$client->calling()->update(['id' => $callId, 'metadata' => ['priority' => 'high']]);
+$client->calling()->end($callId, ['reason' => 'hangup']);
 ```
 
 ## Fax
 
 ```php
-$client->calling->sendFax($callId, document: 'https://example.com/doc.pdf');
-$client->calling->sendFaxStop($callId);
-$client->calling->receiveFaxStop($callId);
+$client->calling()->sendFaxStop($callId);
+$client->calling()->receiveFaxStop($callId);
 ```
 
 ## Complete Example
@@ -159,27 +159,27 @@ require 'vendor/autoload.php';
 use SignalWire\REST\RestClient;
 
 $client = new RestClient(
-    project: $_ENV['SIGNALWIRE_PROJECT_ID'] ?? die("Set SIGNALWIRE_PROJECT_ID\n"),
-    token:   $_ENV['SIGNALWIRE_API_TOKEN']  ?? die("Set SIGNALWIRE_API_TOKEN\n"),
-    host:    $_ENV['SIGNALWIRE_SPACE']      ?? die("Set SIGNALWIRE_SPACE\n"),
+    $_ENV['SIGNALWIRE_PROJECT_ID'] ?? '',
+    $_ENV['SIGNALWIRE_API_TOKEN']  ?? '',
+    $_ENV['SIGNALWIRE_SPACE']      ?? '',
 );
 
 // Dial a call
-$call = $client->calling->dial(
-    from: '+15559876543',
-    to:   '+15551234567',
-    url:  'https://example.com/handler',
-);
+$call = $client->calling()->dial([
+    'from' => '+15559876543',
+    'to'   => '+15551234567',
+    'url'  => 'https://example.com/handler',
+]);
 $callId = $call['id'];
 
 // Play a greeting
-$client->calling->play($callId,
-    play: [['type' => 'tts', 'text' => 'Welcome to our service.']],
-);
+$client->calling()->play($callId, [
+    'play' => [['type' => 'tts', 'text' => 'Welcome to our service.']],
+]);
 
 // Record the call
-$client->calling->record($callId, beep: true, format: 'mp3');
+$client->calling()->record($callId, ['beep' => true, 'format' => 'mp3']);
 
 // End the call
-$client->calling->end($callId, reason: 'hangup');
+$client->calling()->end($callId, ['reason' => 'hangup']);
 ```

--- a/rest/docs/client-reference.md
+++ b/rest/docs/client-reference.md
@@ -2,52 +2,58 @@
 
 ## Constructor
 
+`RestClient` takes positional `projectId`, `token`, and `space` arguments.
+Each falls back to its environment variable (`SIGNALWIRE_PROJECT_ID`,
+`SIGNALWIRE_API_TOKEN`, `SIGNALWIRE_SPACE`) when an empty string is passed.
+
 ```php
 use SignalWire\REST\RestClient;
 
 $client = new RestClient(
-    project: string,   // SignalWire project ID (required)
-    token:   string,   // SignalWire API token (required)
-    host:    string,   // Space hostname, e.g. 'example.signalwire.com' (required)
+    'your-project-id',        // projectId (required)
+    'your-api-token',         // token (required)
+    'example.signalwire.com', // space hostname or full base URL (required)
 );
 ```
 
 ## Namespaces
 
-All API surfaces are accessed as properties:
+All API surfaces are accessed as method calls that return the namespace object.
+There are 21 namespaces:
 
-| Property | Description |
+| Accessor | Description |
 |----------|-------------|
-| `$client->fabric` | Fabric API: AI agents, SWML, subscribers, call flows, etc. |
-| `$client->calling` | REST call control commands |
-| `$client->phoneNumbers` | Phone number search, purchase, manage |
-| `$client->compat` | Twilio-compatible LAML API |
-| `$client->video` | Video rooms, sessions, conferences, streams |
-| `$client->datasphere` | Document upload and semantic search |
-| `$client->registry` | 10DLC brands, campaigns, orders |
-| `$client->queues` | Call queue management |
-| `$client->recordings` | Call recording access |
-| `$client->mfa` | Multi-factor authentication |
-| `$client->numberGroups` | Phone number group management |
-| `$client->lookup` | Phone number carrier lookup |
-| `$client->verifiedCallers` | Verified caller ID management |
-| `$client->sipProfile` | SIP profile configuration |
-| `$client->shortCodes` | Short code management |
-| `$client->addresses` | Regulatory address management |
-| `$client->logs` | Call, message, fax, conference logs |
-| `$client->projectNs` | Project-level token management |
-| `$client->pubsub` | PubSub token creation |
-| `$client->chat` | Chat token creation |
+| `$client->fabric()` | Fabric API: AI agents, SWML, subscribers, call flows, etc. |
+| `$client->calling()` | REST call control commands |
+| `$client->phoneNumbers()` | Phone number search, purchase, manage |
+| `$client->compat()` | Twilio-compatible LAML API |
+| `$client->video()` | Video rooms, sessions, conferences, streams |
+| `$client->datasphere()` | Document upload and semantic search |
+| `$client->registry()` | 10DLC brands, campaigns, orders, numbers |
+| `$client->queues()` | Call queue management |
+| `$client->recordings()` | Call recording access |
+| `$client->mfa()` | Multi-factor authentication |
+| `$client->numberGroups()` | Phone number group management |
+| `$client->lookup()` | Phone number carrier lookup |
+| `$client->verifiedCallers()` | Verified caller ID management |
+| `$client->sipProfile()` | SIP profile configuration |
+| `$client->shortCodes()` | Short code management |
+| `$client->addresses()` | Address management |
+| `$client->importedNumbers()` | Imported phone numbers |
+| `$client->logs()` | Call, message, fax, conference logs |
+| `$client->project()` | Project-level token management |
+| `$client->pubsub()` | PubSub token creation |
+| `$client->chat()` | Chat token creation |
 
 ## Return Values
 
 All methods return associative arrays (decoded JSON). No wrapper objects:
 
 ```php
-$agent = $client->fabric->aiAgents->create(
-    name: 'Bot',
-    prompt: ['text' => 'You are helpful.'],
-);
+$agent = $client->fabric()->aiAgents()->create([
+    'name'   => 'Bot',
+    'prompt' => ['text' => 'You are helpful.'],
+]);
 
 echo $agent['id'];     // Direct access
 echo $agent['name'];   // No ->getId() or ->getName()
@@ -56,7 +62,7 @@ echo $agent['name'];   // No ->getId() or ->getName()
 List operations return paginated results:
 
 ```php
-$numbers = $client->phoneNumbers->list();
+$numbers = $client->phoneNumbers()->list();
 foreach (($numbers['data'] ?? []) as $num) {
     echo $num['number'] . "\n";
 }
@@ -70,7 +76,7 @@ API errors throw `SignalWireRestError`:
 use SignalWire\REST\SignalWireRestError;
 
 try {
-    $client->fabric->aiAgents->get('nonexistent-id');
+    $client->fabric()->aiAgents()->get('nonexistent-id');
 } catch (SignalWireRestError $e) {
     echo "HTTP " . $e->getCode() . ": " . $e->getMessage() . "\n";
 }
@@ -105,12 +111,11 @@ The REST client is stateless per-request and safe to use in concurrent contexts.
 require 'vendor/autoload.php';
 
 use SignalWire\REST\RestClient;
-use SignalWire\REST\SignalWireRestError;
 
 $client = new RestClient(
-    project: $_ENV['SIGNALWIRE_PROJECT_ID'] ?? die("Set SIGNALWIRE_PROJECT_ID\n"),
-    token:   $_ENV['SIGNALWIRE_API_TOKEN']  ?? die("Set SIGNALWIRE_API_TOKEN\n"),
-    host:    $_ENV['SIGNALWIRE_SPACE']      ?? die("Set SIGNALWIRE_SPACE\n"),
+    $_ENV['SIGNALWIRE_PROJECT_ID'] ?? '',
+    $_ENV['SIGNALWIRE_API_TOKEN']  ?? '',
+    $_ENV['SIGNALWIRE_SPACE']      ?? '',
 );
 
 function safe(string $label, callable $fn): mixed
@@ -126,16 +131,16 @@ function safe(string $label, callable $fn): mixed
 }
 
 // Create agent
-$agent = safe('Create agent', fn() => $client->fabric->aiAgents->create(
-    name: 'Demo Bot',
-    prompt: ['text' => 'You are helpful.'],
-));
+$agent = safe('Create agent', fn() => $client->fabric()->aiAgents()->create([
+    'name'   => 'Demo Bot',
+    'prompt' => ['text' => 'You are helpful.'],
+]));
 
 // List numbers
-safe('List numbers', fn() => $client->phoneNumbers->list());
+safe('List numbers', fn() => $client->phoneNumbers()->list());
 
 // Clean up
 if ($agent) {
-    safe('Delete agent', fn() => $client->fabric->aiAgents->delete($agent['id']));
+    safe('Delete agent', fn() => $client->fabric()->aiAgents()->delete($agent['id']));
 }
 ```

--- a/rest/docs/compat.md
+++ b/rest/docs/compat.md
@@ -2,123 +2,127 @@
 
 ## Overview
 
-The Compatibility API provides a Twilio-compatible LAML surface. It supports phone numbers, messaging, calls, conferences, queues, recordings, faxes, applications, and more. Access it via `$client->compat`.
+The Compatibility API provides a Twilio-compatible LAML surface. It supports
+phone numbers, messaging, calls, conferences, queues, recordings, faxes,
+applications, and more. Access it via `$client->compat()`. Sub-resources are
+method calls, and request bodies are passed as a single associative array using
+the Twilio-compatible PascalCase field names.
 
 ## Phone Numbers
 
 ```php
 // Search
-$client->compat->phoneNumbers->searchLocal('US', AreaCode: '512');
-$client->compat->phoneNumbers->searchTollFree('US');
-$client->compat->phoneNumbers->listAvailableCountries();
+$client->compat()->phoneNumbers()->searchLocal('US', ['AreaCode' => '512']);
+$client->compat()->phoneNumbers()->searchTollFree('US');
+$client->compat()->phoneNumbers()->listAvailableCountries();
 
 // Purchase
-$num = $client->compat->phoneNumbers->purchase(PhoneNumber: '+15125551234');
+$num = $client->compat()->phoneNumbers()->purchase(['PhoneNumber' => '+15125551234']);
 
 // Delete
-$client->compat->phoneNumbers->delete($num['sid']);
+$client->compat()->phoneNumbers()->delete($num['sid']);
 ```
 
 ## Messaging
 
 ```php
 // Send SMS
-$msg = $client->compat->messages->create(
-    From: '+15559876543',
-    To:   '+15551234567',
-    Body: 'Hello from SignalWire!',
-);
+$msg = $client->compat()->messages()->create([
+    'From' => '+15559876543',
+    'To'   => '+15551234567',
+    'Body' => 'Hello from SignalWire!',
+]);
 
 // List / Get / Media
-$messages = $client->compat->messages->list();
-$detail   = $client->compat->messages->get($msg['sid']);
-$media    = $client->compat->messages->listMedia($msg['sid']);
+$messages = $client->compat()->messages()->list();
+$detail   = $client->compat()->messages()->get($msg['sid']);
+$media    = $client->compat()->messages()->listMedia($msg['sid']);
 ```
 
 ## Calls
 
 ```php
 // Create outbound call
-$call = $client->compat->calls->create(
-    From: '+15559876543',
-    To:   '+15551234567',
-    Url:  'https://example.com/voice-handler',
-);
+$call = $client->compat()->calls()->create([
+    'From' => '+15559876543',
+    'To'   => '+15551234567',
+    'Url'  => 'https://example.com/voice-handler',
+]);
 
 // Start recording/streaming on active call
-$client->compat->calls->startRecording($call['sid']);
-$client->compat->calls->startStream($call['sid'], Url: 'wss://example.com/stream');
+$client->compat()->calls()->startRecording($call['sid']);
+$client->compat()->calls()->startStream($call['sid'], ['Url' => 'wss://example.com/stream']);
 ```
 
 ## LaML Bins
 
 ```php
-$laml = $client->compat->lamlBins->create(
-    Name:     'Hold Music',
-    Contents: '<Response><Say>Please hold.</Say></Response>',
-);
-$client->compat->lamlBins->delete($laml['sid']);
+$laml = $client->compat()->lamlBins()->create([
+    'Name'     => 'Hold Music',
+    'Contents' => '<Response><Say>Please hold.</Say></Response>',
+]);
+$client->compat()->lamlBins()->delete($laml['sid']);
 ```
 
 ## Applications
 
 ```php
-$app = $client->compat->applications->create(
-    FriendlyName: 'Demo App',
-    VoiceUrl:     'https://example.com/voice',
-);
-$client->compat->applications->delete($app['sid']);
+$app = $client->compat()->applications()->create([
+    'FriendlyName' => 'Demo App',
+    'VoiceUrl'     => 'https://example.com/voice',
+]);
+$client->compat()->applications()->delete($app['sid']);
 ```
 
 ## Conferences
 
 ```php
-$confs = $client->compat->conferences->list();
+$confs = $client->compat()->conferences()->list();
 if (!empty($confs['data'])) {
     $confSid = $confs['data'][0]['sid'];
-    $detail  = $client->compat->conferences->get($confSid);
-    $parts   = $client->compat->conferences->listParticipants($confSid);
-    $recs    = $client->compat->conferences->listRecordings($confSid);
+    $detail  = $client->compat()->conferences()->get($confSid);
+    $parts   = $client->compat()->conferences()->listParticipants($confSid);
+    $recs    = $client->compat()->conferences()->listRecordings($confSid);
 }
 ```
 
 ## Queues
 
 ```php
-$queue = $client->compat->queues->create(FriendlyName: 'support-queue');
-$members = $client->compat->queues->listMembers($queue['sid']);
-$client->compat->queues->delete($queue['sid']);
+$queue = $client->compat()->queues()->create(['FriendlyName' => 'support-queue']);
+$members = $client->compat()->queues()->listMembers($queue['sid']);
+$client->compat()->queues()->delete($queue['sid']);
 ```
 
 ## Recordings and Transcriptions
 
 ```php
-$recordings     = $client->compat->recordings->list();
-$transcriptions = $client->compat->transcriptions->list();
+$recordings     = $client->compat()->recordings()->list();
+$transcriptions = $client->compat()->transcriptions()->list();
 
 if (!empty($recordings['data'])) {
-    $detail = $client->compat->recordings->get($recordings['data'][0]['sid']);
+    $detail = $client->compat()->recordings()->get($recordings['data'][0]['sid']);
 }
 ```
 
 ## Faxes
 
 ```php
-$fax = $client->compat->faxes->create(
-    From:     '+15559876543',
-    To:       '+15551234567',
-    MediaUrl: 'https://example.com/document.pdf',
-);
-$detail = $client->compat->faxes->get($fax['sid']);
+$fax = $client->compat()->faxes()->create([
+    'From'     => '+15559876543',
+    'To'       => '+15551234567',
+    'MediaUrl' => 'https://example.com/document.pdf',
+]);
+$detail = $client->compat()->faxes()->get($fax['sid']);
 ```
 
 ## Accounts and Tokens
 
 ```php
-$accounts = $client->compat->accounts->list();
+$accounts = $client->compat()->accounts()->list();
 
-$token = $client->compat->tokens->create(name: 'demo-token');
-$client->compat->tokens->delete($token['id']);
+$token = $client->compat()->tokens()->create(['name' => 'demo-token']);
+$client->compat()->tokens()->delete($token['id']);
 ```
 
 ## Complete Migration Example
@@ -130,27 +134,27 @@ require 'vendor/autoload.php';
 use SignalWire\REST\RestClient;
 
 $client = new RestClient(
-    project: $_ENV['SIGNALWIRE_PROJECT_ID'] ?? die("Set SIGNALWIRE_PROJECT_ID\n"),
-    token:   $_ENV['SIGNALWIRE_API_TOKEN']  ?? die("Set SIGNALWIRE_API_TOKEN\n"),
-    host:    $_ENV['SIGNALWIRE_SPACE']      ?? die("Set SIGNALWIRE_SPACE\n"),
+    $_ENV['SIGNALWIRE_PROJECT_ID'] ?? '',
+    $_ENV['SIGNALWIRE_API_TOKEN']  ?? '',
+    $_ENV['SIGNALWIRE_SPACE']      ?? '',
 );
 
 // Search for a local number (Twilio-compatible)
-$available = $client->compat->phoneNumbers->searchLocal('US', AreaCode: '512');
+$available = $client->compat()->phoneNumbers()->searchLocal('US', ['AreaCode' => '512']);
 
 // Send an SMS (Twilio-compatible)
-$msg = $client->compat->messages->create(
-    From: '+15559876543',
-    To:   '+15551234567',
-    Body: 'Migrated from Twilio to SignalWire!',
-);
+$msg = $client->compat()->messages()->create([
+    'From' => '+15559876543',
+    'To'   => '+15551234567',
+    'Body' => 'Migrated from Twilio to SignalWire!',
+]);
 echo "Message SID: " . $msg['sid'] . "\n";
 
 // Place a call (Twilio-compatible)
-$call = $client->compat->calls->create(
-    From: '+15559876543',
-    To:   '+15551234567',
-    Url:  'https://example.com/voice-handler',
-);
+$call = $client->compat()->calls()->create([
+    'From' => '+15559876543',
+    'To'   => '+15551234567',
+    'Url'  => 'https://example.com/voice-handler',
+]);
 echo "Call SID: " . $call['sid'] . "\n";
 ```

--- a/rest/docs/fabric.md
+++ b/rest/docs/fabric.md
@@ -2,183 +2,186 @@
 
 ## Overview
 
-The Fabric API manages AI agents, SWML scripts, subscribers, call flows, conference rooms, SIP gateways, and more. Access it via `$client->fabric`.
+The Fabric API manages AI agents, SWML scripts, subscribers, call flows,
+conference rooms, SIP gateways, and more. Access it via `$client->fabric()`.
+Sub-resources are method calls, and CRUD methods take a single associative
+array.
 
 ## AI Agents
 
 ```php
 // Create
-$agent = $client->fabric->aiAgents->create(
-    name:   'Support Bot',
-    prompt: ['text' => 'You are a helpful support agent.'],
-);
+$agent = $client->fabric()->aiAgents()->create([
+    'name'   => 'Support Bot',
+    'prompt' => ['text' => 'You are a helpful support agent.'],
+]);
 $agentId = $agent['id'];
 
 // List
-$agents = $client->fabric->aiAgents->list();
+$agents = $client->fabric()->aiAgents()->list();
 foreach (($agents['data'] ?? []) as $a) {
     echo "- {$a['id']}: " . ($a['name'] ?? 'unnamed') . "\n";
 }
 
 // Get / Update / Delete
-$detail = $client->fabric->aiAgents->get($agentId);
-$client->fabric->aiAgents->update($agentId, name: 'Updated Bot');
-$client->fabric->aiAgents->delete($agentId);
+$detail = $client->fabric()->aiAgents()->get($agentId);
+$client->fabric()->aiAgents()->update($agentId, ['name' => 'Updated Bot']);
+$client->fabric()->aiAgents()->delete($agentId);
 ```
 
 ## SWML Scripts
 
 ```php
-$swml = $client->fabric->swmlScripts->create(
-    name:     'Greeting Script',
-    contents: [
+$swml = $client->fabric()->swmlScripts()->create([
+    'name'     => 'Greeting Script',
+    'contents' => [
         'sections' => [
             'main' => [['play' => ['url' => 'say:Hello from SignalWire']]],
         ],
     ],
-);
+]);
 $swmlId = $swml['id'];
 
-$scripts = $client->fabric->swmlScripts->list();
-$client->fabric->swmlScripts->delete($swmlId);
+$scripts = $client->fabric()->swmlScripts()->list();
+$client->fabric()->swmlScripts()->delete($swmlId);
 ```
 
 ## SWML Webhooks
 
 ```php
-$webhook = $client->fabric->swmlWebhooks->create(
-    name:              'External Handler',
-    primaryRequestUrl: 'https://example.com/swml-handler',
-);
-$client->fabric->swmlWebhooks->delete($webhook['id']);
+$webhook = $client->fabric()->swmlWebhooks()->create([
+    'name'                => 'External Handler',
+    'primary_request_url' => 'https://example.com/swml-handler',
+]);
+$client->fabric()->swmlWebhooks()->delete($webhook['id']);
 ```
 
 ## Call Flows
 
 ```php
 // Create
-$flow = $client->fabric->callFlows->create(title: 'Main IVR Flow');
+$flow = $client->fabric()->callFlows()->create(['title' => 'Main IVR Flow']);
 $flowId = $flow['id'];
 
 // Deploy a version
-$client->fabric->callFlows->deployVersion($flowId, label: 'v1');
+$client->fabric()->callFlows()->deployVersion($flowId, ['label' => 'v1']);
 
 // List versions
-$versions = $client->fabric->callFlows->listVersions($flowId);
+$versions = $client->fabric()->callFlows()->listVersions($flowId);
 
 // List addresses
-$addrs = $client->fabric->callFlows->listAddresses($flowId);
+$addrs = $client->fabric()->callFlows()->listAddresses($flowId);
 
-$client->fabric->callFlows->delete($flowId);
+$client->fabric()->callFlows()->delete($flowId);
 ```
 
 ## Subscribers
 
 ```php
 // Create subscriber
-$subscriber = $client->fabric->subscribers->create(
-    name:  'Alice Johnson',
-    email: 'alice@example.com',
-);
+$subscriber = $client->fabric()->subscribers()->create([
+    'name'  => 'Alice Johnson',
+    'email' => 'alice@example.com',
+]);
 $subId = $subscriber['id'];
 
 // Add SIP endpoint
-$endpoint = $client->fabric->subscribers->createSipEndpoint($subId,
-    username: 'alice_sip',
-    password: 'SecurePass123!',
-);
+$endpoint = $client->fabric()->subscribers()->createSipEndpoint($subId, [
+    'username' => 'alice_sip',
+    'password' => 'SecurePass123!',
+]);
 $epId = $endpoint['id'];
 
 // List / Get SIP endpoints
-$endpoints = $client->fabric->subscribers->listSipEndpoints($subId);
-$detail    = $client->fabric->subscribers->getSipEndpoint($subId, $epId);
+$endpoints = $client->fabric()->subscribers()->listSipEndpoints($subId);
+$detail    = $client->fabric()->subscribers()->getSipEndpoint($subId, $epId);
 
 // Clean up
-$client->fabric->subscribers->deleteSipEndpoint($subId, $epId);
-$client->fabric->subscribers->delete($subId);
+$client->fabric()->subscribers()->deleteSipEndpoint($subId, $epId);
+$client->fabric()->subscribers()->delete($subId);
 ```
 
 ## SIP Gateways
 
 ```php
-$gateway = $client->fabric->sipGateways->create(
-    name:       'Office PBX Gateway',
-    uri:        'sip:pbx.example.com',
-    encryption: 'required',
-    ciphers:    ['AES_256_CM_HMAC_SHA1_80'],
-    codecs:     ['PCMU', 'PCMA'],
-);
-$client->fabric->sipGateways->delete($gateway['id']);
+$gateway = $client->fabric()->sipGateways()->create([
+    'name'       => 'Office PBX Gateway',
+    'uri'        => 'sip:pbx.example.com',
+    'encryption' => 'required',
+    'ciphers'    => ['AES_256_CM_HMAC_SHA1_80'],
+    'codecs'     => ['PCMU', 'PCMA'],
+]);
+$client->fabric()->sipGateways()->delete($gateway['id']);
 ```
 
 ## Conference Rooms
 
 ```php
-$room = $client->fabric->conferenceRooms->create(name: 'team-standup');
-$addrs = $client->fabric->conferenceRooms->listAddresses($room['id']);
-$client->fabric->conferenceRooms->delete($room['id']);
+$room = $client->fabric()->conferenceRooms()->create(['name' => 'team-standup']);
+$addrs = $client->fabric()->conferenceRooms()->listAddresses($room['id']);
+$client->fabric()->conferenceRooms()->delete($room['id']);
 ```
 
 ## cXML Scripts and Webhooks
 
 ```php
-$cxml = $client->fabric->cxmlScripts->create(
-    name:     'Hold Music',
-    contents: '<Response><Say>Please hold.</Say></Response>',
-);
+$cxml = $client->fabric()->cxmlScripts()->create([
+    'name'     => 'Hold Music',
+    'contents' => '<Response><Say>Please hold.</Say></Response>',
+]);
 
-$cxmlWh = $client->fabric->cxmlWebhooks->create(
-    name:              'External cXML Handler',
-    primaryRequestUrl: 'https://example.com/cxml-handler',
-);
+$cxmlWh = $client->fabric()->cxmlWebhooks()->create([
+    'name'                => 'External cXML Handler',
+    'primary_request_url' => 'https://example.com/cxml-handler',
+]);
 
-$client->fabric->cxmlWebhooks->delete($cxmlWh['id']);
-$client->fabric->cxmlScripts->delete($cxml['id']);
+$client->fabric()->cxmlWebhooks()->delete($cxmlWh['id']);
+$client->fabric()->cxmlScripts()->delete($cxml['id']);
 ```
 
 ## Relay Applications
 
 ```php
-$app = $client->fabric->relayApplications->create(
-    name:  'Inbound Handler',
-    topic: 'office',
-);
-$client->fabric->relayApplications->delete($app['id']);
+$app = $client->fabric()->relayApplications()->create([
+    'name'  => 'Inbound Handler',
+    'topic' => 'office',
+]);
+$client->fabric()->relayApplications()->delete($app['id']);
 ```
 
 ## Generic Resources
 
 ```php
-$resources = $client->fabric->resources->list();
-$detail    = $client->fabric->resources->get($resourceId);
+$resources = $client->fabric()->resources()->list();
+$detail    = $client->fabric()->resources()->get($resourceId);
 
 // Assign routes
-$client->fabric->resources->assignPhoneRoute($resourceId, phoneNumber: '+15551234567');
-$client->fabric->resources->assignDomainApplication($resourceId, domain: 'app.example.com');
+$client->fabric()->resources()->assignPhoneRoute($resourceId, ['phone_number' => '+15551234567']);
+$client->fabric()->resources()->assignDomainApplication($resourceId, ['domain' => 'app.example.com']);
 ```
 
 ## Fabric Addresses
 
 ```php
-$addresses = $client->fabric->addresses->list();
-$detail    = $client->fabric->addresses->get($addressId);
+$addresses = $client->fabric()->addresses()->list();
+$detail    = $client->fabric()->addresses()->get($addressId);
 ```
 
 ## Tokens
 
 ```php
 // Guest token
-$guest = $client->fabric->tokens->createGuestToken(resourceId: $resourceId);
+$guest = $client->fabric()->tokens()->createGuestToken(['resource_id' => $resourceId]);
 
 // Invite token
-$invite = $client->fabric->tokens->createInviteToken(resourceId: $resourceId);
+$invite = $client->fabric()->tokens()->createInviteToken(['resource_id' => $resourceId]);
 
 // Embed token
-$embed = $client->fabric->tokens->createEmbedToken(resourceId: $resourceId);
+$embed = $client->fabric()->tokens()->createEmbedToken(['resource_id' => $resourceId]);
 
 // Subscriber token
-$sub = $client->fabric->tokens->createSubscriberToken(
-    subscriberId: $subscriberId,
-    reference:    $subscriberId,
-);
+$sub = $client->fabric()->tokens()->createSubscriberToken([
+    'subscriber_id' => $subscriberId,
+    'reference'     => $subscriberId,
+]);
 ```

--- a/rest/docs/getting-started.md
+++ b/rest/docs/getting-started.md
@@ -18,6 +18,9 @@ export SIGNALWIRE_SPACE=example.signalwire.com
 
 ## Creating the Client
 
+The `RestClient` constructor takes positional `projectId`, `token`, and `space`
+arguments (each falls back to the matching environment variable when empty).
+
 ```php
 <?php
 require 'vendor/autoload.php';
@@ -25,23 +28,26 @@ require 'vendor/autoload.php';
 use SignalWire\REST\RestClient;
 
 $client = new RestClient(
-    project: $_ENV['SIGNALWIRE_PROJECT_ID'] ?? die("Set SIGNALWIRE_PROJECT_ID\n"),
-    token:   $_ENV['SIGNALWIRE_API_TOKEN']  ?? die("Set SIGNALWIRE_API_TOKEN\n"),
-    host:    $_ENV['SIGNALWIRE_SPACE']      ?? die("Set SIGNALWIRE_SPACE\n"),
+    $_ENV['SIGNALWIRE_PROJECT_ID'] ?? '',
+    $_ENV['SIGNALWIRE_API_TOKEN']  ?? '',
+    $_ENV['SIGNALWIRE_SPACE']      ?? '',
 );
 ```
 
 ## First API Call
 
+Namespaces are accessed via method calls (`$client->phoneNumbers()`), and
+`create`/`search`/`update` take a single associative array.
+
 ```php
 // List phone numbers
-$numbers = $client->phoneNumbers->list();
+$numbers = $client->phoneNumbers()->list();
 foreach (($numbers['data'] ?? []) as $num) {
     echo "- " . ($num['number'] ?? 'unknown') . "\n";
 }
 
 // Search available numbers
-$available = $client->phoneNumbers->search(areaCode: '512', maxResults: 3);
+$available = $client->phoneNumbers()->search(['area_code' => '512', 'max_results' => 3]);
 foreach (($available['data'] ?? []) as $num) {
     echo "- " . ($num['e164'] ?? $num['number'] ?? 'unknown') . "\n";
 }
@@ -55,10 +61,10 @@ All REST methods throw `SignalWireRestError` on failure:
 use SignalWire\REST\SignalWireRestError;
 
 try {
-    $agent = $client->fabric->aiAgents->create(
-        name:   'Test Bot',
-        prompt: ['text' => 'You are helpful.'],
-    );
+    $agent = $client->fabric()->aiAgents()->create([
+        'name'   => 'Test Bot',
+        'prompt' => ['text' => 'You are helpful.'],
+    ]);
     echo "Created agent: " . $agent['id'] . "\n";
 } catch (SignalWireRestError $e) {
     echo "API error: " . $e->getMessage() . "\n";
@@ -82,8 +88,8 @@ function safe(string $label, callable $fn): mixed
     }
 }
 
-safe('List agents', fn() => $client->fabric->aiAgents->list());
-safe('List numbers', fn() => $client->phoneNumbers->list());
+safe('List agents', fn() => $client->fabric()->aiAgents()->list());
+safe('List numbers', fn() => $client->phoneNumbers()->list());
 ```
 
 ## Next Steps

--- a/rest/docs/namespaces.md
+++ b/rest/docs/namespaces.md
@@ -2,209 +2,213 @@
 
 ## Overview
 
-The `RestClient` provides namespaced sub-objects for every SignalWire API surface. Each namespace uses method chaining for resource access.
+The `RestClient` provides namespaced sub-objects for every SignalWire API
+surface. Namespaces and their sub-resources are accessed via method calls, and
+CRUD methods (`create`, `update`, `search`, ...) take a single associative
+array.
 
 ## Namespace Map
 
 ```php
-$client->fabric->...           // Fabric API (AI agents, SWML, subscribers, etc.)
-$client->calling->...          // REST call control commands
-$client->phoneNumbers->...     // Phone number management
-$client->compat->...           // Twilio-compatible LAML API
-$client->video->...            // Video rooms, sessions, recordings
-$client->datasphere->...       // Documents and semantic search
-$client->registry->...         // 10DLC brands, campaigns, orders
-$client->queues->...           // Call queues
-$client->recordings->...       // Call recordings
-$client->mfa->...              // Multi-factor authentication
-$client->numberGroups->...     // Phone number groups
-$client->lookup->...           // Phone number lookup
-$client->verifiedCallers->...  // Verified caller IDs
-$client->sipProfile->...       // SIP profile management
-$client->shortCodes->...       // Short codes
-$client->addresses->...        // Regulatory addresses
-$client->logs->...             // Call, message, fax, conference logs
-$client->projectNs->...       // Project-level tokens
-$client->pubsub->...          // PubSub tokens
-$client->chat->...            // Chat tokens
+$client->fabric()->...           // Fabric API (AI agents, SWML, subscribers, etc.)
+$client->calling()->...          // REST call control commands
+$client->phoneNumbers()->...     // Phone number management
+$client->compat()->...           // Twilio-compatible LAML API
+$client->video()->...            // Video rooms, sessions, recordings
+$client->datasphere()->...       // Documents and semantic search
+$client->registry()->...         // 10DLC brands, campaigns, orders, numbers
+$client->queues()->...           // Call queues
+$client->recordings()->...       // Call recordings
+$client->mfa()->...              // Multi-factor authentication
+$client->numberGroups()->...     // Phone number groups
+$client->lookup()->...           // Phone number lookup
+$client->verifiedCallers()->...  // Verified caller IDs
+$client->sipProfile()->...       // SIP profile management
+$client->shortCodes()->...       // Short codes
+$client->addresses()->...        // Addresses
+$client->importedNumbers()->...  // Imported numbers
+$client->logs()->...             // Call, message, fax, conference logs
+$client->project()->...          // Project-level tokens
+$client->pubsub()->...           // PubSub tokens
+$client->chat()->...             // Chat tokens
 ```
 
 ## Phone Numbers
 
 ```php
 // Search
-$available = $client->phoneNumbers->search(areaCode: '512', maxResults: 5);
+$available = $client->phoneNumbers()->search(['area_code' => '512', 'max_results' => 5]);
 
 // Purchase
-$number = $client->phoneNumbers->create(number: '+15125551234');
+$number = $client->phoneNumbers()->create(['number' => '+15125551234']);
 
 // List / Get / Update / Delete
-$numbers = $client->phoneNumbers->list();
-$detail  = $client->phoneNumbers->get($numId);
-$client->phoneNumbers->update($numId, name: 'Main Line');
-$client->phoneNumbers->delete($numId);
+$numbers = $client->phoneNumbers()->list();
+$detail  = $client->phoneNumbers()->get($numId);
+$client->phoneNumbers()->update($numId, ['name' => 'Main Line']);
+$client->phoneNumbers()->delete($numId);
 ```
 
 ## Number Groups
 
 ```php
-$group = $client->numberGroups->create(name: 'Sales Pool');
-$client->numberGroups->addMembership($groupId, phoneNumberId: $numId);
-$members = $client->numberGroups->listMemberships($groupId);
-$client->numberGroups->delete($groupId);
+$group = $client->numberGroups()->create(['name' => 'Sales Pool']);
+$client->numberGroups()->addMembership($groupId, ['phone_number_id' => $numId]);
+$members = $client->numberGroups()->listMemberships($groupId);
+$client->numberGroups()->delete($groupId);
 ```
 
 ## Datasphere
 
 ```php
 // Upload document
-$doc = $client->datasphere->documents->create(
-    url:  'https://example.com/document.txt',
-    tags: ['support'],
-);
+$doc = $client->datasphere()->documents()->create([
+    'url'  => 'https://example.com/document.txt',
+    'tags' => ['support'],
+]);
 
 // Check status
-$status = $client->datasphere->documents->get($docId);
+$status = $client->datasphere()->documents()->get($docId);
 
 // List chunks
-$chunks = $client->datasphere->documents->listChunks($docId);
+$chunks = $client->datasphere()->documents()->listChunks($docId);
 
 // Semantic search
-$results = $client->datasphere->documents->search(
-    queryString: 'how to reset password',
-    count:       5,
-);
+$results = $client->datasphere()->documents()->search([
+    'query_string' => 'how to reset password',
+    'count'        => 5,
+]);
 
 // Delete
-$client->datasphere->documents->delete($docId);
+$client->datasphere()->documents()->delete($docId);
 ```
 
 ## Video
 
 ```php
 // Rooms
-$room = $client->video->rooms->create(name: 'standup', maxMembers: 10);
-$rooms = $client->video->rooms->list();
-$client->video->rooms->delete($roomId);
+$room = $client->video()->rooms()->create(['name' => 'standup', 'max_members' => 10]);
+$rooms = $client->video()->rooms()->list();
+$client->video()->rooms()->delete($roomId);
 
 // Room tokens
-$token = $client->video->roomTokens->create(
-    roomName:    'standup',
-    userName:    'alice',
-    permissions: ['room.self.audio_mute'],
-);
+$token = $client->video()->roomTokens()->create([
+    'room_name'   => 'standup',
+    'user_name'   => 'alice',
+    'permissions' => ['room.self.audio_mute'],
+]);
 
 // Sessions
-$sessions = $client->video->roomSessions->list();
-$members  = $client->video->roomSessions->listMembers($sessionId);
+$sessions = $client->video()->roomSessions()->list();
+$members  = $client->video()->roomSessions()->listMembers($sessionId);
 
 // Recordings
-$recordings = $client->video->roomRecordings->list();
+$recordings = $client->video()->roomRecordings()->list();
 
 // Conferences
-$conf = $client->video->conferences->create(name: 'all-hands');
-$client->video->conferences->createStream($confId, url: 'rtmp://live.example.com/key');
+$conf = $client->video()->conferences()->createStream($confId, ['url' => 'rtmp://live.example.com/key']);
 
 // Streams
-$client->video->streams->update($streamId, url: 'rtmp://backup.example.com/key');
-$client->video->streams->delete($streamId);
+$client->video()->streams()->update($streamId, ['url' => 'rtmp://backup.example.com/key']);
+$client->video()->streams()->delete($streamId);
 ```
 
 ## Queues
 
 ```php
-$queue   = $client->queues->create(name: 'Support Queue', maxSize: 50);
-$queues  = $client->queues->list();
-$members = $client->queues->listMembers($queueId);
-$next    = $client->queues->getNextMember($queueId);
-$client->queues->delete($queueId);
+$queue   = $client->queues()->create(['name' => 'Support Queue', 'max_size' => 50]);
+$queues  = $client->queues()->list();
+$members = $client->queues()->listMembers($queueId);
+$next    = $client->queues()->getNextMember($queueId);
+$client->queues()->delete($queueId);
 ```
 
 ## Recordings
 
 ```php
-$recordings = $client->recordings->list();
-$detail     = $client->recordings->get($recId);
+$recordings = $client->recordings()->list();
+$detail     = $client->recordings()->get($recId);
+$client->recordings()->delete($recId);
 ```
 
 ## MFA
 
 ```php
 // Send via SMS
-$sms = $client->mfa->sms(
-    to:          '+15551234567',
-    from:        '+15559876543',
-    message:     'Your code is {{code}}',
-    tokenLength: 6,
-);
+$sms = $client->mfa()->sms([
+    'to'           => '+15551234567',
+    'from'         => '+15559876543',
+    'message'      => 'Your code is {{code}}',
+    'token_length' => 6,
+]);
 
 // Send via voice call
-$voice = $client->mfa->call(
-    to:          '+15551234567',
-    from:        '+15559876543',
-    message:     'Your code is {{code}}',
-    tokenLength: 6,
-);
+$voice = $client->mfa()->call([
+    'to'           => '+15551234567',
+    'from'         => '+15559876543',
+    'message'      => 'Your code is {{code}}',
+    'token_length' => 6,
+]);
 
 // Verify
-$result = $client->mfa->verify($requestId, token: '123456');
+$result = $client->mfa()->verify($requestId, ['token' => '123456']);
 ```
 
 ## Lookup
 
 ```php
-$info = $client->lookup->phoneNumber('+15125551234');
+$info = $client->lookup()->phoneNumber('+15125551234');
 echo "Carrier: " . ($info['carrier']['name'] ?? 'unknown') . "\n";
 ```
 
 ## Verified Callers
 
 ```php
-$caller = $client->verifiedCallers->create(phoneNumber: '+15125559999');
-$client->verifiedCallers->submitVerification($callerId, verificationCode: '123456');
-$client->verifiedCallers->delete($callerId);
+$caller = $client->verifiedCallers()->create(['phone_number' => '+15125559999']);
+$client->verifiedCallers()->submitVerification($callerId, ['verification_code' => '123456']);
+$client->verifiedCallers()->delete($callerId);
 ```
 
 ## SIP Profile
 
 ```php
-$profile = $client->sipProfile->get();
-$client->sipProfile->update(defaultCodecs: ['PCMU', 'PCMA']);
+$profile = $client->sipProfile()->get();
+$client->sipProfile()->update(['default_codecs' => ['PCMU', 'PCMA']]);
 ```
 
 ## Logs
 
 ```php
-$messageLogs    = $client->logs->messages->list();
-$voiceLogs      = $client->logs->voice->list();
-$voiceDetail    = $client->logs->voice->get($logId);
-$voiceEvents    = $client->logs->voice->listEvents($logId);
-$faxLogs        = $client->logs->fax->list();
-$conferenceLogs = $client->logs->conferences->list();
+$messageLogs    = $client->logs()->messages()->list();
+$voiceLogs      = $client->logs()->voice()->list();
+$voiceDetail    = $client->logs()->voice()->get($logId);
+$voiceEvents    = $client->logs()->voice()->listEvents($logId);
+$faxLogs        = $client->logs()->fax()->list();
+$conferenceLogs = $client->logs()->conferences()->list();
 ```
 
 ## Project Tokens
 
 ```php
-$token = $client->projectNs->tokens->create(
-    name:        'CI Token',
-    permissions: ['calling', 'messaging', 'video'],
-);
-$client->projectNs->tokens->update($tokenId, name: 'Updated Token');
-$client->projectNs->tokens->delete($tokenId);
+$token = $client->project()->tokens()->create([
+    'name'        => 'CI Token',
+    'permissions' => ['calling', 'messaging', 'video'],
+]);
+$client->project()->tokens()->update($tokenId, ['name' => 'Updated Token']);
+$client->project()->tokens()->delete($tokenId);
 ```
 
 ## PubSub and Chat Tokens
 
 ```php
-$client->pubsub->createToken(
-    channels: ['notifications' => ['read' => true, 'write' => true]],
-    ttl:      3600,
-);
+$client->pubsub()->createToken([
+    'channels' => ['notifications' => ['read' => true, 'write' => true]],
+    'ttl'      => 3600,
+]);
 
-$client->chat->createToken(
-    memberId: 'user-alice',
-    channels: ['general' => ['read' => true, 'write' => true]],
-    ttl:      3600,
-);
+$client->chat()->createToken([
+    'member_id' => 'user-alice',
+    'channels'  => ['general' => ['read' => true, 'write' => true]],
+    'ttl'       => 3600,
+]);
 ```


### PR DESCRIPTION
Content/consistency audit of the top-level `README.md` against the Python reference README (`signalwire-python/README.md`) and the actual `src/` surface. No new gate added.

## Findings + fixes

**Accuracy / broken examples (would not run as written):**

- **RELAY example** — `new Client(project: ..., token: ..., host: ..., contexts: ...)` is invalid: `Relay\Client::__construct` takes a single `array $options`. Also `$client->connectWs(); $client->authenticate();` — there is no `connectWs()` method; the real call is `$client->connect()`, which opens the WebSocket *and* authenticates internally. Fixed to the array constructor + `connect()`.
- **REST example** — three problems fixed:
  - `new RestClient(project:, token:, host:)` → real ctor is `(string $projectId, string $token, string $space, ...)`, so the named params are `projectId:`, `token:`, `space:`.
  - Property-style namespace access (`$client->fabric->aiAgents->...`) → namespaces are **method** accessors (`$client->fabric()->aiAgents()->...`); `RestClient` has no `__get`.
  - `create(name:, prompt:)`, `search(areaCode:)`, `search(queryString:)` use named scalar args, but `CrudResource::create(array $data)`, `PhoneNumbersResource::search(array $params)`, and `DatasphereDocuments::search(array $body)` each take a **single array**. Rewritten with array literals. `Calling::play($callId, array $params)` keeps the valid `params:` named arg.
- **REST feature count** — "Fabric (13 resource types)" → **16** (counted the accessor methods on `REST/Namespaces/Fabric.php`).
- **Serverless feature bullet** — claimed "native PHP/CGI support, plus Lambda and Cloud Functions adapters"; the adapter (`Serverless/Adapter.php` + `ExecutionMode.php`) actually handles CGI/FastCGI, AWS Lambda, Google Cloud Functions, **and Azure Functions**. Updated to match.
- **PHP version** — Installation said "PHP 8.1+"; `composer.json` requires `php: >=8.2`. Fixed to 8.2+ (extension list reordered to match `ext-json`/`ext-mbstring`/`ext-openssl`).

**Structural consistency (added applicable, existing-but-unlinked guides the Python README also surfaces):**

- Skills and Extensions → **MCP Gateway** (`docs/mcp_gateway_reference.md`)
- Deployment → **Cloud Functions** (`docs/cloud_functions_guide.md`)
- Reference → **Web Service** (`docs/web_service.md`)

**Verified accurate, left unchanged:**

- AI Agents example matches `examples/simple_agent.php` exactly: `new AgentBase(name:, route:)`, `addLanguage(name:, code:, voice:)`, `promptAddSection(...)`, `defineTool(name:, description:, parameters:, handler:)`, `$agent->run()`. `swaig-test` flags (`--list-tools`, `--dump-swml`, `--exec`) exist in `bin/swaig-test`.
- 5 prefabs (InfoGatherer, Survey, FAQ, Receptionist, Concierge), 18 built-in skills, 21 REST namespaces, package `signalwire/sdk`.
- All relative links resolve (docs/, examples/, `relay/README.md`, `rest/README.md`, `examples/README.md`, `LICENSE`); external URLs well-formed.

## Python-only sections omitted (correctly, no equivalent feature)

- **Search System** docs section + `pip install signalwire-sdk[search-*]` extras + `.swsearch`/`sw-search` CLI. The PHP port has a `NativeVectorSearch` skill but no search-index build CLI, no install extras, and no search guides — so the whole Search section and the search install variants are not applicable.
- **Bedrock Agent** deployment guide — no `docs/bedrock_agent.md` in the PHP port.
- **Local search** agent-feature bullet — not surfaced (consistent with no search docs/CLI).

## DOC-AUDIT result

`scripts/run-ci.sh` Gate 9 (DOC-AUDIT) scans `docs/` + `examples/` fenced code blocks, not the top-level README, so README edits don't move the gate. Ran it anyway — **PASS** (1137/1512 symbols resolved, zero unresolved). Every symbol used in the README was also manually verified against `src/`.

> Note (out of scope for this PR): the same broken RELAY `connectWs()`/array-ctor idiom and property-style REST access appear in `relay/README.md`, `rest/README.md`, and several files under `examples/`/`rest/examples/`/`relay/examples/`. DOC-AUDIT passes on them only because `connectWs` is allowlisted in `DOC_AUDIT_IGNORE.md` for the *SWML* `<connect>` verb (auto-vivified), and property chains resolve on the final real method name. Worth a follow-up to fix those examples to the real runtime API.

---

## Sub-docs audit (second commit)

Extended the audit to **every sub-doc** — `relay/docs/*` (5), `rest/docs/*` (6), and `docs/*` (the guide files) — fixing the same defect classes found in the README, all verified against `src/` (not Python idioms).

**RELAY docs (`relay/docs/`)** — fully audited (getting-started, client-reference, call-methods, events, messaging):
- `new Client([...])` single options array; `connect()`/`disconnect()` (removed `connectWs`/`disconnectWs`/separate `authenticate()`).
- `dial($devices, ['dial_timeout'=>...])`; `sendMessage(array)` with `to_number`/`from_number`.
- Call state via **properties** `$call->callId` / `$call->state` (not `callId()`/`state()`); `Message` via `getFromNumber()`/`getToNumber()`/`getBody()`/`getState()`/`getMedia()`; `Action` via `getUrl()`/`isDone()`; `Event` via `getEventType()`/`getParams()`/`getCallId()`.
- `record(array $audio, array $opts)`, `detect(array $detect, array $opts)`, `connect(array $params)` — fixed named-scalar args. Removed nonexistent `EVENT_CALL_RECEIVED`/`EVENT_MESSAGE_RECEIVED` constants.

**REST docs (`rest/docs/`)** — fully audited (getting-started, client-reference, namespaces, calling, fabric, compat):
- Positional ctor `new RestClient($projectId, $token, $space)`; namespaces are **method** accessors (`$client->fabric()->aiAgents()->...`), not properties.
- `create`/`search`/`update` take a single array everywhere; sub-resources are method calls (`datasphere()->documents()`, `video()->rooms()`, `logs()->voice()`, `project()->tokens()`).
- Fixed invented `$client->projectNs` → `project()`. `calling()` commands are `($callId, array $params)` with `dial()`/`update()` taking a single array; removed **phantom** `calling()->connect()` and `calling()->sendFax()` (only `disconnect`, `sendFaxStop`/`receiveFaxStop` exist). `compat()` sub-resources as methods with LAML body arrays.

**Guide docs (`docs/`)** — audited agent_guide, swaig_reference, api_reference, contexts_guide, configuration, security, cloud_functions_guide, architecture, web_service (fully); spot-checked datamap_guide, skills_system, skills_parameter_schema, third_party_skills, mcp_integration, mcp_gateway_reference, sdk_features, cli_guide, llm_parameters (no defects found):
- **contexts_guide** — rewrote the array-config blocks to the real fluent `ContextBuilder` API: `addContext()->setSystemPrompt()/setConsolidate()/setFullReset()`, `addStep(task:, criteria:, valid_steps:)->setValidContexts()`.
- **cloud_functions_guide** — `handleServerlessRequest()` does not exist → use `Serverless\Adapter::handleGcf()`/`handleAzure()`/`serve()`; fixed auth ctor args (`basicAuthUser`/`basicAuthPassword`) and env vars (`SIGNALWIRE_API_TOKEN`, `SWML_BASIC_AUTH_USER`/`SWML_BASIC_AUTH_PASSWORD` — `SIGNALWIRE_TOKEN`/`AGENT_USERNAME`/`AGENT_PASSWORD` are not read by the SDK).
- **web_service** — was an entire **Python-only** doc for a `WebService` class that does not exist in the PHP port. Replaced with the real PHP HTTP-serving surface: `AgentBase`/`Service` (`serve()`/`run()`/`handleRequest()`, Basic Auth), `AgentServer` multi-agent hosting + static-file serving (`serveStatic()`). Keeps the README's existing link valid.
- **api_reference** — corrected `defineTool(..., bool $secure = false)`, `sendSms(..., $tags, $region)`, `connect(..., string $from = '')`, `addAction(array $action)` signatures.
- **agent_guide / swaig_reference** — `addAction()` takes a single `['name' => $data]` array; `set_global_data` shown via the dedicated `updateGlobalData()`.
- **configuration / security / architecture** — RestClient/RELAY ctor + namespace-access idioms fixed.

**Python-only content** — none remained after the web_service rewrite (no `.swsearch`/`sw-search`/`[search-*]`/sentence-transformers/Bedrock/LiveKit references in any sub-doc).

**Counts verified against `src/`:** PHP >= 8.2, 21 REST namespaces, Fabric 16 sub-resources, Calling 37 commands, serverless modes `cgi`/`lambda`/`gcf`/`azure`/`server`. **No dead relative links** in any sub-doc.

**DOC-AUDIT:** `audit_docs.py` (Gate 9) scans `docs/` + `rest/docs` + `relay/docs` + `examples/` fenced blocks — **PASS** (1485/1822 resolved, zero unresolved), no `DOC_AUDIT_IGNORE.md` entries added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
