### PR TITLE
chore: raise phpstan to level 9 (zero findings, no suppression)

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,5 @@
 parameters:
-    level: 5
+    level: 6
     paths:
         - src
         - scripts

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,5 @@
 parameters:
-    level: 6
+    level: 9
     paths:
         - src
         - scripts

--- a/port_signatures.json
+++ b/port_signatures.json
@@ -5175,7 +5175,7 @@
                 },
                 {
                   "name": "agent",
-                  "type": "any",
+                  "type": "class:signalwire.core.agent_base.AgentBase",
                   "required": true
                 }
               ],

--- a/port_signatures.json
+++ b/port_signatures.json
@@ -354,7 +354,7 @@
               "params": [
                 {
                   "name": "agent",
-                  "type": "any",
+                  "type": "class:signalwire.swml.SWMLService",
                   "required": true
                 },
                 {
@@ -369,7 +369,7 @@
               "params": [
                 {
                   "name": "agent",
-                  "type": "any",
+                  "type": "class:signalwire.swml.SWMLService",
                   "required": true
                 }
               ],
@@ -379,7 +379,7 @@
               "params": [
                 {
                   "name": "agent",
-                  "type": "any",
+                  "type": "class:signalwire.swml.SWMLService",
                   "required": true
                 }
               ],
@@ -389,7 +389,7 @@
               "params": [
                 {
                   "name": "agent",
-                  "type": "any",
+                  "type": "class:signalwire.swml.SWMLService",
                   "required": true
                 },
                 {
@@ -409,7 +409,7 @@
               "params": [
                 {
                   "name": "agent",
-                  "type": "any",
+                  "type": "class:signalwire.swml.SWMLService",
                   "required": true
                 },
                 {
@@ -5021,7 +5021,7 @@
                 },
                 {
                   "name": "agent",
-                  "type": "any",
+                  "type": "class:signalwire.core.agent_base.AgentBase",
                   "required": true
                 },
                 {
@@ -7110,7 +7110,7 @@
                 },
                 {
                   "name": "client",
-                  "type": "any",
+                  "type": "class:signalwire.relay.RelayClient",
                   "required": true
                 }
               ],
@@ -7249,15 +7249,6 @@
                   "type": "any",
                   "required": false,
                   "default": []
-                }
-              ],
-              "returns": "any"
-            },
-            "client": {
-              "params": [
-                {
-                  "name": "self",
-                  "kind": "self"
                 }
               ],
               "returns": "any"
@@ -16585,7 +16576,7 @@
                 },
                 {
                   "name": "agent",
-                  "type": "any",
+                  "type": "class:signalwire.core.agent_base.AgentBase",
                   "required": true
                 },
                 {
@@ -16658,7 +16649,7 @@
                 },
                 {
                   "name": "agent",
-                  "type": "any",
+                  "type": "class:signalwire.core.agent_base.AgentBase",
                   "required": true
                 },
                 {
@@ -16749,7 +16740,7 @@
                 },
                 {
                   "name": "agent",
-                  "type": "any",
+                  "type": "class:signalwire.core.agent_base.AgentBase",
                   "required": true
                 },
                 {
@@ -16822,7 +16813,7 @@
                 },
                 {
                   "name": "agent",
-                  "type": "any",
+                  "type": "class:signalwire.core.agent_base.AgentBase",
                   "required": true
                 },
                 {
@@ -16913,7 +16904,7 @@
                 },
                 {
                   "name": "agent",
-                  "type": "any",
+                  "type": "class:signalwire.core.agent_base.AgentBase",
                   "required": true
                 },
                 {
@@ -17004,7 +16995,7 @@
                 },
                 {
                   "name": "agent",
-                  "type": "any",
+                  "type": "class:signalwire.core.agent_base.AgentBase",
                   "required": true
                 },
                 {
@@ -17077,7 +17068,7 @@
                 },
                 {
                   "name": "agent",
-                  "type": "any",
+                  "type": "class:signalwire.core.agent_base.AgentBase",
                   "required": true
                 },
                 {
@@ -17297,7 +17288,7 @@
                 },
                 {
                   "name": "agent",
-                  "type": "any",
+                  "type": "class:signalwire.core.agent_base.AgentBase",
                   "required": true
                 },
                 {
@@ -17388,7 +17379,7 @@
                 },
                 {
                   "name": "agent",
-                  "type": "any",
+                  "type": "class:signalwire.core.agent_base.AgentBase",
                   "required": true
                 },
                 {
@@ -17470,7 +17461,7 @@
                 },
                 {
                   "name": "agent",
-                  "type": "any",
+                  "type": "class:signalwire.core.agent_base.AgentBase",
                   "required": true
                 },
                 {
@@ -17543,7 +17534,7 @@
                 },
                 {
                   "name": "agent",
-                  "type": "any",
+                  "type": "class:signalwire.core.agent_base.AgentBase",
                   "required": true
                 },
                 {
@@ -17634,7 +17625,7 @@
                 },
                 {
                   "name": "agent",
-                  "type": "any",
+                  "type": "class:signalwire.core.agent_base.AgentBase",
                   "required": true
                 },
                 {
@@ -17716,7 +17707,7 @@
                 },
                 {
                   "name": "agent",
-                  "type": "any",
+                  "type": "class:signalwire.core.agent_base.AgentBase",
                   "required": true
                 },
                 {
@@ -17947,7 +17938,7 @@
                 },
                 {
                   "name": "agent",
-                  "type": "any",
+                  "type": "class:signalwire.core.agent_base.AgentBase",
                   "required": true
                 },
                 {
@@ -18029,7 +18020,7 @@
                 },
                 {
                   "name": "agent",
-                  "type": "any",
+                  "type": "class:signalwire.core.agent_base.AgentBase",
                   "required": true
                 },
                 {
@@ -18120,7 +18111,7 @@
                 },
                 {
                   "name": "agent",
-                  "type": "any",
+                  "type": "class:signalwire.core.agent_base.AgentBase",
                   "required": true
                 },
                 {
@@ -18184,7 +18175,7 @@
                 },
                 {
                   "name": "agent",
-                  "type": "any",
+                  "type": "class:signalwire.core.agent_base.AgentBase",
                   "required": true
                 },
                 {
@@ -18293,7 +18284,7 @@
                 },
                 {
                   "name": "agent",
-                  "type": "any",
+                  "type": "class:signalwire.core.agent_base.AgentBase",
                   "required": true
                 },
                 {

--- a/scripts/emit_skills.php
+++ b/scripts/emit_skills.php
@@ -149,7 +149,9 @@ function load_corpus(): array
         if (!is_array($decoded) || !isset($decoded['corpus']) || !is_array($decoded['corpus'])) {
             throw new \RuntimeException("malformed corpus from {$script}");
         }
-        return $decoded['corpus'];
+        /** @var list<array{id: string, skill: string, config?: array<string, mixed>}> $corpus */
+        $corpus = $decoded['corpus'];
+        return $corpus;
     }
 
     throw new \RuntimeException(

--- a/scripts/emit_skills.php
+++ b/scripts/emit_skills.php
@@ -54,17 +54,31 @@ declare(strict_types=1);
 
 require __DIR__ . '/../vendor/autoload.php';
 
+use SignalWire\Agent\AgentInterface;
+use SignalWire\Skills\SkillName;
 use SignalWire\Skills\SkillRegistry;
 
 /**
  * CapturingAgent — a minimal fake agent that records the tool contracts a skill
- * registers, via either of the two registration paths skills use. It implements
- * only the surface SkillBase + the DataMap skills touch during registerTools().
+ * registers, via either of the two registration paths skills use. It satisfies
+ * the INTERNAL AgentInterface (the same contract production AgentBase satisfies)
+ * so the duck-typed SkillBase::$agent receiver can be precisely typed without
+ * narrowing to AgentBase. The two tool-registration methods record contracts;
+ * the remaining interface methods (addSkill/addHints/promptAddSection/
+ * updateGlobalData) are captured as no-ops since they don't contribute tool
+ * contracts — but implementing them keeps the harness hardened against the
+ * addHints-fatal class of bug.
  */
-final class CapturingAgent
+final class CapturingAgent implements AgentInterface
 {
     /** @var list<array{name: string, parameters: array<string, mixed>, required?: list<string>}> */
     public array $tools = [];
+
+    /** @var list<string> */
+    public array $hints = [];
+
+    /** @var array<string, mixed> */
+    public array $globalData = [];
 
     /**
      * Mirror of SWMLService::defineTool — handler tools. `$parameters` is the
@@ -81,7 +95,7 @@ final class CapturingAgent
         array $parameters,
         callable $handler,
         bool $secure = false,
-    ): self {
+    ): static {
         $props = [];
         $required = [];
         foreach ($parameters as $param => $def) {
@@ -109,14 +123,66 @@ final class CapturingAgent
      *
      * @param array<string, mixed> $funcDef
      */
-    public function registerSwaigFunction(array $funcDef): self
+    public function registerSwaigFunction(array $funcDef): static
     {
         $name = $funcDef['function'] ?? '';
-        if ($name === '') {
+        if (!is_string($name) || $name === '') {
             return $this;
         }
         $argument = $funcDef['argument'] ?? [];
-        $this->tools[] = ['name' => $name, 'parameters' => $argument];
+        $parameters = [];
+        if (is_array($argument)) {
+            foreach ($argument as $argKey => $argValue) {
+                $parameters[(string) $argKey] = $argValue;
+            }
+        }
+        $this->tools[] = ['name' => $name, 'parameters' => $parameters];
+        return $this;
+    }
+
+    /**
+     * Captured no-op — skills may add nested skills; not part of the tool
+     * contract the differ compares.
+     *
+     * @param array<string, mixed> $params
+     */
+    public function addSkill(SkillName|string $name, array $params = []): static
+    {
+        return $this;
+    }
+
+    /**
+     * Captured — records hints so registerTools() that calls addHints does not
+     * fatal (the addHints-fatal class of bug this harness must survive).
+     *
+     * @param list<string> $hints
+     */
+    public function addHints(array $hints): static
+    {
+        foreach ($hints as $hint) {
+            $this->hints[] = (string) $hint;
+        }
+        return $this;
+    }
+
+    /**
+     * Captured no-op — prompt sections are not part of the tool contract.
+     *
+     * @param list<string> $bullets
+     */
+    public function promptAddSection(string $title, string $body, array $bullets = []): static
+    {
+        return $this;
+    }
+
+    /**
+     * Captured — records merged global data; not part of the tool contract.
+     *
+     * @param array<string, mixed> $data
+     */
+    public function updateGlobalData(array $data): static
+    {
+        $this->globalData = array_merge($this->globalData, $data);
         return $this;
     }
 }

--- a/scripts/enumerate_surface.py
+++ b/scripts/enumerate_surface.py
@@ -375,6 +375,16 @@ MIXIN_PROJECTIONS: dict[tuple[str, str], tuple[str, list[str]]] = {
 CLASS_RENAME_MAP: dict[str, str] = {
     "Service": "SWMLService",
     "Client": "RelayClient",
+    # Internal duck-type contracts (the TS RelayClientLike pattern) fold onto
+    # the canonical concrete class they abstract, so any signature that
+    # references one as a param/return type compares against the Python-
+    # equivalent class instead of a PHP-only interface name. The interfaces
+    # themselves are @internal and excluded from the dumps (see
+    # signature_dump.php / _parse_file's @internal handling) — this is a
+    # rename, not an omission.
+    "AgentInterface": "AgentBase",
+    "RelayClientLike": "RelayClient",
+    "RequestHandlerLike": "SWMLService",
     # REST namespace classes (Python uses descriptive *Resource / *Namespace names)
     "Calling": "CallingNamespace",
     "Fabric": "FabricNamespace",  # not in Python; emitted into fabric.py module
@@ -446,6 +456,17 @@ RE_NAMESPACE = re.compile(r"^\s*namespace\s+([\\\w]+)\s*;")
 # excluded — only hand-written public methods on the enum are captured.
 RE_CLASS = re.compile(
     r"^\s*(?:final\s+|abstract\s+)?(?:class|enum)\s+([A-Za-z_]\w*)"
+)
+# Interfaces are class-like scopes too. They were absent from this SDK until
+# the internal duck-type contracts (AgentInterface, RelayClientLike,
+# RequestHandlerLike — the TS RelayClientLike pattern) were added. We must
+# recognise them as a scope so their `public function` declarations are NOT
+# mistaken for `__module__` free functions; whether a given interface lands on
+# the public surface is decided separately via its `@internal` marker (see
+# _parse_file). A method declaration in an interface body has no `{ ... }`, so
+# it does not perturb brace tracking.
+RE_INTERFACE = re.compile(
+    r"^\s*interface\s+([A-Za-z_]\w*)"
 )
 RE_PUBLIC_METHOD = re.compile(
     r"^\s*public\s+(?:static\s+)?function\s+(\w+)\s*\("
@@ -563,13 +584,23 @@ def _parse_file(path: Path) -> tuple[set[str], dict[str, set[str]], set[str]]:
     lines = text.splitlines()
     cur_class: str | None = None
     cur_class_brace: int = 0
+    # When the current scope is an `@internal` interface, its methods are
+    # excluded from the surface entirely (they are an internal duck-type
+    # contract, not exported API) — but the scope is still tracked so its
+    # methods do not leak as `__module__` free functions.
+    cur_excluded: bool = False
     brace_depth = 0
     in_block_comment = False
+    # True when the immediately-preceding docblock carried an `@internal` tag;
+    # consumed by the next class/interface declaration.
+    internal_pending = False
 
     for raw_line in lines:
         # Strip block comments naively (sufficient for this SDK)
         line = raw_line
         if in_block_comment:
+            if "@internal" in raw_line:
+                internal_pending = True
             end = line.find("*/")
             if end != -1:
                 line = line[end + 2:]
@@ -583,9 +614,13 @@ def _parse_file(path: Path) -> tuple[set[str], dict[str, set[str]], set[str]]:
                 break
             end = line.find("*/", start + 2)
             if end == -1:
+                if "@internal" in line[start:]:
+                    internal_pending = True
                 line = line[:start]
                 in_block_comment = True
                 break
+            if "@internal" in line[start:end]:
+                internal_pending = True
             line = line[:start] + line[end + 2:]
         # Strip line comments
         ls_idx = line.find("//")
@@ -602,11 +637,25 @@ def _parse_file(path: Path) -> tuple[set[str], dict[str, set[str]], set[str]]:
         m_class = RE_CLASS.match(line)
         if m_class:
             cur_class = m_class.group(1)
+            cur_excluded = False
             classes.add(cur_class)
+            internal_pending = False
             # Brace might appear later on the same or following line; we'll
             # enter the class scope as soon as `{` is seen.
             cur_class_brace = -1
             # Continue to count braces on this line below.
+
+        # Interface declaration — a class-like scope. If marked `@internal`,
+        # exclude it (and its methods) from the surface; it is consumed only
+        # internally and must not appear as exported API.
+        m_iface = RE_INTERFACE.match(line)
+        if m_iface:
+            cur_class = m_iface.group(1)
+            cur_excluded = internal_pending
+            if not cur_excluded:
+                classes.add(cur_class)
+            internal_pending = False
+            cur_class_brace = -1
 
         # Public method
         m_method = RE_PUBLIC_METHOD.match(line)
@@ -623,7 +672,11 @@ def _parse_file(path: Path) -> tuple[set[str], dict[str, set[str]], set[str]]:
                 py_name = camel_to_snake(method_name)
             # Apply Python-canonical aliasing where PHP idiom differs.
             py_name = METHOD_ALIASES.get(py_name, py_name)
-            if cur_class is not None:
+            if cur_excluded:
+                # Internal interface body — neither surface method nor a
+                # leaked free function.
+                pass
+            elif cur_class is not None:
                 methods[cur_class].add(py_name)
             else:
                 free_fns.add(py_name)
@@ -642,6 +695,7 @@ def _parse_file(path: Path) -> tuple[set[str], dict[str, set[str]], set[str]]:
             if cur_class is not None and brace_depth < cur_class_brace:
                 cur_class = None
                 cur_class_brace = 0
+                cur_excluded = False
 
     return free_fns, dict(methods), classes
 

--- a/scripts/run-ci.sh
+++ b/scripts/run-ci.sh
@@ -20,7 +20,7 @@
 #                                            vs Python to_dict() over the shared
 #                                            81-entry corpus; needs no mocks)
 #   7. fmt gate                           — php-cs-fixer (local: apply; CI: --dry-run)
-#   8. lint gate                          — phpstan level 5, zero findings (the floor)
+#   8. lint gate                          — phpstan level 6, zero findings (the floor)
 #   9. doc-audit gate                     — porting-sdk audit_docs.py
 #  10. surface-diff gate                  — porting-sdk diff_port_surface.py
 #  11. skill-contract gate                — porting-sdk diff_skill_contracts.py
@@ -340,23 +340,26 @@ fmt_gate() {
 }
 run_gate "FMT" "php-cs-fixer (local: apply; CI: --dry-run --diff)" fmt_gate
 
-# Gate 8: LINT — the language lint gate (php: phpstan level 5, zero findings).
+# Gate 8: LINT — the language lint gate (php: phpstan level 6, zero findings).
 # This is the blocking quality floor: phpstan.neon analyses src/ + scripts/ at
-# level 5 (the highest level reachable with ZERO genuine findings without an
-# ignore-baseline) and the burndown took it 41 → 0 with every fix at the source
-# (no @phpstan-ignore, no baseline, no silencing casts). Proven neutral:
-# port_signatures.json byte-identical, port_surface.json differs only in the
-# generated_from git-sha, EMISSION 81/81. Mirrors the go golangci / rust clippy
-# blocking-lint gate.
+# level 6 (the highest level reachable with ZERO genuine findings without an
+# ignore-baseline) and the burndown took it 41 → 0 (level 5) then 372 → 0
+# (level 6, the bare-array value-type block) with every fix at the source
+# (no @phpstan-ignore, no baseline, no silencing casts; array shapes sourced
+# from the python reference / SWML schema / call sites). Levels 7-9 remain
+# gated only by a small residual of genuinely-ambiguous items (duck-typed
+# RELAY/serverless receivers tested via anonymous mock classes, and curl
+# CURLOPT_URL non-empty-string strictness) left for human triage — see the PR.
+# Mirrors the go golangci / rust clippy blocking-lint gate.
 #
 # --memory-limit=512M: phpstan defaults to php.ini's memory_limit, which on a
-# stock CLI install is 128M — too low for a full level-5 analysis of src/ +
+# stock CLI install is 128M — too low for a full level-6 analysis of src/ +
 # scripts/ (it OOMs mid-run with "Result is incomplete because of severe
 # errors", not a real finding). Pin a generous limit so the gate's result
 # depends on the code, not the host php.ini. This is not a suppression: no
 # baseline, no @phpstan-ignore — the analysis still runs to completion at
-# level 5 and must report zero findings.
-run_gate "LINT" "phpstan level 5 zero findings (lint gate)" \
+# level 6 and must report zero findings.
+run_gate "LINT" "phpstan level 6 zero findings (lint gate)" \
     vendor/bin/phpstan analyse --no-progress --memory-limit=512M
 
 # Gate 9: DOC-AUDIT — every method/class referenced in docs/ + examples/ fenced

--- a/scripts/run-ci.sh
+++ b/scripts/run-ci.sh
@@ -20,7 +20,7 @@
 #                                            vs Python to_dict() over the shared
 #                                            81-entry corpus; needs no mocks)
 #   7. fmt gate                           — php-cs-fixer (local: apply; CI: --dry-run)
-#   8. lint gate                          — phpstan level 6, zero findings (the floor)
+#   8. lint gate                          — phpstan level 9, zero findings (the floor)
 #   9. doc-audit gate                     — porting-sdk audit_docs.py
 #  10. surface-diff gate                  — porting-sdk diff_port_surface.py
 #  11. skill-contract gate                — porting-sdk diff_skill_contracts.py
@@ -340,26 +340,33 @@ fmt_gate() {
 }
 run_gate "FMT" "php-cs-fixer (local: apply; CI: --dry-run --diff)" fmt_gate
 
-# Gate 8: LINT — the language lint gate (php: phpstan level 6, zero findings).
+# Gate 8: LINT — the language lint gate (php: phpstan level 9, zero findings).
 # This is the blocking quality floor: phpstan.neon analyses src/ + scripts/ at
-# level 6 (the highest level reachable with ZERO genuine findings without an
-# ignore-baseline) and the burndown took it 41 → 0 (level 5) then 372 → 0
-# (level 6, the bare-array value-type block) with every fix at the source
-# (no @phpstan-ignore, no baseline, no silencing casts; array shapes sourced
-# from the python reference / SWML schema / call sites). Levels 7-9 remain
-# gated only by a small residual of genuinely-ambiguous items (duck-typed
-# RELAY/serverless receivers tested via anonymous mock classes, and curl
-# CURLOPT_URL non-empty-string strictness) left for human triage — see the PR.
+# level 9 (the MAX level — full mixed-type strictness) with ZERO genuine
+# findings and NO ignore-baseline. The burndown took it 41 → 0 (level 5),
+# 372 → 0 (level 6, bare-array value-type block), then the three deferred
+# level-7+ item-groups were cleared at the source: duck-typed receivers got
+# minimal INTERNAL interfaces (Agent\AgentInterface for skills, Relay\
+# RelayClientLike for Call/Action, SWML\RequestHandlerLike for the serverless
+# Adapter — the TS RelayClientLike pattern); the FaxAction|T startAction return
+# got a genuine `assert($action instanceof $actionClass)` invariant; and the
+# curl CURLOPT_URL non-empty-string strictness was carried from its real source
+# (RestClient establishes non-empty baseUrl, HttpClient keeps the non-empty-
+# string type to the curl call) with a genuine empty-input guard at HttpHelper's
+# external entry. Level 8→9 then cleared ~375 mixed-narrowing findings, each
+# fixed by genuine runtime narrowing (is_string/is_array/...) or precise array
+# shapes sourced from the python reference / SWML schema — no @phpstan-ignore,
+# no baseline, no silencing casts, no mixed-widening.
 # Mirrors the go golangci / rust clippy blocking-lint gate.
 #
 # --memory-limit=512M: phpstan defaults to php.ini's memory_limit, which on a
-# stock CLI install is 128M — too low for a full level-6 analysis of src/ +
+# stock CLI install is 128M — too low for a full level-9 analysis of src/ +
 # scripts/ (it OOMs mid-run with "Result is incomplete because of severe
 # errors", not a real finding). Pin a generous limit so the gate's result
 # depends on the code, not the host php.ini. This is not a suppression: no
 # baseline, no @phpstan-ignore — the analysis still runs to completion at
-# level 6 and must report zero findings.
-run_gate "LINT" "phpstan level 6 zero findings (lint gate)" \
+# level 9 and must report zero findings.
+run_gate "LINT" "phpstan level 9 zero findings (lint gate)" \
     vendor/bin/phpstan analyse --no-progress --memory-limit=512M
 
 # Gate 9: DOC-AUDIT — every method/class referenced in docs/ + examples/ fenced

--- a/scripts/signature_dump.php
+++ b/scripts/signature_dump.php
@@ -15,6 +15,10 @@ declare(strict_types=1);
 require __DIR__ . '/../vendor/autoload.php';
 
 $root = realpath(__DIR__ . '/../src/SignalWire');
+if ($root === false) {
+    fwrite(STDERR, "Could not resolve src/SignalWire path\n");
+    exit(1);
+}
 $classes = [];
 $sourceFiles = [];
 $rii = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($root));
@@ -151,6 +155,16 @@ foreach ($declared['user'] as $fn) {
 
 echo json_encode($out, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES), "\n";
 
+/**
+ * @return array{
+ *     name: string,
+ *     is_constructor: bool,
+ *     is_static: bool,
+ *     parameters: list<array{name: string, type: string, has_default: bool, default: string|int|float|bool|array{}|null, is_variadic: bool, is_optional: bool, allows_null: bool}>,
+ *     return_type: string,
+ *     return_allows_null: bool
+ * }
+ */
 function methodEntry(ReflectionMethod $m, bool $isCtor): array
 {
     $declaringClass = $m->getDeclaringClass()->getName();
@@ -205,6 +219,10 @@ function typeString(?ReflectionType $t, ?string $declaringClass = null): string
     return (string) $t;
 }
 
+/**
+ * @param mixed $v
+ * @return string|int|float|bool|array{}|null
+ */
 function normaliseDefault($v)
 {
     if ($v === null) {

--- a/scripts/signature_dump.php
+++ b/scripts/signature_dump.php
@@ -23,6 +23,9 @@ $classes = [];
 $sourceFiles = [];
 $rii = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($root));
 foreach ($rii as $f) {
+    if (!$f instanceof SplFileInfo) {
+        continue;
+    }
     if ($f->isDir()) {
         continue;
     }
@@ -54,6 +57,17 @@ foreach ($classes as $fqcn) {
     // Existence is verified above, so ReflectionClass cannot throw here.
     $r = new ReflectionClass($fqcn);
     if ($r->isInternal()) {
+        continue;
+    }
+    // Skip @internal duck-type contracts (AgentInterface, RelayClientLike,
+    // RequestHandlerLike — the TS RelayClientLike pattern). They are consumed
+    // only internally and are NOT exported API, so they must not enter the
+    // cross-language signature comparison. References to them in other
+    // signatures are folded onto their canonical concrete class via the
+    // CLASS_RENAME_MAP in enumerate_surface.py (e.g. AgentInterface ->
+    // AgentBase) — a rename, not an omission.
+    $docComment = $r->getDocComment();
+    if ($docComment !== false && strpos($docComment, '@internal') !== false) {
         continue;
     }
 

--- a/src/SignalWire/Agent/AgentBase.php
+++ b/src/SignalWire/Agent/AgentBase.php
@@ -22,6 +22,7 @@ class AgentBase extends Service
 
     // ── Prompt / POM ────────────────────────────────────────────────────
     protected bool $usePom;
+    /** @var list<array<string,mixed>> */
     protected array $pomSections;
     protected string $promptText;
     protected string $postPrompt;
@@ -49,7 +50,9 @@ class AgentBase extends Service
     protected array $pronunciations;
 
     // ── Params / data ───────────────────────────────────────────────────
+    /** @var array<string,mixed> */
     protected array $params;
+    /** @var array<string,mixed> */
     protected array $globalData;
 
     // ── Native functions / fillers / debug ───────────────────────────────
@@ -66,7 +69,9 @@ class AgentBase extends Service
     protected ?string $debugEventsLevel;
 
     // ── LLM params ──────────────────────────────────────────────────────
+    /** @var array<string,mixed> */
     protected array $promptLlmParams;
+    /** @var array<string,mixed> */
     protected array $postPromptLlmParams;
 
     // ── Verbs ───────────────────────────────────────────────────────────
@@ -76,6 +81,7 @@ class AgentBase extends Service
     protected array $postAnswerVerbs;
     /** @var list<array{string, mixed}> */
     protected array $postAiVerbs;
+    /** @var array<string,mixed> */
     protected array $answerConfig;
 
     // ── Callbacks ───────────────────────────────────────────────────────
@@ -89,10 +95,11 @@ class AgentBase extends Service
     // ── Web / URLs ──────────────────────────────────────────────────────
     protected ?string $webhookUrl;
     protected ?string $postPromptUrl;
+    /** @var array<string,string> */
     protected array $swaigQueryParams;
 
     // ── Function includes ───────────────────────────────────────────────
-    /** @var list<array> */
+    /** @var list<array<string, mixed>> */
     protected array $functionIncludes;
 
     // ── Session / context / skills ──────────────────────────────────────
@@ -256,6 +263,8 @@ class AgentBase extends Service
 
     /**
      * Add a top-level POM section with an optional body and bullets.
+     *
+     * @param list<string> $bullets
      */
     public function promptAddSection(string $title, string $body, array $bullets = []): self
     {
@@ -316,6 +325,8 @@ class AgentBase extends Service
 
     /**
      * Append body text and/or bullets to an existing section.
+     *
+     * @param list<string> $bullets
      */
     public function promptAddToSection(string $title, ?string $body = null, array $bullets = []): self
     {
@@ -371,7 +382,7 @@ class AgentBase extends Service
     /**
      * Return the prompt payload: POM array if enabled and populated, otherwise raw text.
      *
-     * @return array|string
+     * @return list<array<string,mixed>>|string
      */
     public function getPrompt(): array|string
     {
@@ -414,6 +425,9 @@ class AgentBase extends Service
      *
      * Mirrors Python's PromptManager::set_prompt_pom — accepts a list of
      * section dicts and stores them in pomSections.
+     *
+     * @param list<mixed> $pom List of POM section arrays; non-array entries are
+     *                         defensively skipped by the loop below.
      */
     public function setPromptPom(array $pom): self
     {
@@ -459,6 +473,8 @@ class AgentBase extends Service
      *
      * Mirrors Python's PromptManager::get_contexts which returns the
      * contexts dict or None.
+     *
+     * @return array<string, array<string,mixed>>|null
      */
     public function getContexts(): ?array
     {
@@ -517,6 +533,9 @@ class AgentBase extends Service
         return $this;
     }
 
+    /**
+     * @param list<string> $hints
+     */
     public function addHints(array $hints): self
     {
         foreach ($hints as $hint) {
@@ -602,6 +621,9 @@ class AgentBase extends Service
         return null;
     }
 
+    /**
+     * @param list<array<string,mixed>> $languages
+     */
     public function setLanguages(array $languages): self
     {
         $this->languages = $languages;
@@ -621,6 +643,9 @@ class AgentBase extends Service
         return $this;
     }
 
+    /**
+     * @param list<array{replace: string, with: string, ignore?: string}> $pronunciations
+     */
     public function setPronunciations(array $pronunciations): self
     {
         $this->pronunciations = $pronunciations;
@@ -633,6 +658,9 @@ class AgentBase extends Service
         return $this;
     }
 
+    /**
+     * @param array<string,mixed> $params
+     */
     public function setParams(array $params): self
     {
         $this->params = $params;
@@ -646,6 +674,8 @@ class AgentBase extends Service
      * TypeScript reference (safeAssign) — skills and other callers each
      * contribute keys, so a replacing setGlobalData would silently clobber
      * their contributions.
+     *
+     * @param array<string,mixed> $data
      */
     public function setGlobalData(array $data): self
     {
@@ -653,12 +683,18 @@ class AgentBase extends Service
         return $this;
     }
 
+    /**
+     * @param array<string,mixed> $data
+     */
     public function updateGlobalData(array $data): self
     {
         $this->globalData = array_merge($this->globalData, $data);
         return $this;
     }
 
+    /**
+     * @param list<string> $functions
+     */
     public function setNativeFunctions(array $functions): self
     {
         $this->nativeFunctions = $functions;
@@ -710,6 +746,8 @@ class AgentBase extends Service
      * typo early.
      *
      * Expected format: ['function_name' => ['language_code' => ['phrase', ...]]]
+     *
+     * @param array<string, array<string, list<string>>> $fillers
      */
     public function setInternalFillers(array $fillers): self
     {
@@ -746,6 +784,8 @@ class AgentBase extends Service
      * See setInternalFillers() for the complete list of supported
      * function names and what fillers do. Names outside the supported
      * set log a warning.
+     *
+     * @param list<string>|null $fillers
      */
     public function addInternalFiller(string $filler_or_function, ?string $languageCode = null, ?array $fillers = null): self
     {
@@ -782,6 +822,9 @@ class AgentBase extends Service
         return $this;
     }
 
+    /**
+     * @param array<string, mixed> $include
+     */
     public function addFunctionInclude(array $include): self
     {
         $this->functionIncludes[] = $include;
@@ -795,6 +838,9 @@ class AgentBase extends Service
      * field; entries missing either are dropped (matching the TypeScript
      * reference's filter), and each dropped entry is warned so a malformed
      * include is caught at registration time rather than silently vanishing.
+     *
+     * @param list<mixed> $includes List of include arrays ({url, functions, ...});
+     *                              malformed / non-array entries are defensively dropped.
      */
     public function setFunctionIncludes(array $includes): self
     {
@@ -822,12 +868,18 @@ class AgentBase extends Service
         return $this;
     }
 
+    /**
+     * @param array<string,mixed> $params
+     */
     public function setPromptLlmParams(array $params): self
     {
         $this->promptLlmParams = $params;
         return $this;
     }
 
+    /**
+     * @param array<string,mixed> $params
+     */
     public function setPostPromptLlmParams(array $params): self
     {
         $this->postPromptLlmParams = $params;
@@ -955,6 +1007,8 @@ class AgentBase extends Service
 
     /**
      * Add a skill by name.
+     *
+     * @param array<string, mixed> $params
      */
     public function addSkill(SkillName|string $name, array $params = []): self
     {
@@ -968,6 +1022,9 @@ class AgentBase extends Service
         return $this;
     }
 
+    /**
+     * @return list<string>
+     */
     public function listSkills(): array
     {
         if ($this->skillManager === null) {
@@ -1025,6 +1082,9 @@ class AgentBase extends Service
         return $this;
     }
 
+    /**
+     * @param array<string,string> $params
+     */
     public function addSwaigQueryParams(array $params): self
     {
         $this->swaigQueryParams = array_merge($this->swaigQueryParams, $params);
@@ -1083,7 +1143,9 @@ class AgentBase extends Service
      *   5. AI verb
      *   6. Post-AI verbs
      *
-     * @return array The SWML document array.
+     * @param array<string, mixed>|null $requestBody
+     * @param array<string, string> $headers
+     * @return array<string, mixed> The SWML document array.
      */
     public function renderSwml(?array $requestBody = null, array $headers = []): array
     {
@@ -1131,6 +1193,9 @@ class AgentBase extends Service
 
     /**
      * Build the AI verb configuration block.
+     *
+     * @param array<string, string> $headers
+     * @return array<string, mixed>
      */
     public function buildAiVerb(array $headers = []): array
     {
@@ -1234,6 +1299,11 @@ class AgentBase extends Service
      * If a dynamic-config callback is registered, clone the agent, pass the
      * clone to the callback for customisation, and render from the clone.
      */
+    /**
+     * @param array<string, mixed>|null $requestData
+     * @param array<string, string> $headers
+     * @return array{int, array<string, string>, string}
+     */
     protected function handleSwmlRequest(string $method, ?array $requestData, array $headers): array
     {
         if ($this->dynamicConfigCallback !== null) {
@@ -1259,6 +1329,10 @@ class AgentBase extends Service
 
     /**
      * Handle the post-prompt callback.
+     *
+     * @param array<string, mixed>|null $requestData
+     * @param array<string, string> $headers
+     * @return array{int, array<string, string>, string}
      */
     protected function handlePostPrompt(?array $requestData, array $headers): array
     {
@@ -1325,6 +1399,9 @@ class AgentBase extends Service
 
     /**
      * Build the SWAIG block for the AI verb.
+     *
+     * @param array<string, string> $headers
+     * @return array<string, mixed>
      */
     private function buildSwaigBlock(array $headers): array
     {
@@ -1368,6 +1445,8 @@ class AgentBase extends Service
 
     /**
      * Build the authenticated SWAIG webhook URL with query params.
+     *
+     * @param array<string, string> $headers
      */
     private function buildSwaigWebhookUrl(array $headers): string
     {
@@ -1393,6 +1472,8 @@ class AgentBase extends Service
 
     /**
      * Resolve the proxy URL base, preferring manual override.
+     *
+     * @param array<string, string> $headers
      */
     private function resolveProxyBase(array $headers): string
     {
@@ -1404,6 +1485,10 @@ class AgentBase extends Service
 
     /**
      * Recursively deep-copy an array (handles nested arrays).
+     *
+     * @template T of array<array-key, mixed>
+     * @param T $array
+     * @return T
      */
     private function deepCopyArray(array $array): array
     {
@@ -1417,6 +1502,7 @@ class AgentBase extends Service
                 $copy[$key] = $value;
             }
         }
+        /** @var T $copy */
         return $copy;
     }
 }

--- a/src/SignalWire/Agent/AgentBase.php
+++ b/src/SignalWire/Agent/AgentBase.php
@@ -12,7 +12,17 @@ use SignalWire\Skills\SkillName;
 use SignalWire\SWML\Schema;
 use SignalWire\SWML\Service;
 
-class AgentBase extends Service
+/**
+ * @phpstan-type PomSection array{
+ *   title: string,
+ *   body?: string,
+ *   bullets?: list<string>,
+ *   numbered?: bool,
+ *   numberedBullets?: bool,
+ *   subsections?: list<array<string, mixed>>
+ * }
+ */
+class AgentBase extends Service implements AgentInterface
 {
     // ── Call handling ────────────────────────────────────────────────────
     protected bool $autoAnswer;
@@ -22,7 +32,7 @@ class AgentBase extends Service
 
     // ── Prompt / POM ────────────────────────────────────────────────────
     protected bool $usePom;
-    /** @var list<array<string,mixed>> */
+    /** @var list<PomSection> */
     protected array $pomSections;
     protected string $promptText;
     protected string $postPrompt;
@@ -105,7 +115,7 @@ class AgentBase extends Service
     // ── Session / context / skills ──────────────────────────────────────
     protected SessionManager $sessionManager;
     protected ?ContextBuilder $contextBuilder;
-    protected mixed $skillManager;
+    protected ?SkillManager $skillManager;
 
     // ── Proxy override ──────────────────────────────────────────────────
     protected ?string $manualProxyUrl = null;
@@ -266,7 +276,7 @@ class AgentBase extends Service
      *
      * @param list<string> $bullets
      */
-    public function promptAddSection(string $title, string $body, array $bullets = []): self
+    public function promptAddSection(string $title, string $body, array $bullets = []): static
     {
         $this->usePom = true;
 
@@ -434,11 +444,72 @@ class AgentBase extends Service
         $this->usePom      = true;
         $this->pomSections = [];
         foreach ($pom as $section) {
-            if (is_array($section)) {
-                $this->pomSections[] = $section;
+            if (!is_array($section)) {
+                continue;
+            }
+            $built = $this->normalizePomSection($section);
+            if ($built !== null) {
+                $this->pomSections[] = $built;
             }
         }
         return $this;
+    }
+
+    /**
+     * Coerce an externally-supplied section array into the internal
+     * PomSection shape, validating each recognised key at runtime. Sections
+     * without a string title are skipped (Python's renderer requires one).
+     *
+     * @param array<mixed, mixed> $section
+     * @return PomSection|null
+     */
+    private function normalizePomSection(array $section): ?array
+    {
+        $title = $section['title'] ?? null;
+        if (!is_string($title)) {
+            return null;
+        }
+        $out = ['title' => $title];
+
+        $body = $section['body'] ?? null;
+        if (is_string($body)) {
+            $out['body'] = $body;
+        }
+
+        $bullets = $section['bullets'] ?? null;
+        if (is_array($bullets)) {
+            $out['bullets'] = array_values(array_filter($bullets, 'is_string'));
+        }
+
+        $numbered = $section['numbered'] ?? null;
+        if (is_bool($numbered)) {
+            $out['numbered'] = $numbered;
+        }
+
+        $numberedBullets = $section['numberedBullets'] ?? ($section['numbered_bullets'] ?? null);
+        if (is_bool($numberedBullets)) {
+            $out['numberedBullets'] = $numberedBullets;
+        }
+
+        $subsections = $section['subsections'] ?? null;
+        if (is_array($subsections)) {
+            $subs = [];
+            foreach ($subsections as $sub) {
+                if (!is_array($sub)) {
+                    continue;
+                }
+                $subData = [];
+                foreach ($sub as $k => $v) {
+                    if (is_string($k)) {
+                        $subData[$k] = $v;
+                    }
+                }
+                $subs[] = $subData;
+            }
+            $out['subsections'] = $subs;
+        }
+
+        return $out;
     }
 
     /**
@@ -536,7 +607,7 @@ class AgentBase extends Service
     /**
      * @param list<string> $hints
      */
-    public function addHints(array $hints): self
+    public function addHints(array $hints): static
     {
         foreach ($hints as $hint) {
             $this->hints[] = (string) $hint;
@@ -615,7 +686,17 @@ class AgentBase extends Service
     {
         foreach ($this->languages as $language) {
             if (($language['code'] ?? null) === $code) {
-                return $language['params'] ?? null;
+                $params = $language['params'] ?? null;
+                if (!is_array($params)) {
+                    return null;
+                }
+                $out = [];
+                foreach ($params as $k => $v) {
+                    if (is_string($k)) {
+                        $out[$k] = $v;
+                    }
+                }
+                return $out;
             }
         }
         return null;
@@ -686,7 +767,7 @@ class AgentBase extends Service
     /**
      * @param array<string,mixed> $data
      */
-    public function updateGlobalData(array $data): self
+    public function updateGlobalData(array $data): static
     {
         $this->globalData = array_merge($this->globalData, $data);
         return $this;
@@ -1010,7 +1091,7 @@ class AgentBase extends Service
      *
      * @param array<string, mixed> $params
      */
-    public function addSkill(SkillName|string $name, array $params = []): self
+    public function addSkill(SkillName|string $name, array $params = []): static
     {
         $this->getSkillManager()->loadSkill($name instanceof SkillName ? $name->value : $name, $params);
         return $this;
@@ -1337,7 +1418,9 @@ class AgentBase extends Service
     protected function handlePostPrompt(?array $requestData, array $headers): array
     {
         if ($this->summaryCallback !== null && $requestData !== null) {
-            $summary = $requestData['post_prompt_data']['raw'] ?? $requestData['summary'] ?? '';
+            $postPromptData = $requestData['post_prompt_data'] ?? null;
+            $raw = is_array($postPromptData) ? ($postPromptData['raw'] ?? null) : null;
+            $summary = $raw ?? $requestData['summary'] ?? '';
 
             ($this->summaryCallback)($summary, $requestData, $headers);
         }

--- a/src/SignalWire/Agent/AgentInterface.php
+++ b/src/SignalWire/Agent/AgentInterface.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SignalWire\Agent;
+
+use SignalWire\Skills\SkillName;
+
+/**
+ * INTERNAL duck-type contract for the agent receiver that skills configure.
+ *
+ * This mirrors the TypeScript port's internal `RelayClientLike` pattern: it is
+ * NOT part of the public surface and is consumed only internally (by SkillBase,
+ * SkillManager, and the skill-dump harness's CapturingAgent). It declares
+ * EXACTLY the methods a skill invokes on its agent during setup/registerTools,
+ * with AgentBase's real signatures, so the duck-typed `$agent` receiver can be
+ * typed precisely without narrowing to the full AgentBase (which would break
+ * the SKILL-CONTRACT harness's lightweight CapturingAgent fake).
+ *
+ * Return types are declared as `static` (the late-static-bound implementing
+ * class) so that AgentBase (whose tool methods return `static` via Service) and
+ * CapturingAgent (returning itself) are both valid, PHP-compatible
+ * implementations — a `self`-typed interface return would reject Service's
+ * `static`-returning defineTool().
+ *
+ * @internal
+ */
+interface AgentInterface
+{
+    /**
+     * @param array<string, mixed> $params
+     */
+    public function addSkill(SkillName|string $name, array $params = []): static;
+
+    /**
+     * @param list<string> $hints
+     */
+    public function addHints(array $hints): static;
+
+    /**
+     * @param array<string, mixed> $parameters
+     */
+    public function defineTool(
+        string $name,
+        string $description,
+        array $parameters,
+        callable $handler,
+        bool $secure = false,
+    ): static;
+
+    /**
+     * @param list<string> $bullets
+     */
+    public function promptAddSection(string $title, string $body, array $bullets = []): static;
+
+    /**
+     * @param array<string, mixed> $funcDef
+     */
+    public function registerSwaigFunction(array $funcDef): static;
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    public function updateGlobalData(array $data): static;
+}

--- a/src/SignalWire/Contexts/ContextBuilder.php
+++ b/src/SignalWire/Contexts/ContextBuilder.php
@@ -187,7 +187,7 @@ class Step
     /** @var list<string>|null */
     private ?array $validContexts = null;
 
-    /** @var array<int, array<string, mixed>> */
+    /** @var list<array{title: string, body: string}|array{title: string, bullets: list<string>}> */
     private array $sections = [];
 
     private ?GatherInfo $gatherInfo = null;
@@ -600,11 +600,11 @@ class Context
     // Context prompt (plain text or POM)
     private ?string $promptText = null;
 
-    /** @var array<int, array<string, mixed>> */
+    /** @var list<array{title: string, body: string}|array{title: string, bullets: list<string>}> */
     private array $promptSections = [];
 
     // System prompt (plain text or POM)
-    /** @var array<int, array<string, mixed>> */
+    /** @var list<array{title: string, body: string}|array{title: string, bullets: list<string>}> */
     private array $systemPromptSections = [];
 
     // Fillers
@@ -984,7 +984,7 @@ class Context
     /**
      * Render POM sections to markdown text.
      *
-     * @param array<int, array<string, mixed>> $sections
+     * @param list<array{title: string, body: string}|array{title: string, bullets: list<string>}> $sections
      */
     private function renderSections(array $sections): string
     {
@@ -1341,8 +1341,9 @@ class ContextBuilder
         if ($this->toolNameSupplier !== null) {
             $registered = ($this->toolNameSupplier)();
             if (is_array($registered)) {
+                $registeredNames = array_values(array_filter($registered, 'is_string'));
                 $colliding = array_values(array_unique(array_intersect(
-                    $registered,
+                    $registeredNames,
                     RESERVED_NATIVE_TOOL_NAMES
                 )));
                 sort($colliding);

--- a/src/SignalWire/Contexts/ContextBuilder.php
+++ b/src/SignalWire/Contexts/ContextBuilder.php
@@ -31,6 +31,7 @@ class GatherQuestion
     private string $type;
     private bool $confirm;
     private ?string $prompt;
+    /** @var list<string>|null */
     private ?array $functions;
 
     /**
@@ -39,7 +40,7 @@ class GatherQuestion
      * @param string $type      JSON schema type for the answer (default 'string').
      * @param bool   $confirm   If true, the model must confirm the answer.
      * @param ?string $prompt   Extra instruction text appended after the question.
-     * @param ?array<string> $functions Functions to unlock for this question.
+     * @param list<string>|null $functions Functions to unlock for this question.
      */
     public function __construct(
         string $key,
@@ -62,6 +63,9 @@ class GatherQuestion
         return $this->key;
     }
 
+    /**
+     * @return array<string, mixed>
+     */
     public function toArray(): array
     {
         $map = [
@@ -111,7 +115,7 @@ class GatherInfo
      *
      * @param string $key       Key name for storing the answer in global_data.
      * @param string $question  The question text to ask.
-     * @param array{type?:string,confirm?:bool,prompt?:?string,functions?:?array<string>} $kwargs
+     * @param array{type?:string,confirm?:bool,prompt?:?string,functions?:?list<string>} $kwargs
      *                          Optional named arguments forwarded to GatherQuestion.
      */
     public function addQuestion(string $key, string $question, array $kwargs = []): self
@@ -140,6 +144,9 @@ class GatherInfo
         return $this->completionAction;
     }
 
+    /**
+     * @return array<string, mixed>
+     */
     public function toArray(): array
     {
         $map = [];
@@ -172,10 +179,12 @@ class Step
     private ?string $text = null;
     private ?string $stepCriteria = null;
 
-    /** @var string|array|null */
+    /** @var list<string>|string|null */
     private $functions = null;
 
+    /** @var list<string>|null */
     private ?array $validSteps = null;
+    /** @var list<string>|null */
     private ?array $validContexts = null;
 
     /** @var array<int, array<string, mixed>> */
@@ -234,6 +243,8 @@ class Step
 
     /**
      * Add a POM section with bullet points.
+     *
+     * @param list<string> $bullets
      */
     public function addBullets(string $title, array $bullets): self
     {
@@ -289,8 +300,8 @@ class Step
      * used; they are not affected by this list and do not need to
      * appear in it.
      *
-     * @param string|array $functions One of:
-     *   - array<string> — whitelist of function names allowed in this step
+     * @param list<string>|string $functions One of:
+     *   - list<string> — whitelist of function names allowed in this step
      *   - []            — explicit disable-all
      *   - 'none'        — synonym for []
      */
@@ -300,12 +311,18 @@ class Step
         return $this;
     }
 
+    /**
+     * @param list<string> $steps
+     */
     public function setValidSteps(array $steps): self
     {
         $this->validSteps = $steps;
         return $this;
     }
 
+    /**
+     * @param list<string> $contexts
+     */
     public function setValidContexts(array $contexts): self
     {
         $this->validContexts = $contexts;
@@ -388,6 +405,8 @@ class Step
      *   email, geocode a ZIP), list that tool name in this question's
      *   'functions' option. Functions listed here are active ONLY for
      *   this question.
+     *
+     * @param list<string>|null $functions
      */
     public function addGatherQuestion(
         string $key,
@@ -437,11 +456,17 @@ class Step
 
     // ── Package-level accessors for validation ──────────────────────────
 
+    /**
+     * @return list<string>|null
+     */
     public function getValidSteps(): ?array
     {
         return $this->validSteps;
     }
 
+    /**
+     * @return list<string>|null
+     */
     public function getValidContexts(): ?array
     {
         return $this->validContexts;
@@ -486,6 +511,9 @@ class Step
         return rtrim(implode("\n", $parts));
     }
 
+    /**
+     * @return array<string, mixed>
+     */
     public function toArray(): array
     {
         $map = [
@@ -555,7 +583,9 @@ class Context
     /** @var string[] */
     private array $stepOrder = [];
 
+    /** @var list<string>|null */
     private ?array $validContexts = null;
+    /** @var list<string>|null */
     private ?array $validSteps = null;
     private ?string $initialStep = null;
 
@@ -605,13 +635,13 @@ class Context
      *
      * @param string $name       Step name (must be unique within the context).
      * @param ?string $task      Text for the "Task" section (≡ addSection("Task", $task)).
-     * @param ?array<string> $bullets List of bullet strings for the "Process"
+     * @param ?list<string> $bullets List of bullet strings for the "Process"
      *                           section (≡ addBullets("Process", $bullets)).
      *                           Requires $task to also be set.
      * @param ?string $criteria  Step-completion criteria (≡ setStepCriteria()).
-     * @param string|array<string>|null $functions Tool names the step may call,
+     * @param string|list<string>|null $functions Tool names the step may call,
      *                           or 'none' (≡ setFunctions()).
-     * @param ?array<string> $valid_steps Names of steps the agent may
+     * @param ?list<string> $valid_steps Names of steps the agent may
      *                           transition to (≡ setValidSteps()).
      *
      * @return Step The configured Step object for optional further chaining.
@@ -712,6 +742,9 @@ class Context
         return $this;
     }
 
+    /**
+     * @param list<string> $bullets
+     */
     public function addBullets(string $title, array $bullets): self
     {
         if ($this->promptText !== null) {
@@ -747,6 +780,9 @@ class Context
         return $this;
     }
 
+    /**
+     * @param list<string> $bullets
+     */
     public function addSystemBullets(string $title, array $bullets): self
     {
         if ($this->systemPrompt !== null) {
@@ -779,12 +815,18 @@ class Context
         return $this->initialStep;
     }
 
+    /**
+     * @param list<string> $contexts
+     */
     public function setValidContexts(array $contexts): self
     {
         $this->validContexts = $contexts;
         return $this;
     }
 
+    /**
+     * @param list<string> $steps
+     */
     public function setValidSteps(array $steps): self
     {
         $this->validSteps = $steps;
@@ -929,6 +971,9 @@ class Context
         return $this->stepOrder;
     }
 
+    /**
+     * @return list<string>|null
+     */
     public function getValidContexts(): ?array
     {
         return $this->validContexts;
@@ -938,6 +983,8 @@ class Context
 
     /**
      * Render POM sections to markdown text.
+     *
+     * @param array<int, array<string, mixed>> $sections
      */
     private function renderSections(array $sections): string
     {
@@ -962,6 +1009,9 @@ class Context
 
     // ── Serialization ───────────────────────────────────────────────────
 
+    /**
+     * @return array<string, mixed>
+     */
     public function toArray(): array
     {
         $map = [];
@@ -1315,6 +1365,8 @@ class ContextBuilder
 
     /**
      * Serialize all contexts in order. Validates before converting.
+     *
+     * @return array<string, array<string, mixed>>
      */
     public function toArray(): array
     {

--- a/src/SignalWire/DataMap/DataMap.php
+++ b/src/SignalWire/DataMap/DataMap.php
@@ -373,7 +373,7 @@ class DataMap
      * Build a complete SWAIG function definition with expressions only.
      *
      * @param array<array{name: string, type: string, description: string, required?: bool, enum?: array<string>}> $parameters
-     * @param list<array<string, mixed>> $expressions
+     * @param list<array{string: string, pattern: string, output: mixed, nomatch_output?: mixed}> $expressions
      * @return array<string, mixed>
      */
     public static function createExpressionTool(

--- a/src/SignalWire/Logging/Logger.php
+++ b/src/SignalWire/Logging/Logger.php
@@ -13,6 +13,7 @@ class Logger
         'error' => 3,
     ];
 
+    /** @var array<string, self> */
     private static array $instances = [];
 
     private string $name;

--- a/src/SignalWire/POM/PromptObjectModel.php
+++ b/src/SignalWire/POM/PromptObjectModel.php
@@ -80,7 +80,7 @@ class PromptObjectModel
      *   - subsequent (non-first) top-level sections without ``title`` are
      *     auto-titled "Untitled Section" (Python parity)
      *
-     * @param array<int, mixed> $data
+     * @param array<array-key, mixed> $data
      */
     private static function fromArray(array $data): PromptObjectModel
     {

--- a/src/SignalWire/POM/PromptObjectModel.php
+++ b/src/SignalWire/POM/PromptObjectModel.php
@@ -148,7 +148,13 @@ class PromptObjectModel
             if (!is_array($sub)) {
                 throw new \InvalidArgumentException('Each subsection must be a dictionary.');
             }
-            $section->subsections[] = self::buildSection($sub, true);
+            $subData = [];
+            foreach ($sub as $k => $v) {
+                if (is_string($k)) {
+                    $subData[$k] = $v;
+                }
+            }
+            $section->subsections[] = self::buildSection($subData, true);
         }
 
         return $section;
@@ -453,7 +459,16 @@ class PromptObjectModel
         if (is_int($val) || is_float($val)) {
             return (string) $val;
         }
-        $s = (string) $val;
+        if (is_string($val)) {
+            $s = $val;
+        } elseif (is_object($val) && method_exists($val, '__toString')) {
+            $s = (string) $val;
+        } else {
+            // Arrays/objects are not scalars; emit a JSON representation so the
+            // YAML stays well-formed rather than fataling on a cast.
+            $encoded = json_encode($val);
+            $s = $encoded === false ? '' : $encoded;
+        }
         // Quote if contains characters that would confuse the parser, OR
         // looks like a YAML special token (true/false/null/numeric/etc).
         if (self::needsYamlQuote($s)) {

--- a/src/SignalWire/POM/Section.php
+++ b/src/SignalWire/POM/Section.php
@@ -58,10 +58,23 @@ class Section
         if ($bullets !== null && !is_array($bullets)) {
             throw new \InvalidArgumentException('bullets must be a list or null');
         }
-        $this->bullets = $bullets === null ? [] : array_values($bullets);
+        $normalizedBullets = [];
+        if ($bullets !== null) {
+            foreach ($bullets as $b) {
+                if (!is_string($b)) {
+                    throw new \InvalidArgumentException('bullets must contain only strings');
+                }
+                $normalizedBullets[] = $b;
+            }
+        }
+        $this->bullets = $normalizedBullets;
 
         $this->subsections = [];
-        $this->numbered = $params['numbered'] ?? null;
+        $numbered = $params['numbered'] ?? null;
+        if ($numbered !== null && !is_bool($numbered)) {
+            throw new \InvalidArgumentException('numbered must be a bool or null');
+        }
+        $this->numbered = $numbered;
         $this->numberedBullets = (bool) ($params['numberedBullets'] ?? false);
     }
 

--- a/src/SignalWire/Prefabs/ConciergeAgent.php
+++ b/src/SignalWire/Prefabs/ConciergeAgent.php
@@ -27,7 +27,7 @@ class ConciergeAgent extends AgentBase
 
     /**
      * @param string $name Agent name
-     * @param array $venueInfo Venue information: venue_name (required), services, amenities,
+     * @param array<string,mixed> $venueInfo Venue information: venue_name (required), services, amenities,
      *                         hours_of_operation, special_instructions, welcome_message
      * @param string $route
      * @param string|null $host
@@ -192,7 +192,7 @@ class ConciergeAgent extends AgentBase
     }
 
     /**
-     * @return array<string, array>
+     * @return array<string, array{hours?: string, location?: string}>
      */
     public function getAmenities(): array
     {

--- a/src/SignalWire/Prefabs/ConciergeAgent.php
+++ b/src/SignalWire/Prefabs/ConciergeAgent.php
@@ -50,12 +50,59 @@ class ConciergeAgent extends AgentBase
         bool $recordCall = false,
         bool $usePom = true,
     ) {
-        $this->venueName           = $venueInfo['venue_name'];
-        $this->services            = $venueInfo['services'] ?? [];
-        $this->amenities           = $venueInfo['amenities'] ?? [];
-        $this->hoursOfOperation    = $venueInfo['hours_of_operation'] ?? [];
-        $this->specialInstructions = $venueInfo['special_instructions'] ?? [];
-        $this->welcomeMessage      = $venueInfo['welcome_message'] ?? null;
+        $venueName = $venueInfo['venue_name'] ?? '';
+        $this->venueName = is_string($venueName) ? $venueName : '';
+
+        $services = $venueInfo['services'] ?? [];
+        $this->services = [];
+        if (is_array($services)) {
+            foreach ($services as $service) {
+                if (is_string($service)) {
+                    $this->services[] = $service;
+                }
+            }
+        }
+
+        $amenities = $venueInfo['amenities'] ?? [];
+        $this->amenities = [];
+        if (is_array($amenities)) {
+            foreach ($amenities as $amenityName => $info) {
+                if (!is_string($amenityName) || !is_array($info)) {
+                    continue;
+                }
+                $entry = [];
+                if (isset($info['hours']) && is_string($info['hours'])) {
+                    $entry['hours'] = $info['hours'];
+                }
+                if (isset($info['location']) && is_string($info['location'])) {
+                    $entry['location'] = $info['location'];
+                }
+                $this->amenities[$amenityName] = $entry;
+            }
+        }
+
+        $hours = $venueInfo['hours_of_operation'] ?? [];
+        $this->hoursOfOperation = [];
+        if (is_array($hours)) {
+            foreach ($hours as $day => $value) {
+                if (is_string($day) && is_string($value)) {
+                    $this->hoursOfOperation[$day] = $value;
+                }
+            }
+        }
+
+        $instructions = $venueInfo['special_instructions'] ?? [];
+        $this->specialInstructions = [];
+        if (is_array($instructions)) {
+            foreach ($instructions as $instruction) {
+                if (is_string($instruction)) {
+                    $this->specialInstructions[] = $instruction;
+                }
+            }
+        }
+
+        $welcomeMessage = $venueInfo['welcome_message'] ?? null;
+        $this->welcomeMessage = is_string($welcomeMessage) ? $welcomeMessage : null;
 
         $name = $name !== '' ? $name : 'concierge';
 

--- a/src/SignalWire/Prefabs/FAQBotAgent.php
+++ b/src/SignalWire/Prefabs/FAQBotAgent.php
@@ -108,7 +108,7 @@ class FAQBotAgent extends AgentBase
                     return new FunctionResult('Please provide a search query.');
                 }
 
-                $keywords = preg_split('/\s+/', $query);
+                $keywords = preg_split('/\s+/', $query) ?: [];
 
                 // Score each FAQ by keyword matches
                 $scored = [];

--- a/src/SignalWire/REST/HttpClient.php
+++ b/src/SignalWire/REST/HttpClient.php
@@ -27,6 +27,8 @@ class HttpClient
      * Path to a CA bundle (PEM) used to verify the server certificate over
      * HTTPS, or null to use cURL's default trust store. TLS peer verification
      * is always on (cURL's default); this only selects which CA to trust.
+     *
+     * @var non-empty-string|null
      */
     private ?string $caBundle;
 
@@ -48,6 +50,9 @@ class HttpClient
      * Resolve the effective CA bundle: explicit arg wins, otherwise the
      * SIGNALWIRE_CA_FILE then SSL_CERT_FILE env vars (which cURL itself does
      * not consult), otherwise null (cURL's built-in default store).
+     */
+    /**
+     * @return non-empty-string|null
      */
     private static function resolveCaBundle(?string $explicit): ?string
     {
@@ -88,7 +93,8 @@ class HttpClient
     // -----------------------------------------------------------------
 
     /**
-     * @param array<string,string> $params Query-string parameters.
+     * @param array<string,mixed> $params Query-string parameters (scalars are
+     *   url-encoded; nested arrays use PHP's bracketed query syntax).
      * @return array<string,mixed>
      */
     public function get(string $path, array $params = []): array
@@ -141,7 +147,7 @@ class HttpClient
      * Expects the API to return `{ "data": [...], "links": { "next": "..." } }`
      * or similar paginated envelope.  Each yield is one page (array of items).
      *
-     * @param array<string,string> $params Initial query-string parameters.
+     * @param array<string,mixed> $params Initial query-string parameters.
      * @return \Generator<int,array<string,mixed>>
      */
     public function listAll(string $path, array $params = []): \Generator
@@ -169,13 +175,31 @@ class HttpClient
             if (str_starts_with($nextUrl, 'http')) {
                 $parsed = parse_url($nextUrl);
                 $currentPath = $parsed['path'] ?? '';
-                parse_str($parsed['query'] ?? '', $currentParams);
+                $currentParams = self::parseQuery($parsed['query'] ?? '');
             } else {
                 $parts = explode('?', $nextUrl, 2);
                 $currentPath = $parts[0];
-                parse_str($parts[1] ?? '', $currentParams);
+                $currentParams = self::parseQuery($parts[1] ?? '');
             }
         }
+    }
+
+    /**
+     * Parse a query string into a string-keyed parameter map. parse_str() can
+     * yield integer top-level keys (e.g. "0=x"); normalise them to strings so
+     * the result matches the query-param contract.
+     *
+     * @return array<string, mixed>
+     */
+    private static function parseQuery(string $query): array
+    {
+        $parsed = [];
+        parse_str($query, $parsed);
+        $out = [];
+        foreach ($parsed as $k => $v) {
+            $out[(string) $k] = $v;
+        }
+        return $out;
     }
 
     // -----------------------------------------------------------------
@@ -183,7 +207,7 @@ class HttpClient
     // -----------------------------------------------------------------
 
     /**
-     * @param array<string,string> $params  Query-string parameters.
+     * @param array<string,mixed> $params  Query-string parameters.
      * @param array<string,mixed>|null $body JSON body (for POST/PUT/PATCH).
      * @return array<string,mixed>
      * @throws SignalWireRestError on non-2xx responses.
@@ -224,7 +248,11 @@ class HttpClient
         }
 
         if ($body !== null && in_array($method, ['POST', 'PUT', 'PATCH'], true)) {
-            curl_setopt($ch, CURLOPT_POSTFIELDS, json_encode($body));
+            $encodedBody = json_encode($body);
+            if ($encodedBody === false) {
+                throw new \RuntimeException('json_encode failed for request body');
+            }
+            curl_setopt($ch, CURLOPT_POSTFIELDS, $encodedBody);
         }
 
         $responseBody = curl_exec($ch);

--- a/src/SignalWire/REST/HttpClient.php
+++ b/src/SignalWire/REST/HttpClient.php
@@ -14,6 +14,7 @@ class HttpClient
 {
     private string $projectId;
     private string $token;
+    /** @var non-empty-string */
     private string $baseUrl;
     private string $authHeader;
 
@@ -33,6 +34,8 @@ class HttpClient
     private ?string $caBundle;
 
     /**
+     * @param non-empty-string $baseUrl Fully-qualified API base URL (the caller,
+     *   RestClient, guarantees this is non-empty at its source).
      * @param string|null $caBundle Optional CA bundle (PEM) for HTTPS peer
      *   verification. Falls back to the SIGNALWIRE_CA_FILE / SSL_CERT_FILE
      *   env vars (PHP's cURL does not honor those env vars on its own).
@@ -41,7 +44,12 @@ class HttpClient
     {
         $this->projectId = $projectId;
         $this->token = $token;
-        $this->baseUrl = rtrim($baseUrl, '/');
+        $trimmedBaseUrl = rtrim($baseUrl, '/');
+        // rtrim only strips trailing '/', and $baseUrl is non-empty by the
+        // caller's contract; PHPStan cannot infer non-empty through rtrim, so
+        // carry the true invariant forward.
+        assert($trimmedBaseUrl !== '');
+        $this->baseUrl = $trimmedBaseUrl;
         $this->authHeader = 'Basic ' . base64_encode($projectId . ':' . $token);
         $this->caBundle = self::resolveCaBundle($caBundle);
     }
@@ -162,20 +170,25 @@ class HttpClient
             // Yield the items from the current page.
             $data = $response['data'] ?? $response;
             if (is_array($data)) {
-                yield $data;
+                $page = [];
+                foreach ($data as $key => $value) {
+                    $page[(string) $key] = $value;
+                }
+                yield $page;
             }
 
             // Determine if there is a next page.
-            $nextUrl = $response['links']['next'] ?? null;
-            if ($nextUrl === null) {
+            $links = $response['links'] ?? null;
+            $nextUrl = is_array($links) ? ($links['next'] ?? null) : null;
+            if (!is_string($nextUrl)) {
                 break;
             }
 
             // The next URL may be absolute or path-only. Strip the base if absolute.
             if (str_starts_with($nextUrl, 'http')) {
                 $parsed = parse_url($nextUrl);
-                $currentPath = $parsed['path'] ?? '';
-                $currentParams = self::parseQuery($parsed['query'] ?? '');
+                $currentPath = is_array($parsed) ? ($parsed['path'] ?? '') : '';
+                $currentParams = self::parseQuery(is_array($parsed) ? ($parsed['query'] ?? '') : '');
             } else {
                 $parts = explode('?', $nextUrl, 2);
                 $currentPath = $parts[0];
@@ -207,6 +220,7 @@ class HttpClient
     // -----------------------------------------------------------------
 
     /**
+     * @param non-empty-string $method HTTP verb (GET/POST/PUT/PATCH/DELETE).
      * @param array<string,mixed> $params  Query-string parameters.
      * @param array<string,mixed>|null $body JSON body (for POST/PUT/PATCH).
      * @return array<string,mixed>
@@ -289,6 +303,13 @@ class HttpClient
             return ['raw' => (string) $responseBody];
         }
 
-        return $decoded;
+        // A decoded JSON object has string keys; a top-level JSON array has
+        // integer keys. Normalise to string keys to honour the contract.
+        $result = [];
+        foreach ($decoded as $key => $value) {
+            $result[(string) $key] = $value;
+        }
+
+        return $result;
     }
 }

--- a/src/SignalWire/REST/Namespaces/Addresses.php
+++ b/src/SignalWire/REST/Namespaces/Addresses.php
@@ -24,13 +24,19 @@ class Addresses
         return $this->basePath;
     }
 
-    /** @param array<string,mixed> $params @return array<string,mixed> */
+    /**
+     * @param array<string,mixed> $params
+     * @return array<string,mixed>
+     */
     public function list(array $params = []): array
     {
         return $this->http->get($this->basePath, $params);
     }
 
-    /** @param array<string,mixed> $body @return array<string,mixed> */
+    /**
+     * @param array<string,mixed> $body
+     * @return array<string,mixed>
+     */
     public function create(array $body): array
     {
         return $this->http->post($this->basePath, $body);

--- a/src/SignalWire/REST/Namespaces/Calling.php
+++ b/src/SignalWire/REST/Namespaces/Calling.php
@@ -71,7 +71,10 @@ class Calling
     // Call lifecycle (5)
     // -----------------------------------------------------------------
 
-    /** @param array<string,mixed> $params */
+    /**
+     * @param array<string,mixed> $params
+     * @return array<string,mixed>
+     */
     public function dial(array $params = []): array
     {
         return $this->execute('dial', null, $params);
@@ -83,25 +86,35 @@ class Calling
      * ``CallingNamespace.update(**params)``.
      *
      * @param array<string,mixed> $params
+     * @return array<string,mixed>
      */
     public function update(array $params = []): array
     {
         return $this->execute('update', null, $params);
     }
 
-    /** @param array<string,mixed> $params */
+    /**
+     * @param array<string,mixed> $params
+     * @return array<string,mixed>
+     */
     public function end(string $callId, array $params = []): array
     {
         return $this->execute('calling.end', $callId, $params);
     }
 
-    /** @param array<string,mixed> $params */
+    /**
+     * @param array<string,mixed> $params
+     * @return array<string,mixed>
+     */
     public function transfer(string $callId, array $params = []): array
     {
         return $this->execute('calling.transfer', $callId, $params);
     }
 
-    /** @param array<string,mixed> $params */
+    /**
+     * @param array<string,mixed> $params
+     * @return array<string,mixed>
+     */
     public function disconnect(string $callId, array $params = []): array
     {
         return $this->execute('calling.disconnect', $callId, $params);
@@ -111,31 +124,46 @@ class Calling
     // Play (5)
     // -----------------------------------------------------------------
 
-    /** @param array<string,mixed> $params */
+    /**
+     * @param array<string,mixed> $params
+     * @return array<string,mixed>
+     */
     public function play(string $callId, array $params = []): array
     {
         return $this->execute('calling.play', $callId, $params);
     }
 
-    /** @param array<string,mixed> $params */
+    /**
+     * @param array<string,mixed> $params
+     * @return array<string,mixed>
+     */
     public function playPause(string $callId, array $params = []): array
     {
         return $this->execute('calling.play.pause', $callId, $params);
     }
 
-    /** @param array<string,mixed> $params */
+    /**
+     * @param array<string,mixed> $params
+     * @return array<string,mixed>
+     */
     public function playResume(string $callId, array $params = []): array
     {
         return $this->execute('calling.play.resume', $callId, $params);
     }
 
-    /** @param array<string,mixed> $params */
+    /**
+     * @param array<string,mixed> $params
+     * @return array<string,mixed>
+     */
     public function playStop(string $callId, array $params = []): array
     {
         return $this->execute('calling.play.stop', $callId, $params);
     }
 
-    /** @param array<string,mixed> $params */
+    /**
+     * @param array<string,mixed> $params
+     * @return array<string,mixed>
+     */
     public function playVolume(string $callId, array $params = []): array
     {
         return $this->execute('calling.play.volume', $callId, $params);
@@ -145,25 +173,37 @@ class Calling
     // Record (4)
     // -----------------------------------------------------------------
 
-    /** @param array<string,mixed> $params */
+    /**
+     * @param array<string,mixed> $params
+     * @return array<string,mixed>
+     */
     public function record(string $callId, array $params = []): array
     {
         return $this->execute('calling.record', $callId, $params);
     }
 
-    /** @param array<string,mixed> $params */
+    /**
+     * @param array<string,mixed> $params
+     * @return array<string,mixed>
+     */
     public function recordPause(string $callId, array $params = []): array
     {
         return $this->execute('calling.record.pause', $callId, $params);
     }
 
-    /** @param array<string,mixed> $params */
+    /**
+     * @param array<string,mixed> $params
+     * @return array<string,mixed>
+     */
     public function recordResume(string $callId, array $params = []): array
     {
         return $this->execute('calling.record.resume', $callId, $params);
     }
 
-    /** @param array<string,mixed> $params */
+    /**
+     * @param array<string,mixed> $params
+     * @return array<string,mixed>
+     */
     public function recordStop(string $callId, array $params = []): array
     {
         return $this->execute('calling.record.stop', $callId, $params);
@@ -173,19 +213,28 @@ class Calling
     // Collect (3)
     // -----------------------------------------------------------------
 
-    /** @param array<string,mixed> $params */
+    /**
+     * @param array<string,mixed> $params
+     * @return array<string,mixed>
+     */
     public function collect(string $callId, array $params = []): array
     {
         return $this->execute('calling.collect', $callId, $params);
     }
 
-    /** @param array<string,mixed> $params */
+    /**
+     * @param array<string,mixed> $params
+     * @return array<string,mixed>
+     */
     public function collectStop(string $callId, array $params = []): array
     {
         return $this->execute('calling.collect.stop', $callId, $params);
     }
 
-    /** @param array<string,mixed> $params */
+    /**
+     * @param array<string,mixed> $params
+     * @return array<string,mixed>
+     */
     public function collectStartInputTimers(string $callId, array $params = []): array
     {
         return $this->execute('calling.collect.start_input_timers', $callId, $params);
@@ -195,13 +244,19 @@ class Calling
     // Detect (2)
     // -----------------------------------------------------------------
 
-    /** @param array<string,mixed> $params */
+    /**
+     * @param array<string,mixed> $params
+     * @return array<string,mixed>
+     */
     public function detect(string $callId, array $params = []): array
     {
         return $this->execute('calling.detect', $callId, $params);
     }
 
-    /** @param array<string,mixed> $params */
+    /**
+     * @param array<string,mixed> $params
+     * @return array<string,mixed>
+     */
     public function detectStop(string $callId, array $params = []): array
     {
         return $this->execute('calling.detect.stop', $callId, $params);
@@ -211,13 +266,19 @@ class Calling
     // Tap (2)
     // -----------------------------------------------------------------
 
-    /** @param array<string,mixed> $params */
+    /**
+     * @param array<string,mixed> $params
+     * @return array<string,mixed>
+     */
     public function tap(string $callId, array $params = []): array
     {
         return $this->execute('calling.tap', $callId, $params);
     }
 
-    /** @param array<string,mixed> $params */
+    /**
+     * @param array<string,mixed> $params
+     * @return array<string,mixed>
+     */
     public function tapStop(string $callId, array $params = []): array
     {
         return $this->execute('calling.tap.stop', $callId, $params);
@@ -227,13 +288,19 @@ class Calling
     // Stream (2)
     // -----------------------------------------------------------------
 
-    /** @param array<string,mixed> $params */
+    /**
+     * @param array<string,mixed> $params
+     * @return array<string,mixed>
+     */
     public function stream(string $callId, array $params = []): array
     {
         return $this->execute('calling.stream', $callId, $params);
     }
 
-    /** @param array<string,mixed> $params */
+    /**
+     * @param array<string,mixed> $params
+     * @return array<string,mixed>
+     */
     public function streamStop(string $callId, array $params = []): array
     {
         return $this->execute('calling.stream.stop', $callId, $params);
@@ -243,13 +310,19 @@ class Calling
     // Denoise (2)
     // -----------------------------------------------------------------
 
-    /** @param array<string,mixed> $params */
+    /**
+     * @param array<string,mixed> $params
+     * @return array<string,mixed>
+     */
     public function denoise(string $callId, array $params = []): array
     {
         return $this->execute('calling.denoise', $callId, $params);
     }
 
-    /** @param array<string,mixed> $params */
+    /**
+     * @param array<string,mixed> $params
+     * @return array<string,mixed>
+     */
     public function denoiseStop(string $callId, array $params = []): array
     {
         return $this->execute('calling.denoise.stop', $callId, $params);
@@ -259,13 +332,19 @@ class Calling
     // Transcribe (2)
     // -----------------------------------------------------------------
 
-    /** @param array<string,mixed> $params */
+    /**
+     * @param array<string,mixed> $params
+     * @return array<string,mixed>
+     */
     public function transcribe(string $callId, array $params = []): array
     {
         return $this->execute('calling.transcribe', $callId, $params);
     }
 
-    /** @param array<string,mixed> $params */
+    /**
+     * @param array<string,mixed> $params
+     * @return array<string,mixed>
+     */
     public function transcribeStop(string $callId, array $params = []): array
     {
         return $this->execute('calling.transcribe.stop', $callId, $params);
@@ -275,25 +354,37 @@ class Calling
     // AI (4)
     // -----------------------------------------------------------------
 
-    /** @param array<string,mixed> $params */
+    /**
+     * @param array<string,mixed> $params
+     * @return array<string,mixed>
+     */
     public function aiMessage(string $callId, array $params = []): array
     {
         return $this->execute('calling.ai_message', $callId, $params);
     }
 
-    /** @param array<string,mixed> $params */
+    /**
+     * @param array<string,mixed> $params
+     * @return array<string,mixed>
+     */
     public function aiHold(string $callId, array $params = []): array
     {
         return $this->execute('calling.ai_hold', $callId, $params);
     }
 
-    /** @param array<string,mixed> $params */
+    /**
+     * @param array<string,mixed> $params
+     * @return array<string,mixed>
+     */
     public function aiUnhold(string $callId, array $params = []): array
     {
         return $this->execute('calling.ai_unhold', $callId, $params);
     }
 
-    /** @param array<string,mixed> $params */
+    /**
+     * @param array<string,mixed> $params
+     * @return array<string,mixed>
+     */
     public function aiStop(string $callId, array $params = []): array
     {
         return $this->execute('calling.ai.stop', $callId, $params);
@@ -303,13 +394,19 @@ class Calling
     // Live transcribe / translate (2)
     // -----------------------------------------------------------------
 
-    /** @param array<string,mixed> $params */
+    /**
+     * @param array<string,mixed> $params
+     * @return array<string,mixed>
+     */
     public function liveTranscribe(string $callId, array $params = []): array
     {
         return $this->execute('calling.live_transcribe', $callId, $params);
     }
 
-    /** @param array<string,mixed> $params */
+    /**
+     * @param array<string,mixed> $params
+     * @return array<string,mixed>
+     */
     public function liveTranslate(string $callId, array $params = []): array
     {
         return $this->execute('calling.live_translate', $callId, $params);
@@ -319,13 +416,19 @@ class Calling
     // Fax (2)
     // -----------------------------------------------------------------
 
-    /** @param array<string,mixed> $params */
+    /**
+     * @param array<string,mixed> $params
+     * @return array<string,mixed>
+     */
     public function sendFaxStop(string $callId, array $params = []): array
     {
         return $this->execute('calling.send_fax.stop', $callId, $params);
     }
 
-    /** @param array<string,mixed> $params */
+    /**
+     * @param array<string,mixed> $params
+     * @return array<string,mixed>
+     */
     public function receiveFaxStop(string $callId, array $params = []): array
     {
         return $this->execute('calling.receive_fax.stop', $callId, $params);
@@ -335,7 +438,10 @@ class Calling
     // SIP (1)
     // -----------------------------------------------------------------
 
-    /** @param array<string,mixed> $params */
+    /**
+     * @param array<string,mixed> $params
+     * @return array<string,mixed>
+     */
     public function refer(string $callId, array $params = []): array
     {
         return $this->execute('calling.refer', $callId, $params);
@@ -345,7 +451,10 @@ class Calling
     // Custom events (1)
     // -----------------------------------------------------------------
 
-    /** @param array<string,mixed> $params */
+    /**
+     * @param array<string,mixed> $params
+     * @return array<string,mixed>
+     */
     public function userEvent(string $callId, array $params = []): array
     {
         return $this->execute('calling.user_event', $callId, $params);

--- a/src/SignalWire/REST/Namespaces/CompatConferences.php
+++ b/src/SignalWire/REST/Namespaces/CompatConferences.php
@@ -25,7 +25,10 @@ class CompatConferences
         return $this->basePath;
     }
 
-    /** @param array<string,mixed> $params @return array<string,mixed> */
+    /**
+     * @param array<string,mixed> $params
+     * @return array<string,mixed>
+     */
     public function list(array $params = []): array
     {
         return $this->http->get($this->basePath, $params);
@@ -37,7 +40,10 @@ class CompatConferences
         return $this->http->get($this->basePath . '/' . $sid);
     }
 
-    /** @param array<string,mixed> $body @return array<string,mixed> */
+    /**
+     * @param array<string,mixed> $body
+     * @return array<string,mixed>
+     */
     public function update(string $sid, array $body): array
     {
         return $this->http->post($this->basePath . '/' . $sid, $body);
@@ -47,7 +53,10 @@ class CompatConferences
     // Participants
     // ------------------------------------------------------------------
 
-    /** @param array<string,mixed> $params @return array<string,mixed> */
+    /**
+     * @param array<string,mixed> $params
+     * @return array<string,mixed>
+     */
     public function listParticipants(string $conferenceSid, array $params = []): array
     {
         return $this->http->get(
@@ -64,7 +73,10 @@ class CompatConferences
         );
     }
 
-    /** @param array<string,mixed> $body @return array<string,mixed> */
+    /**
+     * @param array<string,mixed> $body
+     * @return array<string,mixed>
+     */
     public function updateParticipant(string $conferenceSid, string $callSid, array $body): array
     {
         return $this->http->post(
@@ -85,7 +97,10 @@ class CompatConferences
     // Conference recordings
     // ------------------------------------------------------------------
 
-    /** @param array<string,mixed> $params @return array<string,mixed> */
+    /**
+     * @param array<string,mixed> $params
+     * @return array<string,mixed>
+     */
     public function listRecordings(string $conferenceSid, array $params = []): array
     {
         return $this->http->get(
@@ -102,7 +117,10 @@ class CompatConferences
         );
     }
 
-    /** @param array<string,mixed> $body @return array<string,mixed> */
+    /**
+     * @param array<string,mixed> $body
+     * @return array<string,mixed>
+     */
     public function updateRecording(string $conferenceSid, string $recordingSid, array $body): array
     {
         return $this->http->post(
@@ -123,7 +141,10 @@ class CompatConferences
     // Conference streams
     // ------------------------------------------------------------------
 
-    /** @param array<string,mixed> $body @return array<string,mixed> */
+    /**
+     * @param array<string,mixed> $body
+     * @return array<string,mixed>
+     */
     public function startStream(string $conferenceSid, array $body): array
     {
         return $this->http->post(
@@ -132,7 +153,10 @@ class CompatConferences
         );
     }
 
-    /** @param array<string,mixed> $body @return array<string,mixed> */
+    /**
+     * @param array<string,mixed> $body
+     * @return array<string,mixed>
+     */
     public function stopStream(string $conferenceSid, string $streamSid, array $body): array
     {
         return $this->http->post(

--- a/src/SignalWire/REST/Namespaces/CompatPhoneNumbers.php
+++ b/src/SignalWire/REST/Namespaces/CompatPhoneNumbers.php
@@ -51,7 +51,10 @@ class CompatPhoneNumbers
         return $this->importedBase;
     }
 
-    /** @param array<string,mixed> $params @return array<string,mixed> */
+    /**
+     * @param array<string,mixed> $params
+     * @return array<string,mixed>
+     */
     public function list(array $params = []): array
     {
         return $this->http->get($this->basePath, $params);
@@ -63,7 +66,10 @@ class CompatPhoneNumbers
         return $this->http->get($this->basePath . '/' . $sid);
     }
 
-    /** @param array<string,mixed> $body @return array<string,mixed> */
+    /**
+     * @param array<string,mixed> $body
+     * @return array<string,mixed>
+     */
     public function update(string $sid, array $body): array
     {
         return $this->http->post($this->basePath . '/' . $sid, $body);
@@ -75,31 +81,46 @@ class CompatPhoneNumbers
         return $this->http->delete($this->basePath . '/' . $sid);
     }
 
-    /** @param array<string,mixed> $body @return array<string,mixed> */
+    /**
+     * @param array<string,mixed> $body
+     * @return array<string,mixed>
+     */
     public function purchase(array $body): array
     {
         return $this->http->post($this->basePath, $body);
     }
 
-    /** @param array<string,mixed> $body @return array<string,mixed> */
+    /**
+     * @param array<string,mixed> $body
+     * @return array<string,mixed>
+     */
     public function importNumber(array $body): array
     {
         return $this->http->post($this->importedBase, $body);
     }
 
-    /** @param array<string,mixed> $params @return array<string,mixed> */
+    /**
+     * @param array<string,mixed> $params
+     * @return array<string,mixed>
+     */
     public function listAvailableCountries(array $params = []): array
     {
         return $this->http->get($this->availableBase, $params);
     }
 
-    /** @param array<string,mixed> $params @return array<string,mixed> */
+    /**
+     * @param array<string,mixed> $params
+     * @return array<string,mixed>
+     */
     public function searchLocal(string $country, array $params = []): array
     {
         return $this->http->get($this->availableBase . '/' . $country . '/Local', $params);
     }
 
-    /** @param array<string,mixed> $params @return array<string,mixed> */
+    /**
+     * @param array<string,mixed> $params
+     * @return array<string,mixed>
+     */
     public function searchTollFree(string $country, array $params = []): array
     {
         return $this->http->get($this->availableBase . '/' . $country . '/TollFree', $params);

--- a/src/SignalWire/REST/Namespaces/CompatQueues.php
+++ b/src/SignalWire/REST/Namespaces/CompatQueues.php
@@ -20,7 +20,10 @@ class CompatQueues extends CrudResource
         return $this->client->post($this->basePath . '/' . $sid, $body);
     }
 
-    /** @param array<string,mixed> $params @return array<string,mixed> */
+    /**
+     * @param array<string,mixed> $params
+     * @return array<string,mixed>
+     */
     public function listMembers(string $queueSid, array $params = []): array
     {
         return $this->client->get(
@@ -37,7 +40,10 @@ class CompatQueues extends CrudResource
         );
     }
 
-    /** @param array<string,mixed> $body @return array<string,mixed> */
+    /**
+     * @param array<string,mixed> $body
+     * @return array<string,mixed>
+     */
     public function dequeueMember(string $queueSid, string $callSid, array $body = []): array
     {
         return $this->client->post(

--- a/src/SignalWire/REST/Namespaces/CompatRecordings.php
+++ b/src/SignalWire/REST/Namespaces/CompatRecordings.php
@@ -28,7 +28,10 @@ class CompatRecordings
         return $this->basePath;
     }
 
-    /** @param array<string,mixed> $params @return array<string,mixed> */
+    /**
+     * @param array<string,mixed> $params
+     * @return array<string,mixed>
+     */
     public function list(array $params = []): array
     {
         return $this->http->get($this->basePath, $params);

--- a/src/SignalWire/REST/Namespaces/CompatTokens.php
+++ b/src/SignalWire/REST/Namespaces/CompatTokens.php
@@ -27,13 +27,19 @@ class CompatTokens
         return $this->basePath;
     }
 
-    /** @param array<string,mixed> $body @return array<string,mixed> */
+    /**
+     * @param array<string,mixed> $body
+     * @return array<string,mixed>
+     */
     public function create(array $body): array
     {
         return $this->http->post($this->basePath, $body);
     }
 
-    /** @param array<string,mixed> $body @return array<string,mixed> */
+    /**
+     * @param array<string,mixed> $body
+     * @return array<string,mixed>
+     */
     public function update(string $tokenId, array $body): array
     {
         return $this->http->patch($this->basePath . '/' . $tokenId, $body);

--- a/src/SignalWire/REST/Namespaces/CompatTranscriptions.php
+++ b/src/SignalWire/REST/Namespaces/CompatTranscriptions.php
@@ -27,7 +27,10 @@ class CompatTranscriptions
         return $this->basePath;
     }
 
-    /** @param array<string,mixed> $params @return array<string,mixed> */
+    /**
+     * @param array<string,mixed> $params
+     * @return array<string,mixed>
+     */
     public function list(array $params = []): array
     {
         return $this->http->get($this->basePath, $params);

--- a/src/SignalWire/REST/Namespaces/ConferenceLogs.php
+++ b/src/SignalWire/REST/Namespaces/ConferenceLogs.php
@@ -25,7 +25,10 @@ class ConferenceLogs
         return $this->basePath;
     }
 
-    /** @param array<string,mixed> $params @return array<string,mixed> */
+    /**
+     * @param array<string,mixed> $params
+     * @return array<string,mixed>
+     */
     public function list(array $params = []): array
     {
         return $this->http->get($this->basePath, $params);

--- a/src/SignalWire/REST/Namespaces/DatasphereDocuments.php
+++ b/src/SignalWire/REST/Namespaces/DatasphereDocuments.php
@@ -17,13 +17,19 @@ class DatasphereDocuments extends CrudResource
         parent::__construct($http, '/api/datasphere/documents');
     }
 
-    /** @param array<string,mixed> $body @return array<string,mixed> */
+    /**
+     * @param array<string,mixed> $body
+     * @return array<string,mixed>
+     */
     public function search(array $body): array
     {
         return $this->client->post($this->basePath . '/search', $body);
     }
 
-    /** @param array<string,mixed> $params @return array<string,mixed> */
+    /**
+     * @param array<string,mixed> $params
+     * @return array<string,mixed>
+     */
     public function listChunks(string $documentId, array $params = []): array
     {
         return $this->client->get(

--- a/src/SignalWire/REST/Namespaces/FabricAddresses.php
+++ b/src/SignalWire/REST/Namespaces/FabricAddresses.php
@@ -25,7 +25,10 @@ class FabricAddresses
         return $this->basePath;
     }
 
-    /** @param array<string,mixed> $params @return array<string,mixed> */
+    /**
+     * @param array<string,mixed> $params
+     * @return array<string,mixed>
+     */
     public function list(array $params = []): array
     {
         return $this->http->get($this->basePath, $params);

--- a/src/SignalWire/REST/Namespaces/FabricCallFlows.php
+++ b/src/SignalWire/REST/Namespaces/FabricCallFlows.php
@@ -23,7 +23,10 @@ class FabricCallFlows extends CrudWithAddresses
         return str_replace('/call_flows', '/call_flow', $this->basePath);
     }
 
-    /** @param array<string,mixed> $params @return array<string,mixed> */
+    /**
+     * @param array<string,mixed> $params
+     * @return array<string,mixed>
+     */
     public function listAddresses(string $resourceId, array $params = []): array
     {
         return $this->client->get(
@@ -32,7 +35,10 @@ class FabricCallFlows extends CrudWithAddresses
         );
     }
 
-    /** @param array<string,mixed> $params @return array<string,mixed> */
+    /**
+     * @param array<string,mixed> $params
+     * @return array<string,mixed>
+     */
     public function listVersions(string $resourceId, array $params = []): array
     {
         return $this->client->get(
@@ -41,7 +47,10 @@ class FabricCallFlows extends CrudWithAddresses
         );
     }
 
-    /** @param array<string,mixed> $body @return array<string,mixed> */
+    /**
+     * @param array<string,mixed> $body
+     * @return array<string,mixed>
+     */
     public function deployVersion(string $resourceId, array $body = []): array
     {
         return $this->client->post(

--- a/src/SignalWire/REST/Namespaces/FabricConferenceRooms.php
+++ b/src/SignalWire/REST/Namespaces/FabricConferenceRooms.php
@@ -18,7 +18,10 @@ class FabricConferenceRooms extends CrudWithAddresses
         return str_replace('/conference_rooms', '/conference_room', $this->basePath);
     }
 
-    /** @param array<string,mixed> $params @return array<string,mixed> */
+    /**
+     * @param array<string,mixed> $params
+     * @return array<string,mixed>
+     */
     public function listAddresses(string $resourceId, array $params = []): array
     {
         return $this->client->get(

--- a/src/SignalWire/REST/Namespaces/FabricGenericResources.php
+++ b/src/SignalWire/REST/Namespaces/FabricGenericResources.php
@@ -28,7 +28,10 @@ class FabricGenericResources
         return $this->basePath;
     }
 
-    /** @param array<string,mixed> $params @return array<string,mixed> */
+    /**
+     * @param array<string,mixed> $params
+     * @return array<string,mixed>
+     */
     public function list(array $params = []): array
     {
         return $this->http->get($this->basePath, $params);
@@ -46,7 +49,10 @@ class FabricGenericResources
         return $this->http->delete($this->basePath . '/' . $resourceId);
     }
 
-    /** @param array<string,mixed> $params @return array<string,mixed> */
+    /**
+     * @param array<string,mixed> $params
+     * @return array<string,mixed>
+     */
     public function listAddresses(string $resourceId, array $params = []): array
     {
         return $this->http->get(

--- a/src/SignalWire/REST/Namespaces/FabricSubscribers.php
+++ b/src/SignalWire/REST/Namespaces/FabricSubscribers.php
@@ -13,7 +13,10 @@ use SignalWire\REST\CrudWithAddresses;
  */
 class FabricSubscribers extends CrudWithAddresses
 {
-    /** @param array<string,mixed> $params @return array<string,mixed> */
+    /**
+     * @param array<string,mixed> $params
+     * @return array<string,mixed>
+     */
     public function listSipEndpoints(string $subscriberId, array $params = []): array
     {
         return $this->client->get(
@@ -22,7 +25,10 @@ class FabricSubscribers extends CrudWithAddresses
         );
     }
 
-    /** @param array<string,mixed> $body @return array<string,mixed> */
+    /**
+     * @param array<string,mixed> $body
+     * @return array<string,mixed>
+     */
     public function createSipEndpoint(string $subscriberId, array $body): array
     {
         return $this->client->post(
@@ -39,7 +45,10 @@ class FabricSubscribers extends CrudWithAddresses
         );
     }
 
-    /** @param array<string,mixed> $body @return array<string,mixed> */
+    /**
+     * @param array<string,mixed> $body
+     * @return array<string,mixed>
+     */
     public function updateSipEndpoint(string $subscriberId, string $endpointId, array $body): array
     {
         return $this->client->patch(

--- a/src/SignalWire/REST/Namespaces/FabricTokens.php
+++ b/src/SignalWire/REST/Namespaces/FabricTokens.php
@@ -31,13 +31,19 @@ class FabricTokens
         return $this->basePath;
     }
 
-    /** @param array<string,mixed> $body @return array<string,mixed> */
+    /**
+     * @param array<string,mixed> $body
+     * @return array<string,mixed>
+     */
     public function createSubscriberToken(array $body): array
     {
         return $this->http->post($this->basePath . '/subscribers/tokens', $body);
     }
 
-    /** @param array<string,mixed> $body @return array<string,mixed> */
+    /**
+     * @param array<string,mixed> $body
+     * @return array<string,mixed>
+     */
     public function refreshSubscriberToken(array $body): array
     {
         return $this->http->post($this->basePath . '/subscribers/tokens/refresh', $body);
@@ -55,13 +61,19 @@ class FabricTokens
         return $this->http->post($this->basePath . '/subscriber/invites', $body);
     }
 
-    /** @param array<string,mixed> $body @return array<string,mixed> */
+    /**
+     * @param array<string,mixed> $body
+     * @return array<string,mixed>
+     */
     public function createGuestToken(array $body): array
     {
         return $this->http->post($this->basePath . '/guests/tokens', $body);
     }
 
-    /** @param array<string,mixed> $body @return array<string,mixed> */
+    /**
+     * @param array<string,mixed> $body
+     * @return array<string,mixed>
+     */
     public function createEmbedToken(array $body): array
     {
         return $this->http->post($this->basePath . '/embeds/tokens', $body);

--- a/src/SignalWire/REST/Namespaces/FaxLogs.php
+++ b/src/SignalWire/REST/Namespaces/FaxLogs.php
@@ -25,7 +25,10 @@ class FaxLogs
         return $this->basePath;
     }
 
-    /** @param array<string,mixed> $params @return array<string,mixed> */
+    /**
+     * @param array<string,mixed> $params
+     * @return array<string,mixed>
+     */
     public function list(array $params = []): array
     {
         return $this->http->get($this->basePath, $params);

--- a/src/SignalWire/REST/Namespaces/ImportedNumbers.php
+++ b/src/SignalWire/REST/Namespaces/ImportedNumbers.php
@@ -25,7 +25,10 @@ class ImportedNumbers
         return $this->basePath;
     }
 
-    /** @param array<string,mixed> $body @return array<string,mixed> */
+    /**
+     * @param array<string,mixed> $body
+     * @return array<string,mixed>
+     */
     public function create(array $body): array
     {
         return $this->http->post($this->basePath, $body);

--- a/src/SignalWire/REST/Namespaces/MessageLogs.php
+++ b/src/SignalWire/REST/Namespaces/MessageLogs.php
@@ -25,7 +25,10 @@ class MessageLogs
         return $this->basePath;
     }
 
-    /** @param array<string,mixed> $params @return array<string,mixed> */
+    /**
+     * @param array<string,mixed> $params
+     * @return array<string,mixed>
+     */
     public function list(array $params = []): array
     {
         return $this->http->get($this->basePath, $params);

--- a/src/SignalWire/REST/Namespaces/Mfa.php
+++ b/src/SignalWire/REST/Namespaces/Mfa.php
@@ -24,19 +24,28 @@ class Mfa
         return $this->basePath;
     }
 
-    /** @param array<string,mixed> $body @return array<string,mixed> */
+    /**
+     * @param array<string,mixed> $body
+     * @return array<string,mixed>
+     */
     public function sms(array $body): array
     {
         return $this->http->post($this->basePath . '/sms', $body);
     }
 
-    /** @param array<string,mixed> $body @return array<string,mixed> */
+    /**
+     * @param array<string,mixed> $body
+     * @return array<string,mixed>
+     */
     public function call(array $body): array
     {
         return $this->http->post($this->basePath . '/call', $body);
     }
 
-    /** @param array<string,mixed> $body @return array<string,mixed> */
+    /**
+     * @param array<string,mixed> $body
+     * @return array<string,mixed>
+     */
     public function verify(string $requestId, array $body): array
     {
         return $this->http->post($this->basePath . '/' . $requestId . '/verify', $body);

--- a/src/SignalWire/REST/Namespaces/NumberGroups.php
+++ b/src/SignalWire/REST/Namespaces/NumberGroups.php
@@ -23,7 +23,10 @@ class NumberGroups extends CrudResource
         parent::__construct($http, '/api/relay/rest/number_groups', 'PUT');
     }
 
-    /** @param array<string,mixed> $params @return array<string,mixed> */
+    /**
+     * @param array<string,mixed> $params
+     * @return array<string,mixed>
+     */
     public function listMemberships(string $groupId, array $params = []): array
     {
         return $this->client->get(
@@ -32,7 +35,10 @@ class NumberGroups extends CrudResource
         );
     }
 
-    /** @param array<string,mixed> $body @return array<string,mixed> */
+    /**
+     * @param array<string,mixed> $body
+     * @return array<string,mixed>
+     */
     public function addMembership(string $groupId, array $body): array
     {
         return $this->client->post(

--- a/src/SignalWire/REST/Namespaces/ProjectTokens.php
+++ b/src/SignalWire/REST/Namespaces/ProjectTokens.php
@@ -24,13 +24,19 @@ class ProjectTokens
         return $this->basePath;
     }
 
-    /** @param array<string,mixed> $body @return array<string,mixed> */
+    /**
+     * @param array<string,mixed> $body
+     * @return array<string,mixed>
+     */
     public function create(array $body): array
     {
         return $this->http->post($this->basePath, $body);
     }
 
-    /** @param array<string,mixed> $body @return array<string,mixed> */
+    /**
+     * @param array<string,mixed> $body
+     * @return array<string,mixed>
+     */
     public function update(string $tokenId, array $body): array
     {
         return $this->http->patch($this->basePath . '/' . $tokenId, $body);

--- a/src/SignalWire/REST/Namespaces/Queues.php
+++ b/src/SignalWire/REST/Namespaces/Queues.php
@@ -21,7 +21,10 @@ class Queues extends CrudResource
         parent::__construct($http, '/api/relay/rest/queues', 'PUT');
     }
 
-    /** @param array<string,mixed> $params @return array<string,mixed> */
+    /**
+     * @param array<string,mixed> $params
+     * @return array<string,mixed>
+     */
     public function listMembers(string $queueId, array $params = []): array
     {
         return $this->client->get(

--- a/src/SignalWire/REST/Namespaces/Recordings.php
+++ b/src/SignalWire/REST/Namespaces/Recordings.php
@@ -24,7 +24,10 @@ class Recordings
         return $this->basePath;
     }
 
-    /** @param array<string,mixed> $params @return array<string,mixed> */
+    /**
+     * @param array<string,mixed> $params
+     * @return array<string,mixed>
+     */
     public function list(array $params = []): array
     {
         return $this->http->get($this->basePath, $params);

--- a/src/SignalWire/REST/Namespaces/RegistryBrands.php
+++ b/src/SignalWire/REST/Namespaces/RegistryBrands.php
@@ -25,13 +25,19 @@ class RegistryBrands
         return $this->basePath;
     }
 
-    /** @param array<string,mixed> $params @return array<string,mixed> */
+    /**
+     * @param array<string,mixed> $params
+     * @return array<string,mixed>
+     */
     public function list(array $params = []): array
     {
         return $this->http->get($this->basePath, $params);
     }
 
-    /** @param array<string,mixed> $body @return array<string,mixed> */
+    /**
+     * @param array<string,mixed> $body
+     * @return array<string,mixed>
+     */
     public function create(array $body): array
     {
         return $this->http->post($this->basePath, $body);
@@ -43,13 +49,19 @@ class RegistryBrands
         return $this->http->get($this->basePath . '/' . $brandId);
     }
 
-    /** @param array<string,mixed> $params @return array<string,mixed> */
+    /**
+     * @param array<string,mixed> $params
+     * @return array<string,mixed>
+     */
     public function listCampaigns(string $brandId, array $params = []): array
     {
         return $this->http->get($this->basePath . '/' . $brandId . '/campaigns', $params);
     }
 
-    /** @param array<string,mixed> $body @return array<string,mixed> */
+    /**
+     * @param array<string,mixed> $body
+     * @return array<string,mixed>
+     */
     public function createCampaign(string $brandId, array $body): array
     {
         return $this->http->post($this->basePath . '/' . $brandId . '/campaigns', $body);

--- a/src/SignalWire/REST/Namespaces/RegistryCampaigns.php
+++ b/src/SignalWire/REST/Namespaces/RegistryCampaigns.php
@@ -43,19 +43,28 @@ class RegistryCampaigns
         return $this->http->put($this->basePath . '/' . $campaignId, $body);
     }
 
-    /** @param array<string,mixed> $params @return array<string,mixed> */
+    /**
+     * @param array<string,mixed> $params
+     * @return array<string,mixed>
+     */
     public function listNumbers(string $campaignId, array $params = []): array
     {
         return $this->http->get($this->basePath . '/' . $campaignId . '/numbers', $params);
     }
 
-    /** @param array<string,mixed> $params @return array<string,mixed> */
+    /**
+     * @param array<string,mixed> $params
+     * @return array<string,mixed>
+     */
     public function listOrders(string $campaignId, array $params = []): array
     {
         return $this->http->get($this->basePath . '/' . $campaignId . '/orders', $params);
     }
 
-    /** @param array<string,mixed> $body @return array<string,mixed> */
+    /**
+     * @param array<string,mixed> $body
+     * @return array<string,mixed>
+     */
     public function createOrder(string $campaignId, array $body): array
     {
         return $this->http->post($this->basePath . '/' . $campaignId . '/orders', $body);

--- a/src/SignalWire/REST/Namespaces/ShortCodes.php
+++ b/src/SignalWire/REST/Namespaces/ShortCodes.php
@@ -24,7 +24,10 @@ class ShortCodes
         return $this->basePath;
     }
 
-    /** @param array<string,mixed> $params @return array<string,mixed> */
+    /**
+     * @param array<string,mixed> $params
+     * @return array<string,mixed>
+     */
     public function list(array $params = []): array
     {
         return $this->http->get($this->basePath, $params);
@@ -36,7 +39,10 @@ class ShortCodes
         return $this->http->get($this->basePath . '/' . $shortCodeId);
     }
 
-    /** @param array<string,mixed> $body @return array<string,mixed> */
+    /**
+     * @param array<string,mixed> $body
+     * @return array<string,mixed>
+     */
     public function update(string $shortCodeId, array $body): array
     {
         return $this->http->put($this->basePath . '/' . $shortCodeId, $body);

--- a/src/SignalWire/REST/Namespaces/SipProfile.php
+++ b/src/SignalWire/REST/Namespaces/SipProfile.php
@@ -30,7 +30,10 @@ class SipProfile
         return $this->http->get($this->basePath);
     }
 
-    /** @param array<string,mixed> $body @return array<string,mixed> */
+    /**
+     * @param array<string,mixed> $body
+     * @return array<string,mixed>
+     */
     public function update(array $body): array
     {
         return $this->http->put($this->basePath, $body);

--- a/src/SignalWire/REST/Namespaces/VideoConferences.php
+++ b/src/SignalWire/REST/Namespaces/VideoConferences.php
@@ -13,7 +13,10 @@ use SignalWire\REST\CrudResource;
  */
 class VideoConferences extends CrudResource
 {
-    /** @param array<string,mixed> $params @return array<string,mixed> */
+    /**
+     * @param array<string,mixed> $params
+     * @return array<string,mixed>
+     */
     public function listConferenceTokens(string $conferenceId, array $params = []): array
     {
         return $this->client->get(
@@ -22,7 +25,10 @@ class VideoConferences extends CrudResource
         );
     }
 
-    /** @param array<string,mixed> $params @return array<string,mixed> */
+    /**
+     * @param array<string,mixed> $params
+     * @return array<string,mixed>
+     */
     public function listStreams(string $conferenceId, array $params = []): array
     {
         return $this->client->get(
@@ -31,7 +37,10 @@ class VideoConferences extends CrudResource
         );
     }
 
-    /** @param array<string,mixed> $body @return array<string,mixed> */
+    /**
+     * @param array<string,mixed> $body
+     * @return array<string,mixed>
+     */
     public function createStream(string $conferenceId, array $body): array
     {
         return $this->client->post(

--- a/src/SignalWire/REST/Namespaces/VideoRoomRecordings.php
+++ b/src/SignalWire/REST/Namespaces/VideoRoomRecordings.php
@@ -26,7 +26,10 @@ class VideoRoomRecordings
         return $this->basePath;
     }
 
-    /** @param array<string,mixed> $params @return array<string,mixed> */
+    /**
+     * @param array<string,mixed> $params
+     * @return array<string,mixed>
+     */
     public function list(array $params = []): array
     {
         return $this->http->get($this->basePath, $params);
@@ -44,7 +47,10 @@ class VideoRoomRecordings
         return $this->http->delete($this->basePath . '/' . $recordingId);
     }
 
-    /** @param array<string,mixed> $params @return array<string,mixed> */
+    /**
+     * @param array<string,mixed> $params
+     * @return array<string,mixed>
+     */
     public function listEvents(string $recordingId, array $params = []): array
     {
         return $this->http->get($this->basePath . '/' . $recordingId . '/events', $params);

--- a/src/SignalWire/REST/Namespaces/VideoRoomSessions.php
+++ b/src/SignalWire/REST/Namespaces/VideoRoomSessions.php
@@ -26,7 +26,10 @@ class VideoRoomSessions
         return $this->basePath;
     }
 
-    /** @param array<string,mixed> $params @return array<string,mixed> */
+    /**
+     * @param array<string,mixed> $params
+     * @return array<string,mixed>
+     */
     public function list(array $params = []): array
     {
         return $this->http->get($this->basePath, $params);
@@ -38,19 +41,28 @@ class VideoRoomSessions
         return $this->http->get($this->basePath . '/' . $sessionId);
     }
 
-    /** @param array<string,mixed> $params @return array<string,mixed> */
+    /**
+     * @param array<string,mixed> $params
+     * @return array<string,mixed>
+     */
     public function listEvents(string $sessionId, array $params = []): array
     {
         return $this->http->get($this->basePath . '/' . $sessionId . '/events', $params);
     }
 
-    /** @param array<string,mixed> $params @return array<string,mixed> */
+    /**
+     * @param array<string,mixed> $params
+     * @return array<string,mixed>
+     */
     public function listMembers(string $sessionId, array $params = []): array
     {
         return $this->http->get($this->basePath . '/' . $sessionId . '/members', $params);
     }
 
-    /** @param array<string,mixed> $params @return array<string,mixed> */
+    /**
+     * @param array<string,mixed> $params
+     * @return array<string,mixed>
+     */
     public function listRecordings(string $sessionId, array $params = []): array
     {
         return $this->http->get($this->basePath . '/' . $sessionId . '/recordings', $params);

--- a/src/SignalWire/REST/Namespaces/VideoRoomTokens.php
+++ b/src/SignalWire/REST/Namespaces/VideoRoomTokens.php
@@ -25,7 +25,10 @@ class VideoRoomTokens
         return $this->basePath;
     }
 
-    /** @param array<string,mixed> $body @return array<string,mixed> */
+    /**
+     * @param array<string,mixed> $body
+     * @return array<string,mixed>
+     */
     public function create(array $body): array
     {
         return $this->http->post($this->basePath, $body);

--- a/src/SignalWire/REST/Namespaces/VideoRooms.php
+++ b/src/SignalWire/REST/Namespaces/VideoRooms.php
@@ -13,13 +13,19 @@ use SignalWire\REST\CrudResource;
  */
 class VideoRooms extends CrudResource
 {
-    /** @param array<string,mixed> $params @return array<string,mixed> */
+    /**
+     * @param array<string,mixed> $params
+     * @return array<string,mixed>
+     */
     public function listStreams(string $roomId, array $params = []): array
     {
         return $this->client->get($this->basePath . '/' . $roomId . '/streams', $params);
     }
 
-    /** @param array<string,mixed> $body @return array<string,mixed> */
+    /**
+     * @param array<string,mixed> $body
+     * @return array<string,mixed>
+     */
     public function createStream(string $roomId, array $body): array
     {
         return $this->client->post($this->basePath . '/' . $roomId . '/streams', $body);

--- a/src/SignalWire/REST/Namespaces/VideoStreams.php
+++ b/src/SignalWire/REST/Namespaces/VideoStreams.php
@@ -31,7 +31,10 @@ class VideoStreams
         return $this->http->get($this->basePath . '/' . $streamId);
     }
 
-    /** @param array<string,mixed> $body @return array<string,mixed> */
+    /**
+     * @param array<string,mixed> $body
+     * @return array<string,mixed>
+     */
     public function update(string $streamId, array $body): array
     {
         return $this->http->put($this->basePath . '/' . $streamId, $body);

--- a/src/SignalWire/REST/Namespaces/VoiceLogs.php
+++ b/src/SignalWire/REST/Namespaces/VoiceLogs.php
@@ -25,7 +25,10 @@ class VoiceLogs
         return $this->basePath;
     }
 
-    /** @param array<string,mixed> $params @return array<string,mixed> */
+    /**
+     * @param array<string,mixed> $params
+     * @return array<string,mixed>
+     */
     public function list(array $params = []): array
     {
         return $this->http->get($this->basePath, $params);
@@ -37,7 +40,10 @@ class VoiceLogs
         return $this->http->get($this->basePath . '/' . $logId);
     }
 
-    /** @param array<string,mixed> $params @return array<string,mixed> */
+    /**
+     * @param array<string,mixed> $params
+     * @return array<string,mixed>
+     */
     public function listEvents(string $logId, array $params = []): array
     {
         return $this->http->get($this->basePath . '/' . $logId . '/events', $params);

--- a/src/SignalWire/REST/PaginatedIterator.php
+++ b/src/SignalWire/REST/PaginatedIterator.php
@@ -130,7 +130,14 @@ class PaginatedIterator implements \Iterator
         $data = $resp[$this->dataKey] ?? [];
         if (is_array($data)) {
             foreach ($data as $row) {
-                $this->items[] = $row;
+                if (!is_array($row)) {
+                    continue;
+                }
+                $item = [];
+                foreach ($row as $key => $value) {
+                    $item[(string) $key] = $value;
+                }
+                $this->items[] = $item;
             }
         }
 

--- a/src/SignalWire/REST/PaginatedIterator.php
+++ b/src/SignalWire/REST/PaginatedIterator.php
@@ -15,6 +15,8 @@ namespace SignalWire\REST;
  *   foreach (new PaginatedIterator($http, '/api/path', ['k' => 'v']) as $item) {
  *       // ...
  *   }
+ *
+ * @implements \Iterator<int,array<string,mixed>>
  */
 class PaginatedIterator implements \Iterator
 {
@@ -138,8 +140,14 @@ class PaginatedIterator implements \Iterator
             // Parse cursor/page token from next URL.
             $parsed = parse_url($nextUrl);
             $query = $parsed['query'] ?? '';
+            $parts = [];
             parse_str($query, $parts);
-            $this->params = $parts;
+            /** @var array<string,mixed> $normalized */
+            $normalized = [];
+            foreach ($parts as $k => $v) {
+                $normalized[(string) $k] = $v;
+            }
+            $this->params = $normalized;
         } else {
             $this->done = true;
         }

--- a/src/SignalWire/REST/RestClient.php
+++ b/src/SignalWire/REST/RestClient.php
@@ -38,6 +38,7 @@ class RestClient
     private string $projectId;
     private string $token;
     private string $space;
+    /** @var non-empty-string */
     private string $baseUrl;
     private HttpClient $http;
 
@@ -100,9 +101,16 @@ class RestClient
         // Accept a bare host ("space.signalwire.com") or a fully-qualified
         // URL. The latter is used by tests and audit harnesses to point
         // the client at a loopback fixture without forcing https://.
-        $this->baseUrl = preg_match('#^https?://#i', $this->space)
+        $baseUrl = preg_match('#^https?://#i', $this->space)
             ? rtrim($this->space, '/')
             : 'https://' . $this->space;
+        // Genuine invariant: $space is non-empty (thrown above), so the
+        // https:// branch is non-empty by construction, and the rtrim branch
+        // strips only trailing '/' from a URL that already begins with a
+        // scheme (so it cannot reduce to ''). PHPStan can't infer this through
+        // rtrim/preg_match, so establish the true type at the source.
+        assert($baseUrl !== '');
+        $this->baseUrl = $baseUrl;
         $this->http = new HttpClient($this->projectId, $this->token, $this->baseUrl, $caBundle);
     }
 

--- a/src/SignalWire/Relay/Action.php
+++ b/src/SignalWire/Relay/Action.php
@@ -22,7 +22,9 @@ class Action
     protected bool $completed = false;
     /** @var mixed */
     protected $result = null;
+    /** @var list<Event> */
     protected array $events = [];
+    /** @var array<string,mixed> */
     protected array $payload = [];
     /** @var callable|null */
     protected $onCompletedCallback = null;
@@ -88,6 +90,7 @@ class Action
         return $this->state;
     }
 
+    /** @return array<string,mixed> */
     public function getPayload(): array
     {
         return $this->payload;
@@ -207,6 +210,8 @@ class Action
      *
      * The payload always includes control_id, call_id, and node_id so
      * the server knows which action instance to target.
+     *
+     * @param array<string,mixed> $extraParams
      */
     public function executeSubcommand(string $method, array $extraParams = []): void
     {
@@ -356,6 +361,8 @@ class CollectAction extends Action
 
     /**
      * Return the structured collect result from the payload.
+     *
+     * @return array<string,mixed>|null
      */
     public function getCollectResult(): ?array
     {
@@ -386,6 +393,7 @@ class DetectAction extends Action
         return 'calling.detect.stop';
     }
 
+    /** @return array<string,mixed>|null */
     public function getDetectResult(): ?array
     {
         return $this->payload['detect'] ?? $this->payload['result'] ?? null;

--- a/src/SignalWire/Relay/Action.php
+++ b/src/SignalWire/Relay/Action.php
@@ -242,6 +242,27 @@ class Action
         $this->callbackFired = true;
         ($this->onCompletedCallback)($this);
     }
+
+    /**
+     * Narrow a JSON-decoded payload value to an ``array<string,mixed>`` (a
+     * JSON object), or null when it is absent or not an object. RELAY
+     * ``result`` / ``detect`` payloads are objects on the wire (the Python
+     * reference reads ``event.params.get("result", {})`` /
+     * ``...get("detect", {})`` as dicts). Re-keys to guarantee string keys.
+     *
+     * @return array<string,mixed>|null
+     */
+    protected static function asStringKeyedArrayOrNull(mixed $value): ?array
+    {
+        if (!is_array($value)) {
+            return null;
+        }
+        $out = [];
+        foreach ($value as $key => $item) {
+            $out[(string) $key] = $item;
+        }
+        return $out;
+    }
 }
 
 // ======================================================================
@@ -307,19 +328,20 @@ class RecordAction extends Action
 
     public function getUrl(): ?string
     {
-        return $this->payload['url'] ?? null;
+        $val = $this->payload['url'] ?? null;
+        return is_string($val) ? $val : null;
     }
 
     public function getDuration(): ?float
     {
         $val = $this->payload['duration'] ?? null;
-        return $val !== null ? (float) $val : null;
+        return is_int($val) || is_float($val) ? (float) $val : null;
     }
 
     public function getSize(): ?int
     {
         $val = $this->payload['size'] ?? null;
-        return $val !== null ? (int) $val : null;
+        return is_int($val) || is_float($val) ? (int) $val : null;
     }
 }
 
@@ -366,7 +388,7 @@ class CollectAction extends Action
      */
     public function getCollectResult(): ?array
     {
-        return $this->payload['result'] ?? null;
+        return self::asStringKeyedArrayOrNull($this->payload['result'] ?? null);
     }
 
     /**
@@ -396,7 +418,11 @@ class DetectAction extends Action
     /** @return array<string,mixed>|null */
     public function getDetectResult(): ?array
     {
-        return $this->payload['detect'] ?? $this->payload['result'] ?? null;
+        $detect = self::asStringKeyedArrayOrNull($this->payload['detect'] ?? null);
+        if ($detect !== null) {
+            return $detect;
+        }
+        return self::asStringKeyedArrayOrNull($this->payload['result'] ?? null);
     }
 }
 

--- a/src/SignalWire/Relay/Call.php
+++ b/src/SignalWire/Relay/Call.php
@@ -32,8 +32,13 @@ class Call
     public ?string $direction = null;
 
     // ── back-references ───────────────────────────────────────────────
-    /** @var object  RELAY Client instance */
-    public object $client;
+    /**
+     * RELAY client handle, typed via the internal RelayClientLike contract.
+     * Mirrors the Python reference's PRIVATE ``self._client`` back-reference
+     * (not part of the public surface); kept non-public so it is not a
+     * port-only public extra.
+     */
+    protected RelayClientLike $client;
 
     /** @var array<string, Action> controlId => Action */
     public array $actions = [];
@@ -50,19 +55,51 @@ class Call
     /**
      * @param array<string,mixed> $params
      */
-    public function __construct(array $params, object $client)
+    public function __construct(array $params, RelayClientLike $client)
     {
         $this->client    = $client;
-        $this->callId    = $params['call_id']   ?? null;
-        $this->nodeId    = $params['node_id']   ?? null;
-        $this->tag       = $params['tag']       ?? null;
-        $this->device    = $params['device']    ?? [];
-        $this->peer      = $params['peer']      ?? [];
-        $this->context   = $params['context']   ?? null;
-        $this->state     = $params['state']     ?? $params['call_state'] ?? 'created';
-        $this->direction = $params['direction'] ?? null;
+        $this->callId    = self::asNullableString($params['call_id']   ?? null);
+        $this->nodeId    = self::asNullableString($params['node_id']   ?? null);
+        $this->tag       = self::asNullableString($params['tag']       ?? null);
+        $this->device    = self::asStringKeyedArray($params['device']  ?? null);
+        $this->peer      = self::asStringKeyedArray($params['peer']    ?? null);
+        $this->context   = self::asNullableString($params['context']   ?? null);
+        $state           = $params['state'] ?? $params['call_state'] ?? null;
+        $this->state     = is_string($state) ? $state : 'created';
+        $this->direction = self::asNullableString($params['direction'] ?? null);
 
         $this->logger = Logger::getLogger('relay.call');
+    }
+
+    /**
+     * Narrow a JSON-decoded value to a string, or null when absent / a
+     * non-string. The RELAY call identity fields (call_id, node_id, tag,
+     * context, direction) are strings on the wire — see the Python
+     * reference's ``str`` typing in relay/call.py.
+     */
+    private static function asNullableString(mixed $value): ?string
+    {
+        return is_string($value) ? $value : null;
+    }
+
+    /**
+     * Narrow a JSON-decoded value to an ``array<string,mixed>`` (a JSON
+     * object) — RELAY ``device``/``peer`` are objects (Python types them as
+     * ``dict[str, Any]``). A missing or non-object value yields an empty
+     * array.
+     *
+     * @return array<string,mixed>
+     */
+    private static function asStringKeyedArray(mixed $value): array
+    {
+        if (!is_array($value)) {
+            return [];
+        }
+        $out = [];
+        foreach ($value as $key => $item) {
+            $out[(string) $key] = $item;
+        }
+        return $out;
     }
 
     // ──────────────────────────────────────────────────────────────────
@@ -84,16 +121,16 @@ class Call
         if ($eventType === 'calling.call.state') {
             // Production wire uses ``call_state``; older fixtures use ``state``.
             $newState = $params['state'] ?? $params['call_state'] ?? null;
-            if ($newState !== null) {
+            if (is_string($newState)) {
                 $this->state = $newState;
             }
-            if (isset($params['end_reason'])) {
+            if (is_string($params['end_reason'] ?? null)) {
                 $this->endReason = $params['end_reason'];
             }
             if (isset($params['peer'])) {
-                $this->peer = $params['peer'];
+                $this->peer = self::asStringKeyedArray($params['peer']);
             }
-            if (isset($params['direction'])) {
+            if (is_string($params['direction'] ?? null)) {
                 $this->direction = $params['direction'];
             }
 
@@ -106,7 +143,7 @@ class Call
         // ── connect events carry peer info ───────────────────────────
         if ($eventType === 'calling.call.connect') {
             if (isset($params['peer'])) {
-                $this->peer = $params['peer'];
+                $this->peer = self::asStringKeyedArray($params['peer']);
             }
         }
 
@@ -148,7 +185,7 @@ class Call
             } else {
                 $terminalMap = Constants::ACTION_TERMINAL_STATES[$eventType] ?? [];
                 $actionState = $params['state'] ?? null;
-                if ($actionState !== null && isset($terminalMap[$actionState])) {
+                if (is_string($actionState) && isset($terminalMap[$actionState])) {
                     $action->resolve($event);
                     unset($this->actions[$controlId]);
                 }
@@ -229,11 +266,8 @@ class Call
         while ($this->stateRank($this->state) < $targetRank
             && microtime(true) < $deadline
         ) {
-            if (method_exists($this->client, 'readOnce')) {
-                $this->client->readOnce();
-            } else {
-                break;
-            }
+            // readOnce() is part of the RelayClientLike contract.
+            $this->client->readOnce();
         }
 
         return $this->stateRank($this->state) >= $targetRank;
@@ -1030,14 +1064,16 @@ class Call
         class_exists(Action::class);
 
         // Caller may pre-supply control_id; otherwise we generate one.
-        $controlId = $opts['control_id'] ?? $wireParams['control_id'] ?? $this->generateUuid();
+        $controlIdRaw = $opts['control_id'] ?? $wireParams['control_id'] ?? null;
+        $controlId = is_string($controlIdRaw) ? $controlIdRaw : $this->generateUuid();
 
         $callId = $this->callId ?? '';
         $nodeId = $this->nodeId ?? '';
 
         // Construct the action with the right signature.
         if ($actionClass === FaxAction::class) {
-            $faxType = $opts['fax_type'] ?? 'send';
+            $faxTypeRaw = $opts['fax_type'] ?? 'send';
+            $faxType = is_string($faxTypeRaw) ? $faxTypeRaw : 'send';
             $action = new FaxAction($controlId, $callId, $nodeId, $this->client, $faxType);
         } else {
             /** @psalm-suppress UnsafeInstantiation */
@@ -1083,6 +1119,12 @@ class Call
                 throw $e;
             }
         }
+
+        // Genuine invariant: the FaxAction branch only runs when $actionClass
+        // === FaxAction::class, and otherwise $action is `new $actionClass`.
+        // PHPStan cannot narrow the template T across the FaxAction branch, so
+        // assert the real guarantee here rather than hand-waving the type.
+        assert($action instanceof $actionClass);
 
         return $action;
     }

--- a/src/SignalWire/Relay/Call.php
+++ b/src/SignalWire/Relay/Call.php
@@ -22,7 +22,9 @@ class Call
 
     // ── state ─────────────────────────────────────────────────────────
     public string $state = 'created';
+    /** @var array<string,mixed> */
     public array  $device = [];
+    /** @var array<string,mixed> */
     public array  $peer = [];
     public ?string $endReason = null;
     public ?string $context = null;
@@ -45,6 +47,9 @@ class Call
     //  Construction
     // ──────────────────────────────────────────────────────────────────
 
+    /**
+     * @param array<string,mixed> $params
+     */
     public function __construct(array $params, object $client)
     {
         $this->client    = $client;
@@ -300,6 +305,7 @@ class Call
     //  Simple RPC methods (fire-and-return)
     // ──────────────────────────────────────────────────────────────────
 
+    /** @return array<string,mixed> */
     public function answer(): array
     {
         return $this->execute('calling.answer');
@@ -312,6 +318,8 @@ class Call
      * The on-wire method is ``calling.end`` (production), which historically
      * was named ``calling.hangup`` — we send ``calling.end`` to match the
      * RELAY schema set extracted from switchblade.
+     *
+     * @return array<string,mixed>
      */
     public function hangup(?string $reason = null): array
     {
@@ -319,61 +327,85 @@ class Call
         return $this->execute('calling.end', $extra);
     }
 
+    /** @return array<string,mixed> */
     public function pass(): array
     {
         return $this->execute('calling.pass');
     }
 
+    /**
+     * @param array<string,mixed> $params
+     * @return array<string,mixed>
+     */
     public function connect(array $params): array
     {
         return $this->execute('calling.connect', $params);
     }
 
+    /** @return array<string,mixed> */
     public function disconnect(): array
     {
         return $this->execute('calling.disconnect');
     }
 
+    /** @return array<string,mixed> */
     public function hold(): array
     {
         return $this->execute('calling.hold');
     }
 
+    /** @return array<string,mixed> */
     public function unhold(): array
     {
         return $this->execute('calling.unhold');
     }
 
+    /** @return array<string,mixed> */
     public function denoise(): array
     {
         return $this->execute('calling.denoise');
     }
 
+    /** @return array<string,mixed> */
     public function denoiseStop(): array
     {
         return $this->execute('calling.denoise.stop');
     }
 
+    /**
+     * @param array<string,mixed> $params
+     * @return array<string,mixed>
+     */
     public function transfer(array $params): array
     {
         return $this->execute('calling.transfer', $params);
     }
 
+    /**
+     * @param array<string,mixed> $params
+     * @return array<string,mixed>
+     */
     public function joinConference(array $params): array
     {
         return $this->execute('calling.conference.join', $params);
     }
 
+    /** @return array<string,mixed> */
     public function leaveConference(): array
     {
         return $this->execute('calling.conference.leave');
     }
 
+    /** @return array<string,mixed> */
     public function echo(): array
     {
         return $this->execute('calling.echo');
     }
 
+    /**
+     * @param array<string,mixed> $params
+     * @return array<string,mixed>
+     */
     public function bindDigit(array $params): array
     {
         return $this->execute('calling.bind_digit', $params);
@@ -388,6 +420,7 @@ class Call
      *                         bindings registered under that realm.
      * @param array<string,mixed> $kwargs Additional params forwarded to the
      *                                     wire call.
+     * @return array<string,mixed>
      */
     public function clearDigitBindings(?string $realm = null, array $kwargs = []): array
     {
@@ -399,51 +432,82 @@ class Call
         return $this->execute('calling.clear_digit_bindings', $params);
     }
 
+    /**
+     * @param array<string,mixed> $params
+     * @return array<string,mixed>
+     */
     public function liveTranscribe(array $params): array
     {
         return $this->execute('calling.live_transcribe', $params);
     }
 
+    /**
+     * @param array<string,mixed> $params
+     * @return array<string,mixed>
+     */
     public function liveTranslate(array $params): array
     {
         return $this->execute('calling.live_translate', $params);
     }
 
+    /**
+     * @param array<string,mixed> $params
+     * @return array<string,mixed>
+     */
     public function joinRoom(array $params): array
     {
         return $this->execute('calling.room.join', $params);
     }
 
+    /** @return array<string,mixed> */
     public function leaveRoom(): array
     {
         return $this->execute('calling.room.leave');
     }
 
+    /**
+     * @param array<string,mixed> $params
+     * @return array<string,mixed>
+     */
     public function amazonBedrock(array $params): array
     {
         return $this->execute('calling.amazon_bedrock', $params);
     }
 
+    /**
+     * @param array<string,mixed> $params
+     * @return array<string,mixed>
+     */
     public function aiMessage(array $params): array
     {
         return $this->execute('calling.ai.message', $params);
     }
 
+    /** @return array<string,mixed> */
     public function aiHold(): array
     {
         return $this->execute('calling.ai.hold');
     }
 
+    /** @return array<string,mixed> */
     public function aiUnhold(): array
     {
         return $this->execute('calling.ai.unhold');
     }
 
+    /**
+     * @param array<string,mixed> $params
+     * @return array<string,mixed>
+     */
     public function userEvent(array $params): array
     {
         return $this->execute('calling.user_event', $params);
     }
 
+    /**
+     * @param array<string,mixed> $params
+     * @return array<string,mixed>
+     */
     public function queueEnter(array $params): array
     {
         return $this->execute('calling.queue.enter', $params);
@@ -467,6 +531,7 @@ class Call
      * @param ?string $status_url  Optional status callback URL.
      * @param array<string,mixed> $kwargs  Extra params merged onto the
      *                                     wire call.
+     * @return array<string,mixed>
      */
     public function queueLeave(
         ?string $queue_name = null,
@@ -501,11 +566,19 @@ class Call
         return $this->execute('calling.queue.leave', $params);
     }
 
+    /**
+     * @param array<string,mixed> $params
+     * @return array<string,mixed>
+     */
     public function refer(array $params): array
     {
         return $this->execute('calling.refer', $params);
     }
 
+    /**
+     * @param array<string,mixed> $params
+     * @return array<string,mixed>
+     */
     public function sendDigits(array $params): array
     {
         return $this->execute('calling.send_digits', $params);
@@ -621,6 +694,7 @@ class Call
 
     /**
      * @param array<string,mixed> $audio  Recording config (``format``, etc.)
+     * @param array<string,mixed> $opts   ``control_id`` / ``on_completed``.
      */
     public function record(array $audio, array $opts = []): RecordAction
     {
@@ -653,6 +727,7 @@ class Call
      *
      * @param array<int,array<string,mixed>> $media
      * @param array<string,mixed> $collect
+     * @param array<string,mixed> $opts ``control_id`` / ``on_completed``.
      */
     public function playAndCollect(array $media, array $collect, array $opts = []): CollectAction
     {
@@ -721,6 +796,7 @@ class Call
     /**
      * @param array<string,mixed> $detect Detection request
      *   (``{type: 'machine'|'fax'|'digit', params: {...}}``).
+     * @param array<string,mixed> $opts ``control_id`` / ``on_completed``.
      */
     public function detect(array $detect, array $opts = []): DetectAction
     {
@@ -826,6 +902,9 @@ class Call
         );
     }
 
+    /**
+     * @param array<string,mixed> $opts ``control_id`` / ``on_completed``.
+     */
     public function sendFax(string $document, ?string $identity = null, array $opts = []): FaxAction
     {
         $extra = ['document' => $document];
@@ -841,6 +920,9 @@ class Call
         );
     }
 
+    /**
+     * @param array<string,mixed> $opts ``control_id`` / ``on_completed``.
+     */
     public function receiveFax(array $opts = []): FaxAction
     {
         return $this->startAction(
@@ -854,6 +936,7 @@ class Call
     /**
      * @param array<string,mixed> $tap     Tap config.
      * @param array<string,mixed> $device  Tap delivery device.
+     * @param array<string,mixed> $opts    ``control_id`` / ``on_completed``.
      */
     public function tap(array $tap, array $device, array $opts = []): TapAction
     {
@@ -865,18 +948,27 @@ class Call
         );
     }
 
+    /**
+     * @param array<string,mixed> $opts ``control_id`` / ``on_completed``.
+     */
     public function stream(string $url, array $opts = []): StreamAction
     {
         $extra = ['url' => $url] + $opts;
         return $this->startAction('calling.stream', StreamAction::class, $extra, $opts);
     }
 
+    /**
+     * @param array<string,mixed> $opts ``control_id`` / ``on_completed``.
+     */
     public function pay(string $paymentConnectorUrl, array $opts = []): PayAction
     {
         $extra = ['payment_connector_url' => $paymentConnectorUrl] + $opts;
         return $this->startAction('calling.pay', PayAction::class, $extra, $opts);
     }
 
+    /**
+     * @param array<string,mixed> $opts ``control_id`` / ``on_completed``.
+     */
     public function transcribe(array $opts = []): TranscribeAction
     {
         return $this->startAction('calling.transcribe', TranscribeAction::class, $opts, $opts);
@@ -884,6 +976,7 @@ class Call
 
     /**
      * @param array<string,mixed> $prompt AI prompt config.
+     * @param array<string,mixed> $opts   ``control_id`` / ``on_completed``.
      */
     public function ai(array $prompt, array $opts = []): AIAction
     {
@@ -901,6 +994,9 @@ class Call
 
     /**
      * Send a simple (non-action) RPC call and return the decoded result.
+     *
+     * @param array<string,mixed> $extra
+     * @return array<string,mixed>
      */
     private function execute(string $method, array $extra = []): array
     {
@@ -1043,6 +1139,8 @@ class Call
 
     /**
      * Common params present in every RPC call for this call.
+     *
+     * @return array{node_id: ?string, call_id: ?string}
      */
     private function baseParams(): array
     {

--- a/src/SignalWire/Relay/Client.php
+++ b/src/SignalWire/Relay/Client.php
@@ -24,6 +24,7 @@ class Client
     public string  $host;
     public string  $scheme = 'wss';
     public string  $relayPath = '/api/relay/ws';
+    /** @var list<string> */
     public array   $contexts = [];
     public bool    $connected = false;
     public ?string $sessionId = null;
@@ -91,6 +92,9 @@ class Client
     //  Construction
     // ══════════════════════════════════════════════════════════════════
 
+    /**
+     * @param array<string,mixed> $options
+     */
     public function __construct(array $options)
     {
         $this->project  = $options['project']  ?? '';
@@ -345,6 +349,8 @@ class Client
      * Send a JSON-RPC request and synchronously wait for the matching
      * response.  Returns the "result" portion of the response.
      *
+     * @param array<string,mixed> $params
+     * @return array<string,mixed>
      * @throws \RuntimeException on error responses or transport timeout.
      */
     public function execute(string $method, array $params = []): array
@@ -408,6 +414,8 @@ class Client
     /**
      * Encode and send a JSON message over the WebSocket. Throws if the
      * socket is closed; the run loop catches and triggers reconnect.
+     *
+     * @param array<string,mixed> $msg
      */
     public function send(array $msg): void
     {
@@ -517,6 +525,8 @@ class Client
 
     /**
      * Route a signalwire.event payload to the appropriate handler.
+     *
+     * @param array<string,mixed> $outerParams
      */
     public function handleEvent(array $outerParams): void
     {
@@ -735,6 +745,8 @@ class Client
     /**
      * Subscribe to one or more inbound contexts so that events for those
      * contexts are delivered to this client.
+     *
+     * @param list<string> $contexts
      */
     public function receive(array $contexts): void
     {
@@ -753,6 +765,8 @@ class Client
 
     /**
      * Unsubscribe from one or more contexts.
+     *
+     * @param list<string> $contexts
      */
     public function unreceive(array $contexts): void
     {
@@ -834,6 +848,8 @@ class Client
 
     /**
      * Handle an inbound call event – create the Call and fire the user handler.
+     *
+     * @param array<string,mixed> $params
      */
     private function handleInboundCall(Event $event, array $params): void
     {
@@ -869,6 +885,8 @@ class Client
      * Production wire shape: the dial event carries no top-level call_id;
      * the winner's call info lives inside ``params.call``. ``dial_state``
      * determines outcome (``answered``, ``failed``, ``no_answer``...).
+     *
+     * @param array<string,mixed> $params
      */
     private function handleDialEvent(Event $event, array $params): void
     {
@@ -923,6 +941,8 @@ class Client
 
     /**
      * Handle a server-initiated disconnect.
+     *
+     * @param array<string,mixed> $params
      */
     private function handleDisconnect(array $params): void
     {

--- a/src/SignalWire/Relay/Client.php
+++ b/src/SignalWire/Relay/Client.php
@@ -15,7 +15,7 @@ use SignalWire\Logging\Logger;
  * thin methods so that unit tests can subclass or mock without needing
  * a real WebSocket extension.
  */
-class Client
+class Client implements RelayClientLike
 {
     // ── identity / auth ───────────────────────────────────────────────
     public string  $project;
@@ -97,9 +97,11 @@ class Client
      */
     public function __construct(array $options)
     {
-        $this->project  = $options['project']  ?? '';
-        $this->token    = $options['token']    ?? '';
-        $this->contexts = $options['contexts'] ?? [];
+        $project = $options['project'] ?? null;
+        $this->project  = is_string($project) ? $project : '';
+        $token = $options['token'] ?? null;
+        $this->token    = is_string($token) ? $token : '';
+        $this->contexts = self::asStringList($options['contexts'] ?? null);
 
         // JWT-only mode: clients can authenticate with a fresh JWT instead
         // of project/token. Both code paths flow through ``connect()``.
@@ -111,11 +113,13 @@ class Client
         // to point at a local fixture; production uses SIGNALWIRE_SPACE.
         $relayHost = getenv('SIGNALWIRE_RELAY_HOST');
         $space = getenv('SIGNALWIRE_SPACE');
-        $this->host = $options['host']
+        $hostOpt = $options['host'] ?? null;
+        $this->host = (is_string($hostOpt) ? $hostOpt : null)
             ?? ($relayHost !== false && $relayHost !== '' ? $relayHost : '')
             ?: (is_string($space) ? $space : '');
 
-        $scheme = $options['scheme'] ?? null;
+        $schemeOpt = $options['scheme'] ?? null;
+        $scheme = is_string($schemeOpt) ? $schemeOpt : null;
         if ($scheme === null) {
             $envScheme = getenv('SIGNALWIRE_RELAY_SCHEME');
             $scheme = (is_string($envScheme) && $envScheme !== '')
@@ -252,8 +256,14 @@ class Client
         // mirrors it). Read that key — the journal records this connection's
         // frames under the same value, which lets a test scope its journal
         // reads/resets to its own session for concurrency-safe testing.
-        $this->sessionId = $result['sessionid'] ?? $this->sessionId;
-        $this->protocol  = $result['protocol']   ?? $this->protocol;
+        $sessionId = $result['sessionid'] ?? null;
+        if (is_string($sessionId)) {
+            $this->sessionId = $sessionId;
+        }
+        $protocol = $result['protocol'] ?? null;
+        if (is_string($protocol)) {
+            $this->protocol = $protocol;
+        }
         // Capture authorization blob if RELAY/audit fixture sent one.
         $authBlob = $result['authorization'] ?? null;
         if (is_array($authBlob)) {
@@ -484,43 +494,50 @@ class Client
         $this->logger->debug("<< {$raw}");
 
         $data = json_decode($raw, true);
-        if ($data === null) {
+        // A JSON-RPC frame is always an object — decode to a string-keyed
+        // array. Anything else (null from a parse error, a bare scalar, a
+        // top-level JSON array) is not a frame we can route.
+        if (!is_array($data)) {
             $this->logger->warn('Received unparseable message');
             return;
         }
 
         // ── response to a pending request ────────────────────────────
         $id = $data['id'] ?? null;
-        if ($id !== null && isset($this->pending[$id])) {
+        if (is_string($id) && isset($this->pending[$id])) {
             if (isset($data['error'])) {
-                ($this->pending[$id]['reject'])($data['error']);
+                ($this->pending[$id]['reject'])(is_array($data['error']) ? $data['error'] : []);
             } else {
-                ($this->pending[$id]['resolve'])($data['result'] ?? []);
+                $result = $data['result'] ?? [];
+                ($this->pending[$id]['resolve'])(is_array($result) ? $result : []);
             }
             return;
         }
 
         // ── server-initiated request (event / ping / disconnect) ─────
         $method = $data['method'] ?? null;
+        $ackId  = is_string($id) ? $id : '';
 
         if ($method === 'signalwire.ping') {
-            $this->sendAck($id ?? '');
+            $this->sendAck($ackId);
             return;
         }
 
         if ($method === 'signalwire.disconnect') {
-            $this->handleDisconnect($data['params'] ?? []);
+            $disconnectParams = $data['params'] ?? [];
+            $this->handleDisconnect(is_array($disconnectParams) ? $disconnectParams : []);
             return;
         }
 
         if ($method === 'signalwire.event') {
-            $this->sendAck($id ?? '');
+            $this->sendAck($ackId);
             $outerParams = $data['params'] ?? [];
-            $this->handleEvent($outerParams);
+            $this->handleEvent(is_array($outerParams) ? $outerParams : []);
             return;
         }
 
-        $this->logger->debug("Unhandled method: {$method}");
+        $methodLabel = is_string($method) ? $method : '(none)';
+        $this->logger->debug("Unhandled method: {$methodLabel}");
     }
 
     /**
@@ -530,14 +547,16 @@ class Client
      */
     public function handleEvent(array $outerParams): void
     {
-        $eventType = $outerParams['event_type'] ?? '';
-        $params    = $outerParams['params']     ?? [];
+        $eventTypeRaw = $outerParams['event_type'] ?? '';
+        $eventType    = is_string($eventTypeRaw) ? $eventTypeRaw : '';
+        $params       = self::asStringKeyedArray($outerParams['params'] ?? null);
 
         $event = new Event($eventType, $params);
 
         // ── authorization state ──────────────────────────────────────
         if ($eventType === 'signalwire.authorization.state') {
-            $this->authorizationState = $params['authorization_state'] ?? null;
+            $authState = $params['authorization_state'] ?? null;
+            $this->authorizationState = is_string($authState) ? $authState : null;
             $this->logger->info("Authorization state: {$this->authorizationState}");
             return;
         }
@@ -553,9 +572,11 @@ class Client
             // Materialize a Message from the event params (mirrors the
             // Python ``messaging.receive`` flow that hands a Message into
             // the handler, not a bare params dict).
+            $direction = $params['direction'] ?? null;
+            $state     = $params['message_state'] ?? $params['state'] ?? null;
             $msg = new Message(array_merge($params, [
-                'direction' => $params['direction'] ?? 'inbound',
-                'state'     => $params['message_state'] ?? $params['state'] ?? Constants::MESSAGE_STATE_RECEIVED,
+                'direction' => is_string($direction) ? $direction : 'inbound',
+                'state'     => is_string($state) ? $state : Constants::MESSAGE_STATE_RECEIVED,
             ]));
             $msgId = $msg->getMessageId();
             if ($msgId !== null) {
@@ -570,10 +591,10 @@ class Client
         // ── message state updates ────────────────────────────────────
         if ($eventType === 'messaging.state') {
             $msgId = $params['message_id'] ?? null;
-            if ($msgId !== null && isset($this->messages[$msgId])) {
+            if (is_string($msgId) && isset($this->messages[$msgId])) {
                 $this->messages[$msgId]->handleEvent($event);
                 $msgState = $params['state'] ?? $params['message_state'] ?? '';
-                if (isset(Constants::MESSAGE_TERMINAL_STATES[$msgState])) {
+                if (is_string($msgState) && isset(Constants::MESSAGE_TERMINAL_STATES[$msgState])) {
                     unset($this->messages[$msgId]);
                 }
             }
@@ -585,9 +606,9 @@ class Client
             $tag = $params['tag'] ?? null;
 
             // If this tag matches a pending dial, create/track the call
-            if ($tag !== null && isset($this->pendingDials[$tag])) {
+            if (is_string($tag) && isset($this->pendingDials[$tag])) {
                 $callId = $params['call_id'] ?? null;
-                if ($callId !== null && !isset($this->calls[$callId])) {
+                if (is_string($callId) && !isset($this->calls[$callId])) {
                     $call = new Call($params, $this);
                     $this->calls[$callId] = $call;
                 }
@@ -601,7 +622,8 @@ class Client
         }
 
         // ── default: route to the Call by call_id ────────────────────
-        $callId = $params['call_id'] ?? $event->getCallId();
+        $callIdRaw = $params['call_id'] ?? null;
+        $callId = is_string($callIdRaw) ? $callIdRaw : $event->getCallId();
         if ($callId !== null && isset($this->calls[$callId])) {
             $call = $this->calls[$callId];
             $call->dispatchEvent($event);
@@ -642,8 +664,10 @@ class Client
      */
     public function dial(array $devices, array $opts = []): Call
     {
-        $tag = $opts['tag'] ?? $this->generateUuid();
-        $dialTimeout = (float) ($opts['dial_timeout'] ?? 30.0);
+        $tagOpt = $opts['tag'] ?? null;
+        $tag = is_string($tagOpt) ? $tagOpt : $this->generateUuid();
+        $timeoutOpt = $opts['dial_timeout'] ?? 30.0;
+        $dialTimeout = is_int($timeoutOpt) || is_float($timeoutOpt) ? (float) $timeoutOpt : 30.0;
 
         // Strip control keys from opts before passing the rest as wire
         // params alongside ``devices`` and ``tag``.
@@ -725,7 +749,8 @@ class Client
 
         $result = $this->execute('messaging.send', $params);
 
-        $messageId = $result['message_id'] ?? $this->generateUuid();
+        $messageIdRaw = $result['message_id'] ?? null;
+        $messageId = is_string($messageIdRaw) ? $messageIdRaw : $this->generateUuid();
 
         // Materialize the Message with the request params *and* the
         // server-issued message_id, in the ``queued`` initial state. The
@@ -828,6 +853,47 @@ class Client
     // ══════════════════════════════════════════════════════════════════
 
     /**
+     * Narrow a JSON-decoded value to an ``array<string,mixed>`` (a JSON
+     * object). RELAY event/params payloads are always objects on the wire;
+     * a missing or non-object value yields an empty array. Re-keys to
+     * guarantee string keys for the strict ``array<string,mixed>`` shape.
+     *
+     * @return array<string,mixed>
+     */
+    private static function asStringKeyedArray(mixed $value): array
+    {
+        if (!is_array($value)) {
+            return [];
+        }
+        $out = [];
+        foreach ($value as $key => $item) {
+            $out[(string) $key] = $item;
+        }
+        return $out;
+    }
+
+    /**
+     * Narrow a value to a ``list<string>`` — keeping only the string
+     * entries (RELAY ``contexts`` are an array of strings). A missing or
+     * non-array value yields an empty list.
+     *
+     * @return list<string>
+     */
+    private static function asStringList(mixed $value): array
+    {
+        if (!is_array($value)) {
+            return [];
+        }
+        $out = [];
+        foreach ($value as $item) {
+            if (is_string($item)) {
+                $out[] = $item;
+            }
+        }
+        return $out;
+    }
+
+    /**
      * Generate a UUID v4.
      */
     private function generateUuid(): string
@@ -854,7 +920,7 @@ class Client
     private function handleInboundCall(Event $event, array $params): void
     {
         $callId = $params['call_id'] ?? null;
-        if ($callId === null) {
+        if (!is_string($callId)) {
             $this->logger->warn('Inbound call event missing call_id');
             return;
         }
@@ -892,10 +958,12 @@ class Client
     {
         $tag       = $params['tag']        ?? null;
         $dialState = $params['dial_state'] ?? $params['state'] ?? null;
-        $callBlob  = $params['call']       ?? null;
-        $callId    = $params['call_id']    ?? (is_array($callBlob) ? ($callBlob['call_id'] ?? null) : null);
+        $callBlobRaw = $params['call']     ?? null;
+        $callBlob  = is_array($callBlobRaw) ? self::asStringKeyedArray($callBlobRaw) : null;
+        $callIdRaw = $params['call_id'] ?? ($callBlob !== null ? ($callBlob['call_id'] ?? null) : null);
+        $callId    = is_string($callIdRaw) ? $callIdRaw : null;
 
-        if ($tag === null) {
+        if (!is_string($tag)) {
             return;
         }
 
@@ -911,7 +979,7 @@ class Client
         $call = null;
         if ($callId !== null && isset($this->calls[$callId])) {
             $call = $this->calls[$callId];
-        } elseif (is_array($callBlob)) {
+        } elseif ($callBlob !== null) {
             // Production shape: nested params.call has call_id/node_id/tag/device.
             $call = new Call($callBlob, $this);
             if ($call->callId !== null) {

--- a/src/SignalWire/Relay/Event.php
+++ b/src/SignalWire/Relay/Event.php
@@ -56,27 +56,32 @@ class Event
 
     public function getCallId(): ?string
     {
-        return $this->params['call_id'] ?? null;
+        $value = $this->params['call_id'] ?? null;
+        return is_string($value) ? $value : null;
     }
 
     public function getNodeId(): ?string
     {
-        return $this->params['node_id'] ?? null;
+        $value = $this->params['node_id'] ?? null;
+        return is_string($value) ? $value : null;
     }
 
     public function getControlId(): ?string
     {
-        return $this->params['control_id'] ?? null;
+        $value = $this->params['control_id'] ?? null;
+        return is_string($value) ? $value : null;
     }
 
     public function getTag(): ?string
     {
-        return $this->params['tag'] ?? null;
+        $value = $this->params['tag'] ?? null;
+        return is_string($value) ? $value : null;
     }
 
     public function getState(): ?string
     {
-        return $this->params['state'] ?? null;
+        $value = $this->params['state'] ?? null;
+        return is_string($value) ? $value : null;
     }
 
     /**

--- a/src/SignalWire/Relay/Event.php
+++ b/src/SignalWire/Relay/Event.php
@@ -27,6 +27,9 @@ class Event
 {
     private readonly float $timestamp;
 
+    /**
+     * @param array<string,mixed> $params
+     */
     public function __construct(
         private readonly string $eventType,
         private readonly array $params,
@@ -45,6 +48,7 @@ class Event
         return $this->timestamp;
     }
 
+    /** @return array<string,mixed> */
     public function getParams(): array
     {
         return $this->params;
@@ -91,6 +95,7 @@ class Event
         return is_string($wire) ? DialState::tryFromWire($wire) : null;
     }
 
+    /** @return array{event_type: string, timestamp: float, params: array<string,mixed>} */
     public function toArray(): array
     {
         return [
@@ -100,6 +105,9 @@ class Event
         ];
     }
 
+    /**
+     * @param array<string,mixed> $params
+     */
     public static function parse(string $eventType, array $params): self
     {
         return new self($eventType, $params);

--- a/src/SignalWire/Relay/Message.php
+++ b/src/SignalWire/Relay/Message.php
@@ -20,7 +20,9 @@ class Message
     protected ?string $fromNumber;
     protected ?string $toNumber;
     protected ?string $body;
+    /** @var list<string> */
     protected array $media;
+    /** @var list<string> */
     protected array $tags;
     protected ?string $state = null;
     protected ?string $reason = null;
@@ -40,6 +42,8 @@ class Message
      * Expected keys (all optional with sane defaults):
      *   message_id, context, direction, from_number / from,
      *   to_number / to, body, media, tags, state, reason
+     *
+     * @param array<string,mixed> $params
      */
     public function __construct(array $params = [])
     {
@@ -205,11 +209,13 @@ class Message
         return $this->body;
     }
 
+    /** @return list<string> */
     public function getMedia(): array
     {
         return $this->media;
     }
 
+    /** @return list<string> */
     public function getTags(): array
     {
         return $this->tags;

--- a/src/SignalWire/Relay/Message.php
+++ b/src/SignalWire/Relay/Message.php
@@ -47,16 +47,48 @@ class Message
      */
     public function __construct(array $params = [])
     {
-        $this->messageId = $params['message_id'] ?? $params['id'] ?? null;
-        $this->context = $params['context'] ?? null;
-        $this->direction = $params['direction'] ?? null;
-        $this->fromNumber = $params['from_number'] ?? $params['from'] ?? null;
-        $this->toNumber = $params['to_number'] ?? $params['to'] ?? null;
-        $this->body = $params['body'] ?? null;
-        $this->media = $params['media'] ?? [];
-        $this->tags = $params['tags'] ?? [];
-        $this->state = $params['state'] ?? null;
-        $this->reason = $params['reason'] ?? null;
+        $this->messageId = self::asNullableString($params['message_id'] ?? $params['id'] ?? null);
+        $this->context = self::asNullableString($params['context'] ?? null);
+        $this->direction = self::asNullableString($params['direction'] ?? null);
+        $this->fromNumber = self::asNullableString($params['from_number'] ?? $params['from'] ?? null);
+        $this->toNumber = self::asNullableString($params['to_number'] ?? $params['to'] ?? null);
+        $this->body = self::asNullableString($params['body'] ?? null);
+        $this->media = self::asStringList($params['media'] ?? null);
+        $this->tags = self::asStringList($params['tags'] ?? null);
+        $this->state = self::asNullableString($params['state'] ?? null);
+        $this->reason = self::asNullableString($params['reason'] ?? null);
+    }
+
+    /**
+     * Narrow a JSON-decoded value to a string, or null when it is absent or
+     * a non-string (the RELAY messaging fields below are all strings on the
+     * wire — see the Python reference's ``str`` typing in relay/message.py).
+     */
+    private static function asNullableString(mixed $value): ?string
+    {
+        return is_string($value) ? $value : null;
+    }
+
+    /**
+     * Narrow a JSON-decoded value to a ``list<string>`` — keeping only the
+     * string entries (RELAY ``media``/``tags`` are arrays of strings; the
+     * Python reference types them as ``list[str]``). A missing or non-array
+     * value yields an empty list.
+     *
+     * @return list<string>
+     */
+    private static function asStringList(mixed $value): array
+    {
+        if (!is_array($value)) {
+            return [];
+        }
+        $out = [];
+        foreach ($value as $item) {
+            if (is_string($item)) {
+                $out[] = $item;
+            }
+        }
+        return $out;
     }
 
     // ------------------------------------------------------------------
@@ -79,20 +111,20 @@ class Message
 
         // Update mutable fields from the event payload.
         $newState = $params['state'] ?? $params['message_state'] ?? null;
-        if ($newState !== null) {
+        if (is_string($newState)) {
             $this->state = $newState;
         }
-        if (isset($params['reason'])) {
+        if (is_string($params['reason'] ?? null)) {
             $this->reason = $params['reason'];
         }
-        if (isset($params['body'])) {
+        if (is_string($params['body'] ?? null)) {
             $this->body = $params['body'];
         }
         if (isset($params['media'])) {
-            $this->media = $params['media'];
+            $this->media = self::asStringList($params['media']);
         }
         if (isset($params['tags'])) {
-            $this->tags = $params['tags'];
+            $this->tags = self::asStringList($params['tags']);
         }
 
         // Notify all registered event listeners.

--- a/src/SignalWire/Relay/RelayClientLike.php
+++ b/src/SignalWire/Relay/RelayClientLike.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SignalWire\Relay;
+
+/**
+ * INTERNAL duck-type contract for the RELAY client that Call and Action handles
+ * drive. Mirrors the TypeScript port's `RelayClientLike` pattern: it is NOT part
+ * of the public surface and is consumed only internally. It declares EXACTLY the
+ * methods Call/Action invoke on the client (with Client's real signatures), so
+ * the duck-typed `$client` receiver can be typed precisely without coupling the
+ * action handles to the concrete Client.
+ *
+ * @internal
+ */
+interface RelayClientLike
+{
+    /**
+     * Send a JSON-RPC request and return the "result" portion of the response.
+     *
+     * @param array<string, mixed> $params
+     * @return array<string, mixed>
+     */
+    public function execute(string $method, array $params = []): array;
+
+    /**
+     * Pump a single inbound frame through the transport (event-loop step).
+     */
+    public function readOnce(): void;
+}

--- a/src/SignalWire/SWAIG/FunctionResult.php
+++ b/src/SignalWire/SWAIG/FunctionResult.php
@@ -8,6 +8,7 @@ class FunctionResult
 {
     private string $response;
     private bool $postProcess;
+    /** @var list<array<string,mixed>> */
     private array $actions = [];
 
     public function __construct(?string $response = '', bool $postProcess = false)
@@ -30,12 +31,18 @@ class FunctionResult
         return $this;
     }
 
+    /**
+     * @param array<string,mixed> $action
+     */
     public function addAction(array $action): self
     {
         $this->actions[] = $action;
         return $this;
     }
 
+    /**
+     * @param list<array<string,mixed>> $actions
+     */
     public function addActions(array $actions): self
     {
         foreach ($actions as $action) {
@@ -44,6 +51,9 @@ class FunctionResult
         return $this;
     }
 
+    /**
+     * @return array<string,mixed>
+     */
     public function toArray(): array
     {
         $result = [];
@@ -72,7 +82,11 @@ class FunctionResult
 
     public function toJson(): string
     {
-        return json_encode($this->toArray());
+        $encoded = json_encode($this->toArray());
+        if ($encoded === false) {
+            throw new \RuntimeException('json_encode failed');
+        }
+        return $encoded;
     }
 
     // ── Call Control ─────────────────────────────────────────────────────
@@ -169,6 +183,9 @@ class FunctionResult
 
     // ── State & Data ─────────────────────────────────────────────────────
 
+    /**
+     * @param array<string,mixed> $data
+     */
     public function updateGlobalData(array $data): self
     {
         $this->actions[] = ['set_global_data' => $data];
@@ -186,6 +203,9 @@ class FunctionResult
         return $this;
     }
 
+    /**
+     * @param array<string,mixed> $data
+     */
     public function setMetadata(array $data): self
     {
         $this->actions[] = ['set_meta_data' => $data];
@@ -203,6 +223,9 @@ class FunctionResult
         return $this;
     }
 
+    /**
+     * @param array<string,mixed> $eventData
+     */
     public function swmlUserEvent(array $eventData): self
     {
         // Python wraps the event in a SWML document with the data nested under
@@ -427,6 +450,9 @@ class FunctionResult
 
     // ── Speech & AI ──────────────────────────────────────────────────────
 
+    /**
+     * @param list<string|array<string,mixed>> $hints
+     */
     public function addDynamicHints(array $hints): self
     {
         $this->actions[] = ['add_dynamic_hints' => $hints];
@@ -455,6 +481,9 @@ class FunctionResult
         return $this;
     }
 
+    /**
+     * @param array<string,bool> $toggles map of function name => active flag
+     */
     public function toggleFunctions(array $toggles): self
     {
         $formatted = [];
@@ -478,6 +507,9 @@ class FunctionResult
         return $this;
     }
 
+    /**
+     * @param array<string,mixed> $settings
+     */
     public function updateSettings(array $settings): self
     {
         // Python action name is "settings" (not "ai_settings").
@@ -494,7 +526,7 @@ class FunctionResult
      * key "transfer" => "true" is set INSIDE the SWML document; the action is
      * ALWAYS added under the "SWML" key (there is no separate transfer key).
      *
-     * @param array|string $swmlContent SWML JSON string or already-decoded array.
+     * @param array<string,mixed>|string $swmlContent SWML JSON string or already-decoded array.
      */
     public function executeSwml($swmlContent, bool $transfer = false): self
     {

--- a/src/SignalWire/SWML/Document.php
+++ b/src/SignalWire/SWML/Document.php
@@ -69,6 +69,8 @@ class Document
 
     /**
      * Append a pre-formatted verb hash to a section.
+     *
+     * @param array<string, mixed> $verbHash
      */
     public function addRawVerb(string $section, array $verbHash): void
     {
@@ -114,7 +116,11 @@ class Document
      */
     public function render(): string
     {
-        return json_encode($this->toArray(), JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+        $encoded = json_encode($this->toArray(), JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+        if ($encoded === false) {
+            throw new \RuntimeException('json_encode failed');
+        }
+        return $encoded;
     }
 
     /**
@@ -122,6 +128,10 @@ class Document
      */
     public function renderPretty(): string
     {
-        return json_encode($this->toArray(), JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+        $encoded = json_encode($this->toArray(), JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+        if ($encoded === false) {
+            throw new \RuntimeException('json_encode failed');
+        }
+        return $encoded;
     }
 }

--- a/src/SignalWire/SWML/RequestHandlerLike.php
+++ b/src/SignalWire/SWML/RequestHandlerLike.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SignalWire\SWML;
+
+/**
+ * INTERNAL duck-type contract for the HTTP request handler that the serverless
+ * Adapter drives. The Adapter is the PHP analogue of the TypeScript port's
+ * adapter that takes the converted app/router (`{ fetch }`) rather than an
+ * AgentBase: it invokes only the request-serving surface — handleRequest() and
+ * run() — never agent-config methods. This interface declares exactly those two
+ * methods (with Service's real signatures) so the Adapter's `$agent` receiver
+ * can be typed precisely.
+ *
+ * Not part of the public surface; consumed only internally.
+ *
+ * @internal
+ */
+interface RequestHandlerLike
+{
+    /**
+     * Handle an HTTP request. Returns [status, headers, body].
+     *
+     * @param array<string, string> $headers
+     * @return array{int, array<string, string>, string}
+     */
+    public function handleRequest(
+        string $method,
+        string $path,
+        array $headers = [],
+        ?string $body = null,
+    ): array;
+
+    /**
+     * Run the service (blocking serve loop).
+     */
+    public function run(): void;
+}

--- a/src/SignalWire/SWML/Schema.php
+++ b/src/SignalWire/SWML/Schema.php
@@ -84,15 +84,38 @@ class Schema
         if ($raw === false) {
             throw new \RuntimeException("Failed to read SWML schema.json at {$schemaPath}");
         }
-        $this->schemaData = json_decode($raw, true, 512, JSON_THROW_ON_ERROR);
+        $decoded = json_decode($raw, true, 512, JSON_THROW_ON_ERROR);
+        if (!is_array($decoded)) {
+            throw new \RuntimeException("SWML schema.json did not decode to an object at {$schemaPath}");
+        }
+        // The top-level schema is a JSON object, so all keys are strings.
+        $schemaData = [];
+        foreach ($decoded as $k => $v) {
+            if (is_string($k)) {
+                $schemaData[$k] = $v;
+            }
+        }
+        $this->schemaData = $schemaData;
 
-        $defs = $this->schemaData['$defs'] ?? [];
-        $swmlMethod = $defs['SWMLMethod'] ?? [];
-        $anyOf = $swmlMethod['anyOf'] ?? [];
+        $defs = $this->schemaData['$defs'] ?? null;
+        if (!is_array($defs)) {
+            return;
+        }
+        $swmlMethod = $defs['SWMLMethod'] ?? null;
+        if (!is_array($swmlMethod)) {
+            return;
+        }
+        $anyOf = $swmlMethod['anyOf'] ?? null;
+        if (!is_array($anyOf)) {
+            return;
+        }
 
         foreach ($anyOf as $entry) {
+            if (!is_array($entry)) {
+                continue;
+            }
             $ref = $entry['$ref'] ?? null;
-            if ($ref === null) {
+            if (!is_string($ref)) {
                 continue;
             }
 
@@ -101,21 +124,34 @@ class Schema
             $defName = end($parts);
 
             $defn = $defs[$defName] ?? null;
-            if ($defn === null) {
+            if (!is_array($defn)) {
                 continue;
             }
 
-            $props = $defn['properties'] ?? [];
-            if (empty($props)) {
+            $props = $defn['properties'] ?? null;
+            if (!is_array($props) || empty($props)) {
                 continue;
             }
 
             // The first property key is the actual verb name
             $actualVerb = array_key_first($props);
+            if (!is_string($actualVerb)) {
+                continue;
+            }
+
+            // JSON objects decode to string keys; keep only those so the
+            // definition matches the declared array<string, mixed> shape.
+            $definition = [];
+            foreach ($defn as $k => $v) {
+                if (is_string($k)) {
+                    $definition[$k] = $v;
+                }
+            }
+
             $this->verbs[$actualVerb] = [
                 'name' => $actualVerb,
                 'schema_name' => $defName,
-                'definition' => $defn,
+                'definition' => $definition,
             ];
         }
     }

--- a/src/SignalWire/SWML/Schema.php
+++ b/src/SignalWire/SWML/Schema.php
@@ -8,9 +8,10 @@ class Schema
 {
     private static ?self $instance = null;
 
-    /** @var array<string, array{name: string, schema_name: string, definition: array}> */
+    /** @var array<string, array{name: string, schema_name: string, definition: array<string,mixed>}> */
     private array $verbs = [];
 
+    /** @var array<string,mixed> */
     private array $schemaData = [];
 
     private function __construct()
@@ -57,7 +58,7 @@ class Schema
     /**
      * Get verb metadata, or null if not found.
      *
-     * @return array{name: string, schema_name: string, definition: array}|null
+     * @return array{name: string, schema_name: string, definition: array<string,mixed>}|null
      */
     public function getVerb(string $name): ?array
     {
@@ -80,6 +81,9 @@ class Schema
         }
 
         $raw = file_get_contents($schemaPath);
+        if ($raw === false) {
+            throw new \RuntimeException("Failed to read SWML schema.json at {$schemaPath}");
+        }
         $this->schemaData = json_decode($raw, true, 512, JSON_THROW_ON_ERROR);
 
         $defs = $this->schemaData['$defs'] ?? [];

--- a/src/SignalWire/SWML/Service.php
+++ b/src/SignalWire/SWML/Service.php
@@ -8,7 +8,7 @@ use SignalWire\Logging\Logger;
 use SignalWire\SWAIG\FunctionResult;
 use SignalWire\Utils\SchemaUtils;
 
-class Service
+class Service implements RequestHandlerLike
 {
     protected string $name;
     protected string $route;
@@ -58,7 +58,14 @@ class Service
         $this->name = $name;
         $this->route = rtrim($route, '/') ?: '/';
         $this->host = $host ?? '0.0.0.0';
-        $this->port = $port ?? (int) ($_ENV['PORT'] ?? getenv('PORT') ?: 3000);
+        if ($port !== null) {
+            $this->port = $port;
+        } else {
+            $envPort = $_ENV['PORT'] ?? getenv('PORT');
+            $this->port = (is_string($envPort) || is_int($envPort)) && (int) $envPort !== 0
+                ? (int) $envPort
+                : 3000;
+        }
         $this->document = new Document();
         $this->logger = Logger::getLogger('swml_service');
 
@@ -127,9 +134,9 @@ class Service
             // sleep(2000) or sleep('main', 2000)
             if (count($args) === 1 && is_int($args[0])) {
                 $config = $args[0];
-            } elseif (count($args) === 2) {
-                $section = (string) $args[0];
-                $config = (int) $args[1];
+            } elseif (count($args) === 2 && is_string($args[0]) && is_int($args[1])) {
+                $section = $args[0];
+                $config = $args[1];
             } else {
                 throw new \InvalidArgumentException('sleep requires an integer duration');
             }
@@ -144,7 +151,7 @@ class Service
                     $config = $args[0];
                 }
             } elseif (count($args) === 2) {
-                $section = (string) $args[0];
+                $section = is_string($args[0]) ? $args[0] : 'main';
                 $config = is_array($args[1]) ? $args[1] : [];
             }
         }
@@ -261,7 +268,7 @@ class Service
     public function registerSwaigFunction(array $funcDef): static
     {
         $name = $funcDef['function'] ?? '';
-        if ($name === '') {
+        if (!is_string($name) || $name === '') {
             return $this;
         }
         $this->tools[$name] = $funcDef;
@@ -566,7 +573,15 @@ class Service
             if (strlen($body) > 1_048_576) {
                 return $this->jsonResponse(413, ['error' => 'Request body too large']);
             }
-            $requestData = json_decode($body, true);
+            $decoded = json_decode($body, true);
+            if (is_array($decoded)) {
+                $requestData = [];
+                foreach ($decoded as $k => $v) {
+                    if (is_string($k)) {
+                        $requestData[$k] = $v;
+                    }
+                }
+            }
         }
 
         // Webhook signature validation (when signing_key is configured) —
@@ -646,14 +661,22 @@ class Service
         }
 
         $functionName = $requestData['function'] ?? '';
-        if ($functionName === '') {
+        if (!is_string($functionName) || $functionName === '') {
             return $this->jsonResponse(400, ['error' => 'Missing function name']);
         }
         if (!preg_match('/^[a-zA-Z_][a-zA-Z0-9_]*$/', $functionName)) {
             return $this->jsonResponse(400, ['error' => "Invalid function name format: '{$functionName}'"]);
         }
 
-        $args = $requestData['argument']['parsed'][0]
+        $argument = $requestData['argument'] ?? null;
+        $parsedFirst = null;
+        if (is_array($argument)) {
+            $parsed = $argument['parsed'] ?? null;
+            if (is_array($parsed)) {
+                $parsedFirst = $parsed[0] ?? null;
+            }
+        }
+        $args = $parsedFirst
             ?? (is_array($requestData['arguments'] ?? null) ? $requestData['arguments'] : []);
         if (!is_array($args)) {
             $args = [];
@@ -700,7 +723,8 @@ class Service
         }
 
         // Look for SIP URI in common locations
-        $sipUri = $requestBody['call']['to'] ?? $requestBody['to'] ?? null;
+        $call = $requestBody['call'] ?? null;
+        $sipUri = (is_array($call) ? ($call['to'] ?? null) : null) ?? $requestBody['to'] ?? null;
         if ($sipUri === null || !is_string($sipUri)) {
             return null;
         }
@@ -735,7 +759,8 @@ class Service
         //    AgentBase). Subclasses that override the proxy URL set
         //    $this->manualProxyUrl; check via property_exists for safety.
         if (property_exists($this, 'manualProxyUrl')
-            && !empty($this->manualProxyUrl)
+            && is_string($this->manualProxyUrl ?? null)
+            && $this->manualProxyUrl !== ''
         ) {
             return $this->manualProxyUrl;
         }
@@ -749,13 +774,13 @@ class Service
         // 2. X-Forwarded-Proto + X-Forwarded-Host
         $proto = $headers['X-Forwarded-Proto'] ?? $headers['x-forwarded-proto'] ?? null;
         $fwdHost = $headers['X-Forwarded-Host'] ?? $headers['x-forwarded-host'] ?? null;
-        if ($proto !== null && $fwdHost !== null) {
+        if (is_string($proto) && is_string($fwdHost)) {
             return "{$proto}://{$fwdHost}";
         }
 
         // 3. X-Original-URL
         $origUrl = $headers['X-Original-URL'] ?? $headers['x-original-url'] ?? null;
-        if ($origUrl !== null) {
+        if (is_string($origUrl)) {
             return rtrim($origUrl, '/');
         }
 
@@ -823,24 +848,28 @@ class Service
     public function dispatchFromGlobals(): void
     {
         $method = $_SERVER['REQUEST_METHOD'] ?? 'GET';
-        $path = parse_url($_SERVER['REQUEST_URI'] ?? '/', PHP_URL_PATH) ?: '/';
+        $method = is_string($method) ? $method : 'GET';
+        $requestUri = $_SERVER['REQUEST_URI'] ?? '/';
+        $path = parse_url(is_string($requestUri) ? $requestUri : '/', PHP_URL_PATH) ?: '/';
 
         // Reconstruct headers from $_SERVER (cli-server doesn't populate
         // getallheaders() reliably; this works in every SAPI).
         $headers = [];
         foreach ($_SERVER as $k => $v) {
-            if (str_starts_with($k, 'HTTP_')) {
+            if (is_string($k) && str_starts_with($k, 'HTTP_') && is_string($v)) {
                 $name = str_replace('_', '-', substr($k, 5));
                 // Title-case for Authorization, Content-Type compatibility
                 $name = ucwords(strtolower($name), '-');
                 $headers[$name] = $v;
             }
         }
-        if (isset($_SERVER['CONTENT_TYPE'])) {
-            $headers['Content-Type'] = $_SERVER['CONTENT_TYPE'];
+        $contentType = $_SERVER['CONTENT_TYPE'] ?? null;
+        if (is_string($contentType)) {
+            $headers['Content-Type'] = $contentType;
         }
-        if (isset($_SERVER['CONTENT_LENGTH'])) {
-            $headers['Content-Length'] = $_SERVER['CONTENT_LENGTH'];
+        $contentLength = $_SERVER['CONTENT_LENGTH'] ?? null;
+        if (is_string($contentLength)) {
+            $headers['Content-Length'] = $contentLength;
         }
         // PHP's cli-server eats the Authorization header for CGI safety;
         // recover it from REDIRECT_HTTP_AUTHORIZATION / PHP_AUTH_USER if set.
@@ -850,11 +879,12 @@ class Service
                 ?? null;
             if (is_string($authVal) && $authVal !== '') {
                 $headers['Authorization'] = $authVal;
-            } elseif (isset($_SERVER['PHP_AUTH_USER'])) {
+            } elseif (is_string($_SERVER['PHP_AUTH_USER'] ?? null)) {
                 // Reconstruct Basic auth from PHP_AUTH_USER/PW which are
                 // always present when the front-end has parsed the header.
-                $user = (string) $_SERVER['PHP_AUTH_USER'];
-                $pw = (string) ($_SERVER['PHP_AUTH_PW'] ?? '');
+                $user = $_SERVER['PHP_AUTH_USER'];
+                $pwRaw = $_SERVER['PHP_AUTH_PW'] ?? '';
+                $pw = is_string($pwRaw) ? $pwRaw : '';
                 $headers['Authorization'] = 'Basic ' . base64_encode($user . ':' . $pw);
             }
         }
@@ -896,7 +926,8 @@ class Service
         if (is_string($script) && $script !== '' && file_exists($script)) {
             return realpath($script) ?: $script;
         }
-        $argv0 = $_SERVER['argv'][0] ?? null;
+        $argv = $_SERVER['argv'] ?? null;
+        $argv0 = is_array($argv) ? ($argv[0] ?? null) : null;
         if (is_string($argv0) && $argv0 !== '') {
             $abs = realpath($argv0);
             if ($abs !== false && file_exists($abs)) {

--- a/src/SignalWire/SWML/Service.php
+++ b/src/SignalWire/SWML/Service.php
@@ -32,7 +32,7 @@ class Service
      * SWAIG tool registry — lifted from AgentBase so any Service (sidecar,
      * non-agent verb host, etc.) can register and dispatch SWAIG functions.
      *
-     * @var array<string, array>
+     * @var array<string, array<string, mixed>>
      */
     protected array $tools = [];
 
@@ -110,6 +110,8 @@ class Service
      *   $service->answer('main', ['max_duration' => 3600]);
      *   $service->sleep('main', 2000);
      *   $service->hangup();
+     *
+     * @param list<mixed> $args
      */
     public function __call(string $method, array $args): static
     {
@@ -174,7 +176,10 @@ class Service
 
     /** Get (user, password, source) where source is "provided",
      * "environment", or "generated". Python parity:
-     * AuthMixin.get_basic_auth_credentials(include_source=True). */
+     * AuthMixin.get_basic_auth_credentials(include_source=True).
+     *
+     * @return array{string, string, string} [user, password, source]
+     */
     public function getBasicAuthCredentialsWithSource(): array
     {
         $envUser = getenv('SWML_BASIC_AUTH_USER');
@@ -222,6 +227,8 @@ class Service
      *
      * Tool descriptions and parameter descriptions are LLM-facing prompt
      * engineering, not internal documentation. See PORTING_GUIDE for guidance.
+     *
+     * @param array<string, mixed> $parameters JSON-Schema `properties` map for the tool argument.
      */
     public function defineTool(
         string $name,
@@ -248,6 +255,8 @@ class Service
 
     /**
      * Register a raw SWAIG function definition (e.g. DataMap tools).
+     *
+     * @param array<string, mixed> $funcDef
      */
     public function registerSwaigFunction(array $funcDef): static
     {
@@ -264,6 +273,8 @@ class Service
 
     /**
      * Register multiple tool definitions at once.
+     *
+     * @param list<array<string, mixed>> $toolDefs
      */
     public function defineTools(array $toolDefs): static
     {
@@ -280,7 +291,7 @@ class Service
      * harness, and any test that needs to inspect what's been
      * registered without going through a HTTP round trip).
      *
-     * @return array<string, array> name => tool definition
+     * @return array<string, array<string, mixed>> name => tool definition
      */
     public function getTools(): array
     {
@@ -295,14 +306,18 @@ class Service
     }
 
     /** Get a registered SWAIG function by name, or null when absent.
-     * Python parity: ``ToolRegistry.get_function``. */
+     * Python parity: ``ToolRegistry.get_function``.
+     *
+     * @return array<string, mixed>|null */
     public function getFunction(string $name): ?array
     {
         return $this->tools[$name] ?? null;
     }
 
     /** Snapshot of all registered SWAIG functions keyed by name.
-     * Python parity: ``ToolRegistry.get_all_functions``. */
+     * Python parity: ``ToolRegistry.get_all_functions``.
+     *
+     * @return array<string, array<string, mixed>> */
     public function getAllFunctions(): array
     {
         return $this->tools;  // copy on read in PHP arrays
@@ -333,6 +348,9 @@ class Service
 
     /**
      * Dispatch a function call to the registered handler.
+     *
+     * @param array<string, mixed> $args    parsed function arguments
+     * @param array<string, mixed> $rawData full SWAIG request payload
      */
     public function onFunctionCall(string $name, array $args, array $rawData): ?FunctionResult
     {
@@ -378,7 +396,9 @@ class Service
      * config. Returns [target, shortCircuit]: shortCircuit non-null replies
      * directly without dispatch.
      *
-     * @return array{0: object, 1: ?array}
+     * @param array<string, mixed> $requestData
+     * @param array<string, string> $headers
+     * @return array{0: self, 1: ?array<string, mixed>}
      */
     protected function swaigPreDispatch(array $requestData, array $headers, string $functionName): array
     {
@@ -400,6 +420,9 @@ class Service
      * Python parity: WebMixin.on_request(request_data, callback_path).
      * The Python third `request` arg is FastAPI-specific and is not
      * mirrored.
+     *
+     * @param array<string, mixed>|null $requestData
+     * @return array<string, mixed>|null
      */
     public function onRequest(?array $requestData = null, ?string $callbackPath = null): ?array
     {
@@ -413,6 +436,9 @@ class Service
      * callback path and return an associative array of overrides.
      *
      * Python parity: WebMixin.on_swml_request(request_data, callback_path).
+     *
+     * @param array<string, mixed>|null $requestData
+     * @return array<string, mixed>|null
      */
     public function onSwmlRequest(?array $requestData = null, ?string $callbackPath = null): ?array
     {
@@ -473,6 +499,10 @@ class Service
 
     /**
      * Render SWML for a request. Subclasses override this.
+     *
+     * @param array<string, mixed>|null $requestBody
+     * @param array<string, string> $headers
+     * @return array<string, mixed>
      */
     public function renderSwml(?array $requestBody = null, array $headers = []): array
     {
@@ -486,6 +516,7 @@ class Service
     /**
      * Handle an HTTP request. Returns [status, headers, body].
      *
+     * @param array<string, string> $headers
      * @return array{int, array<string, string>, string}
      */
     public function handleRequest(
@@ -578,6 +609,11 @@ class Service
     /**
      * Handle SWML document request.
      */
+    /**
+     * @param array<string, string> $headers
+     * @param array<string, mixed>|null $requestData
+     * @return array{int, array<string, string>, string}
+     */
     protected function handleSwmlRequest(string $method, ?array $requestData, array $headers): array
     {
         $swml = $this->renderSwml($requestData, $headers);
@@ -593,6 +629,10 @@ class Service
      *
      * Lifted from AgentBase so non-agent SWMLServices (e.g. ai_sidecar host)
      * can serve /swaig without subclassing AgentBase.
+     *
+     * @param array<string, string> $headers
+     * @param array<string, mixed>|null $requestData
+     * @return array{int, array<string, string>, string}
      */
     protected function handleSwaigRequest(string $method, ?array $requestData, array $headers): array
     {
@@ -633,6 +673,10 @@ class Service
 
     /**
      * Handle post-prompt callback. Override in AgentBase.
+     *
+     * @param array<string, mixed>|null $requestData
+     * @param array<string, string> $headers
+     * @return array{int, array<string, string>, string}
      */
     protected function handlePostPrompt(?array $requestData, array $headers): array
     {
@@ -646,6 +690,8 @@ class Service
     /**
      * Extract SIP username from a request body.
      * Validates format: only [a-zA-Z0-9._-], max 64 chars.
+     *
+     * @param array<string, mixed>|null $requestBody
      */
     public static function extractSipUsername(?array $requestBody): ?string
     {
@@ -680,6 +726,8 @@ class Service
 
     /**
      * Detect or construct the proxy URL base from request headers.
+     *
+     * @param array<string, mixed> $headers
      */
     public function getProxyUrlBase(array $headers = []): string
     {
@@ -966,6 +1014,8 @@ class Service
      *    proto + host. getProxyUrlBase already normalises this.
      *  - The query string MUST be preserved (Scheme A signs URL+body and
      *    cXML bodySHA256 lives in the query).
+     *
+     * @param array<string, mixed> $headers
      */
     protected function reconstructPublicUrl(array $headers, string $path): string
     {
@@ -994,6 +1044,8 @@ class Service
 
     /**
      * Check Basic Auth from request headers.
+     *
+     * @param array<string, string> $headers
      */
     protected function checkBasicAuth(array $headers): bool
     {
@@ -1048,6 +1100,9 @@ class Service
     protected function jsonResponse(int $status, mixed $data): array
     {
         $body = json_encode($data, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+        if ($body === false) {
+            throw new \RuntimeException('json_encode failed');
+        }
         $headers = array_merge(
             ['Content-Type' => 'application/json'],
             $this->securityHeaders(),
@@ -1057,6 +1112,8 @@ class Service
 
     /**
      * Generate cryptographically secure random hex string.
+     *
+     * @param int<1, max> $bytes Number of random bytes (must be positive).
      */
     protected function randomHex(int $bytes): string
     {

--- a/src/SignalWire/Security/WebhookMiddleware.php
+++ b/src/SignalWire/Security/WebhookMiddleware.php
@@ -94,6 +94,8 @@ final class WebhookMiddleware
     /**
      * Extract the signature header value, preferring X-SignalWire-Signature
      * over the legacy X-Twilio-Signature alias (cXML compat).
+     *
+     * @param array<string,mixed> $headers
      */
     private function extractSignature(array $headers): ?string
     {

--- a/src/SignalWire/Security/WebhookValidator.php
+++ b/src/SignalWire/Security/WebhookValidator.php
@@ -332,13 +332,15 @@ final class WebhookValidator
                 'qparams' => [],
             ];
         }
+        /** @var array<string, string> $qparams */
         $qparams = [];
         if (isset($parts['query']) && $parts['query'] !== '') {
-            parse_str($parts['query'], $qparams);
+            $parsed = [];
+            parse_str($parts['query'], $parsed);
             // parse_str returns mixed; the validator only reads string scalars.
-            foreach ($qparams as $k => $v) {
-                if (!is_string($v)) {
-                    unset($qparams[$k]);
+            foreach ($parsed as $k => $v) {
+                if (is_string($v)) {
+                    $qparams[(string) $k] = $v;
                 }
             }
         }

--- a/src/SignalWire/Server/AgentServer.php
+++ b/src/SignalWire/Server/AgentServer.php
@@ -62,7 +62,14 @@ class AgentServer
         string $logLevel = 'info'
     ) {
         $this->host     = $host ?? '0.0.0.0';
-        $this->port     = $port ?? (int) ($_ENV['PORT'] ?? getenv('PORT') ?: 3000);
+        if ($port !== null) {
+            $this->port = $port;
+        } else {
+            $envPort = $_ENV['PORT'] ?? getenv('PORT');
+            $this->port = (is_string($envPort) || is_int($envPort)) && (int) $envPort !== 0
+                ? (int) $envPort
+                : 3000;
+        }
         $this->logLevel = $logLevel;
         $this->logger   = Logger::getLogger('agent_server');
     }
@@ -396,7 +403,17 @@ class AgentServer
             $rawHeaders = $request->header();
             if (is_array($rawHeaders)) {
                 foreach ($rawHeaders as $name => $value) {
-                    $headers[(string) $name] = is_array($value) ? implode(', ', $value) : (string) $value;
+                    if (!is_string($name)) {
+                        continue;
+                    }
+                    if (is_array($value)) {
+                        $headers[$name] = implode(', ', array_map(
+                            static fn ($v): string => is_string($v) ? $v : '',
+                            $value
+                        ));
+                    } elseif (is_string($value)) {
+                        $headers[$name] = $value;
+                    }
                 }
             }
             $body = $request->rawBody();

--- a/src/SignalWire/Server/AgentServer.php
+++ b/src/SignalWire/Server/AgentServer.php
@@ -237,6 +237,7 @@ class AgentServer
     /**
      * Handle an HTTP request and return [status, headers, body].
      *
+     * @param array<string, string> $headers
      * @return array{int, array<string, string>, string}
      */
     public function handleRequest(
@@ -619,6 +620,9 @@ class AgentServer
     private function jsonResponse(int $status, mixed $data): array
     {
         $body = json_encode($data, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+        if ($body === false) {
+            throw new \RuntimeException('json_encode failed');
+        }
         return [
             $status,
             array_merge(

--- a/src/SignalWire/Serverless/Adapter.php
+++ b/src/SignalWire/Serverless/Adapter.php
@@ -58,9 +58,9 @@ class Adapter
      * compatible response.
      *
      * @param object $agent   An AgentBase or Service instance with handleRequest().
-     * @param array  $event   The API Gateway event payload.
+     * @param array<string,mixed> $event   The API Gateway event payload.
      * @param object $context The Lambda context object.
-     * @return array API Gateway response format {statusCode, headers, body}.
+     * @return array{statusCode: int, headers: array<string,string>, body: string} API Gateway response format.
      */
     public static function handleLambda(object $agent, array $event, object $context): array
     {
@@ -133,8 +133,8 @@ class Adapter
      * response array.
      *
      * @param object $agent   An AgentBase or Service instance with handleRequest().
-     * @param array  $request The Azure Functions HTTP request array.
-     * @return array Azure response format {status, headers, body}.
+     * @param array<string,mixed> $request The Azure Functions HTTP request array.
+     * @return array{status: int, headers: array<string,string>, body: string} Azure response format.
      */
     public static function handleAzure(object $agent, array $request): array
     {

--- a/src/SignalWire/Serverless/Adapter.php
+++ b/src/SignalWire/Serverless/Adapter.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace SignalWire\Serverless;
 
+use SignalWire\SWML\RequestHandlerLike;
+
 /**
  * Auto-detect and handle serverless environments (Lambda, GCF, Azure, CGI)
  * or fall back to the built-in PHP server.
@@ -57,30 +59,42 @@ class Adapter
      * format, calls agent->handleRequest(), and returns an API Gateway
      * compatible response.
      *
-     * @param object $agent   An AgentBase or Service instance with handleRequest().
+     * @param RequestHandlerLike $agent An AgentBase or Service request handler.
      * @param array<string,mixed> $event   The API Gateway event payload.
      * @param object $context The Lambda context object.
      * @return array{statusCode: int, headers: array<string,string>, body: string} API Gateway response format.
      */
-    public static function handleLambda(object $agent, array $event, object $context): array
+    public static function handleLambda(RequestHandlerLike $agent, array $event, object $context): array
     {
-        $method = strtoupper($event['httpMethod'] ?? $event['requestContext']['http']['method'] ?? 'GET');
-        $path   = $event['path'] ?? $event['rawPath'] ?? '/';
-        $body   = $event['body'] ?? null;
+        $requestContext = $event['requestContext'] ?? null;
+        $ctxMethod = null;
+        if (is_array($requestContext)) {
+            $http = $requestContext['http'] ?? null;
+            if (is_array($http)) {
+                $ctxMethod = $http['method'] ?? null;
+            }
+        }
+        $method = strtoupper(self::asString($event['httpMethod'] ?? $ctxMethod ?? 'GET', 'GET'));
+        $path   = self::asString($event['path'] ?? $event['rawPath'] ?? '/', '/');
+
+        $rawBody = $event['body'] ?? null;
+        $body    = is_string($rawBody) ? $rawBody : null;
 
         // Decode base64-encoded bodies
         if ($body !== null && ($event['isBase64Encoded'] ?? false)) {
-            $body = base64_decode($body, true);
-            if ($body === false) {
-                $body = null;
-            }
+            $decoded = base64_decode($body, true);
+            $body = $decoded === false ? null : $decoded;
         }
 
-        // Normalise headers to mixed-case keys
+        // Normalise headers to string values.
         $headers = [];
         $rawHeaders = $event['headers'] ?? [];
-        foreach ($rawHeaders as $key => $value) {
-            $headers[$key] = $value;
+        if (is_array($rawHeaders)) {
+            foreach ($rawHeaders as $key => $value) {
+                if (is_string($key) && is_string($value)) {
+                    $headers[$key] = $value;
+                }
+            }
         }
 
         [$status, $responseHeaders, $responseBody] = $agent->handleRequest($method, $path, $headers, $body);
@@ -98,12 +112,12 @@ class Adapter
      * Reads from php://input and $_SERVER, calls agent->handleRequest(),
      * then outputs headers and body directly to the response stream.
      *
-     * @param object $agent An AgentBase or Service instance with handleRequest().
+     * @param RequestHandlerLike $agent An AgentBase or Service request handler.
      */
-    public static function handleGcf(object $agent): void
+    public static function handleGcf(RequestHandlerLike $agent): void
     {
-        $method = strtoupper($_SERVER['REQUEST_METHOD'] ?? 'GET');
-        $path   = $_SERVER['PATH_INFO'] ?? $_SERVER['REQUEST_URI'] ?? '/';
+        $method = strtoupper(self::asString($_SERVER['REQUEST_METHOD'] ?? 'GET', 'GET'));
+        $path   = self::asString($_SERVER['PATH_INFO'] ?? $_SERVER['REQUEST_URI'] ?? '/', '/');
 
         // Strip query string from path
         $qPos = strpos($path, '?');
@@ -132,21 +146,31 @@ class Adapter
      * array, calls agent->handleRequest(), and returns an Azure-compatible
      * response array.
      *
-     * @param object $agent   An AgentBase or Service instance with handleRequest().
+     * @param RequestHandlerLike $agent An AgentBase or Service request handler.
      * @param array<string,mixed> $request The Azure Functions HTTP request array.
      * @return array{status: int, headers: array<string,string>, body: string} Azure response format.
      */
-    public static function handleAzure(object $agent, array $request): array
+    public static function handleAzure(RequestHandlerLike $agent, array $request): array
     {
-        $method = strtoupper($request['method'] ?? $request['Method'] ?? 'GET');
-        $path   = $request['url'] ?? $request['Url'] ?? '/';
+        $method = strtoupper(self::asString($request['method'] ?? $request['Method'] ?? 'GET', 'GET'));
+        $url    = self::asString($request['url'] ?? $request['Url'] ?? '/', '/');
 
         // Parse the URL to extract just the path
-        $parsed = parse_url($path);
-        $path = $parsed['path'] ?? '/';
+        $parsed = parse_url($url);
+        $path = (is_array($parsed) && isset($parsed['path'])) ? $parsed['path'] : '/';
 
-        $body    = $request['body'] ?? $request['Body'] ?? null;
-        $headers = $request['headers'] ?? $request['Headers'] ?? [];
+        $rawBody = $request['body'] ?? $request['Body'] ?? null;
+        $body    = is_string($rawBody) ? $rawBody : null;
+
+        $rawHeaders = $request['headers'] ?? $request['Headers'] ?? [];
+        $headers = [];
+        if (is_array($rawHeaders)) {
+            foreach ($rawHeaders as $key => $value) {
+                if (is_string($key) && is_string($value)) {
+                    $headers[$key] = $value;
+                }
+            }
+        }
 
         [$status, $responseHeaders, $responseBody] = $agent->handleRequest($method, $path, $headers, $body);
 
@@ -164,12 +188,12 @@ class Adapter
      * reads body from php://input, parses headers from HTTP_* env vars,
      * and outputs the status line, headers, and body to stdout.
      *
-     * @param object $agent An AgentBase or Service instance with handleRequest().
+     * @param RequestHandlerLike $agent An AgentBase or Service request handler.
      */
-    public static function handleCgi(object $agent): void
+    public static function handleCgi(RequestHandlerLike $agent): void
     {
-        $method = $_SERVER['REQUEST_METHOD'] ?? 'GET';
-        $path   = $_SERVER['PATH_INFO'] ?? $_SERVER['REQUEST_URI'] ?? '/';
+        $method = self::asString($_SERVER['REQUEST_METHOD'] ?? 'GET', 'GET');
+        $path   = self::asString($_SERVER['PATH_INFO'] ?? $_SERVER['REQUEST_URI'] ?? '/', '/');
 
         // Strip query string from path
         $qPos = strpos($path, '?');
@@ -206,7 +230,7 @@ class Adapter
      * For serverless environments, calls the appropriate handler.
      * For 'server', calls agent->run().
      *
-     * @param object $agent An AgentBase or Service instance.
+     * @param RequestHandlerLike $agent An AgentBase or Service request handler.
      * @param ExecutionMode|string|null $mode Optional explicit mode override.
      *        Pass an {@see ExecutionMode} (typed) or its backing string
      *        ('lambda'/'gcf'/'azure'/'cgi'/'server', for parity) to pin the
@@ -214,7 +238,7 @@ class Adapter
      *        out-of-set string raises \ValueError. Defaults to null
      *        (auto-detect), preserving the original single-argument behaviour.
      */
-    public static function serve(object $agent, ExecutionMode|string|null $mode = null): void
+    public static function serve(RequestHandlerLike $agent, ExecutionMode|string|null $mode = null): void
     {
         $resolved = $mode === null ? self::detectMode() : ExecutionMode::coerce($mode);
 
@@ -224,7 +248,7 @@ class Adapter
                 // in a real deployment this would be invoked by the runtime.
                 // Here we provide a minimal entrypoint that reads from stdin.
                 $input = file_get_contents('php://input') ?: '{}';
-                $event = json_decode($input, true) ?? [];
+                $event = self::decodeJsonObject($input);
                 $context = new \stdClass();
                 $response = self::handleLambda($agent, $event, $context);
                 echo json_encode($response, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
@@ -236,7 +260,7 @@ class Adapter
 
             case ExecutionMode::Azure:
                 $input = file_get_contents('php://input') ?: '{}';
-                $request = json_decode($input, true) ?? [];
+                $request = self::decodeJsonObject($input);
                 $response = self::handleAzure($agent, $request);
                 echo json_encode($response, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
                 break;
@@ -261,7 +285,7 @@ class Adapter
         $headers = [];
 
         foreach ($_SERVER as $key => $value) {
-            if (str_starts_with($key, 'HTTP_')) {
+            if (is_string($key) && str_starts_with($key, 'HTTP_') && is_string($value)) {
                 // HTTP_ACCEPT_LANGUAGE => Accept-Language
                 $name = str_replace('_', '-', substr($key, 5));
                 $name = implode('-', array_map('ucfirst', explode('-', strtolower($name))));
@@ -270,14 +294,52 @@ class Adapter
         }
 
         // CONTENT_TYPE and CONTENT_LENGTH are not prefixed with HTTP_
-        if (isset($_SERVER['CONTENT_TYPE'])) {
-            $headers['Content-Type'] = $_SERVER['CONTENT_TYPE'];
+        $contentType = $_SERVER['CONTENT_TYPE'] ?? null;
+        if (is_string($contentType)) {
+            $headers['Content-Type'] = $contentType;
         }
-        if (isset($_SERVER['CONTENT_LENGTH'])) {
-            $headers['Content-Length'] = $_SERVER['CONTENT_LENGTH'];
+        $contentLength = $_SERVER['CONTENT_LENGTH'] ?? null;
+        if (is_string($contentLength)) {
+            $headers['Content-Length'] = $contentLength;
         }
 
         return $headers;
+    }
+
+    /**
+     * Coerce a possibly-mixed value to a string, falling back to $default
+     * for non-string/non-scalar inputs.
+     */
+    private static function asString(mixed $value, string $default): string
+    {
+        if (is_string($value)) {
+            return $value;
+        }
+        if (is_int($value) || is_float($value) || is_bool($value)) {
+            return (string) $value;
+        }
+        return $default;
+    }
+
+    /**
+     * Decode a JSON string to a string-keyed array, returning [] when the
+     * payload is not a JSON object.
+     *
+     * @return array<string, mixed>
+     */
+    private static function decodeJsonObject(string $json): array
+    {
+        $decoded = json_decode($json, true);
+        if (!is_array($decoded)) {
+            return [];
+        }
+        $out = [];
+        foreach ($decoded as $k => $v) {
+            if (is_string($k)) {
+                $out[$k] = $v;
+            }
+        }
+        return $out;
     }
 
     /**

--- a/src/SignalWire/SignalWire.php
+++ b/src/SignalWire/SignalWire.php
@@ -74,7 +74,8 @@ final class SignalWire
         // a SKILL_NAME constant or the snake-cased class basename.
         $name = null;
         if (\defined("$skillClass::SKILL_NAME")) {
-            $name = \constant("$skillClass::SKILL_NAME");
+            $constant = \constant("$skillClass::SKILL_NAME");
+            $name = is_string($constant) ? $constant : null;
         }
         if (!$name) {
             // $skillClass is a class-string<SkillBase>, so getName() exists.
@@ -87,7 +88,10 @@ final class SignalWire
         }
         if (!$name) {
             $bare = \substr($skillClass, \strrpos($skillClass, '\\') + 1);
-            $name = \strtolower(\preg_replace('/(?<!^)[A-Z]/', '_$0', $bare));
+            // preg_replace returns null only on a regex engine error, which a
+            // static valid pattern cannot trigger; fall back to the bare name.
+            $snaked = \preg_replace('/(?<!^)[A-Z]/', '_$0', $bare) ?? $bare;
+            $name = \strtolower($snaked);
         }
         SkillRegistry::instance()->registerSkill($name, $skillClass);
     }

--- a/src/SignalWire/Skills/Builtin/ClaudeSkills.php
+++ b/src/SignalWire/Skills/Builtin/ClaudeSkills.php
@@ -469,6 +469,8 @@ class ClaudeSkills extends SkillBase
 
     /**
      * Apply disable-model-invocation / user-invocable flags.
+     *
+     * @param array<string,mixed> $parsed
      */
     private function applyInvocationControl(array &$parsed): void
     {
@@ -499,6 +501,9 @@ class ClaudeSkills extends SkillBase
         return $sanitized !== '' ? $sanitized : 'unnamed';
     }
 
+    /**
+     * @return list<string>
+     */
     public function getHints(): array
     {
         $hints = [];
@@ -517,6 +522,9 @@ class ClaudeSkills extends SkillBase
         return $hints;
     }
 
+    /**
+     * @return list<array{title: string, body?: string, bullets?: list<string>}>
+     */
     public function getPromptSections(): array
     {
         if (!empty($this->params['skip_prompt'])) {

--- a/src/SignalWire/Skills/Builtin/ClaudeSkills.php
+++ b/src/SignalWire/Skills/Builtin/ClaudeSkills.php
@@ -41,11 +41,25 @@ use SignalWire\SWAIG\FunctionResult;
  *     strings on continuation lines). Skill files using deeply
  *     nested YAML constructs aren't supported and will hit a
  *     graceful "frontmatter parse failed" warning at load.
+ *
+ * @phpstan-type DiscoveredSkill array{
+ *     name: string|null,
+ *     description: string|null,
+ *     argument_hint: string|null,
+ *     disable_model_invocation: bool,
+ *     user_invocable: bool,
+ *     body: string,
+ *     path?: string,
+ *     skill_dir?: string,
+ *     sections?: array<string,string>,
+ *     _skip_tool?: bool,
+ *     _skip_prompt?: bool
+ * }
  */
 class ClaudeSkills extends SkillBase
 {
     /**
-     * @var list<array<string,mixed>> Discovered skills.
+     * @var list<DiscoveredSkill> Discovered skills.
      */
     private array $skills = [];
 
@@ -107,32 +121,39 @@ class ClaudeSkills extends SkillBase
 
     public function registerTools(): void
     {
-        $prefix = (string) ($this->params['tool_prefix'] ?? 'claude_');
-        $skillDescriptions = is_array($this->params['skill_descriptions'] ?? null)
-            ? $this->params['skill_descriptions']
-            : [];
-        $responsePrefix = (string) ($this->params['response_prefix'] ?? '');
-        $responsePostfix = (string) ($this->params['response_postfix'] ?? '');
+        $prefixParam = $this->params['tool_prefix'] ?? 'claude_';
+        $prefix = is_string($prefixParam) ? $prefixParam : 'claude_';
+
+        $skillDescriptionsParam = $this->params['skill_descriptions'] ?? null;
+        $skillDescriptions = [];
+        if (is_array($skillDescriptionsParam)) {
+            foreach ($skillDescriptionsParam as $descKey => $descValue) {
+                if (is_string($descKey) && is_string($descValue)) {
+                    $skillDescriptions[$descKey] = $descValue;
+                }
+            }
+        }
+
+        $responsePrefixParam = $this->params['response_prefix'] ?? '';
+        $responsePrefix = is_string($responsePrefixParam) ? $responsePrefixParam : '';
+        $responsePostfixParam = $this->params['response_postfix'] ?? '';
+        $responsePostfix = is_string($responsePostfixParam) ? $responsePostfixParam : '';
 
         foreach ($this->skills as $skill) {
             if (!empty($skill['_skip_tool'])) {
                 continue;
             }
-            $name = (string) $skill['name'];
+            $name = $skill['name'] ?? '';
             $toolName = $prefix . $this->sanitizeToolName($name);
-            $description = (string) (
-                $skillDescriptions[$name]
+            $description = $skillDescriptions[$name]
                 ?? $skill['description']
-                ?? "Use the {$name} skill"
-            );
+                ?? "Use the {$name} skill";
 
             $parameters = [
                 'arguments' => [
                     'type' => 'string',
-                    'description' => (string) (
-                        $skill['argument_hint']
-                        ?? 'Arguments or context to pass to the skill'
-                    ),
+                    'description' => $skill['argument_hint']
+                        ?? 'Arguments or context to pass to the skill',
                 ],
             ];
             $sections = is_array($skill['sections'] ?? null) ? $skill['sections'] : [];
@@ -156,24 +177,26 @@ class ClaudeSkills extends SkillBase
                     $responsePrefix,
                     $responsePostfix,
                 ): FunctionResult {
-                    $section = (string) ($args['section'] ?? '');
-                    $arguments = (string) ($args['arguments'] ?? '');
-                    $skillSections = is_array($skillCopy['sections'] ?? null)
-                        ? $skillCopy['sections']
-                        : [];
+                    $sectionArg = $args['section'] ?? '';
+                    $section = is_string($sectionArg) ? $sectionArg : '';
+                    $argumentsArg = $args['arguments'] ?? '';
+                    $arguments = is_string($argumentsArg) ? $argumentsArg : '';
+                    $skillSections = $skillCopy['sections'] ?? [];
 
                     $content = '';
                     if ($section !== '' && isset($skillSections[$section])) {
-                        $content = (string) @file_get_contents($skillSections[$section]);
+                        $loaded = @file_get_contents($skillSections[$section]);
+                        $content = is_string($loaded) ? $loaded : '';
                         if ($content === '') {
                             $content = "Error loading section '{$section}'";
                         }
                     } else {
-                        $content = (string) ($skillCopy['body'] ?? '');
+                        $content = $skillCopy['body'];
                     }
 
-                    $skillDir = (string) ($skillCopy['skill_dir'] ?? '');
-                    $sessionId = (string) ($rawData['call_id'] ?? '');
+                    $skillDir = $skillCopy['skill_dir'] ?? '';
+                    $sessionIdRaw = $rawData['call_id'] ?? '';
+                    $sessionId = is_string($sessionIdRaw) ? $sessionIdRaw : '';
                     $content = str_replace(
                         ['${CLAUDE_SKILL_DIR}', '${CLAUDE_SESSION_ID}'],
                         [$skillDir, $sessionId],
@@ -199,7 +222,7 @@ class ClaudeSkills extends SkillBase
     }
 
     /**
-     * @return list<array<string,mixed>>
+     * @return list<DiscoveredSkill>
      */
     private function discoverSkills(string $skillsPath): array
     {
@@ -289,7 +312,7 @@ class ClaudeSkills extends SkillBase
     /**
      * Parse a SKILL.md file with YAML frontmatter and markdown body.
      *
-     * @return array<string,mixed>|null
+     * @return DiscoveredSkill|null
      */
     private function parseSkillMd(string $path): ?array
     {
@@ -326,13 +349,30 @@ class ClaudeSkills extends SkillBase
 
         $fields = $this->parseYamlSubset($frontmatter);
         return [
-            'name' => isset($fields['name']) ? (string) $fields['name'] : null,
-            'description' => isset($fields['description']) ? (string) $fields['description'] : null,
-            'argument_hint' => isset($fields['argument-hint']) ? (string) $fields['argument-hint'] : null,
+            'name' => $this->stringField($fields['name'] ?? null),
+            'description' => $this->stringField($fields['description'] ?? null),
+            'argument_hint' => $this->stringField($fields['argument-hint'] ?? null),
             'disable_model_invocation' => $this->boolish($fields['disable-model-invocation'] ?? false),
             'user_invocable' => $this->boolish($fields['user-invocable'] ?? true),
             'body' => trim($body),
         ];
+    }
+
+    /**
+     * Coerce a parsed YAML scalar to a string (or null when absent / non-scalar).
+     */
+    private function stringField(mixed $value): ?string
+    {
+        if (is_string($value)) {
+            return $value;
+        }
+        if (is_bool($value)) {
+            return $value ? 'true' : 'false';
+        }
+        if (is_int($value) || is_float($value)) {
+            return (string) $value;
+        }
+        return null;
     }
 
     /**
@@ -470,7 +510,7 @@ class ClaudeSkills extends SkillBase
     /**
      * Apply disable-model-invocation / user-invocable flags.
      *
-     * @param array<string,mixed> $parsed
+     * @param DiscoveredSkill $parsed
      */
     private function applyInvocationControl(array &$parsed): void
     {
@@ -482,7 +522,7 @@ class ClaudeSkills extends SkillBase
         if (!empty($parsed['disable_model_invocation'])) {
             $parsed['_skip_tool'] = true;
             $parsed['_skip_prompt'] = true;
-        } elseif (!($parsed['user_invocable'] ?? true)) {
+        } elseif (!$parsed['user_invocable']) {
             $parsed['_skip_tool'] = true;
             $parsed['_skip_prompt'] = false;
         } else {
@@ -534,15 +574,16 @@ class ClaudeSkills extends SkillBase
             return [];
         }
 
-        $prefix = (string) ($this->params['tool_prefix'] ?? 'claude_');
+        $prefixParam = $this->params['tool_prefix'] ?? 'claude_';
+        $prefix = is_string($prefixParam) ? $prefixParam : 'claude_';
         $sections = [];
         foreach ($this->skills as $skill) {
             if (!empty($skill['_skip_prompt'])) {
                 continue;
             }
-            $name = (string) ($skill['name'] ?? 'unnamed');
-            $body = (string) ($skill['body'] ?? '');
-            $skillSections = is_array($skill['sections'] ?? null) ? $skill['sections'] : [];
+            $name = $skill['name'] ?? 'unnamed';
+            $body = $skill['body'];
+            $skillSections = $skill['sections'] ?? [];
             $hasTool = empty($skill['_skip_tool']);
             if (count($skillSections) > 0 && $hasTool) {
                 $sectionNames = array_keys($skillSections);

--- a/src/SignalWire/Skills/Builtin/CustomSkills.php
+++ b/src/SignalWire/Skills/Builtin/CustomSkills.php
@@ -53,8 +53,18 @@ class CustomSkills extends SkillBase
             } elseif (isset($toolDef['name'])) {
                 // Standard tool definition — register with defineTool
                 $name = $toolDef['name'];
-                $description = $toolDef['description'] ?? $toolDef['purpose'] ?? '';
-                $parameters = $toolDef['parameters'] ?? $toolDef['properties'] ?? [];
+                if (!is_string($name)) {
+                    continue;
+                }
+                $rawDescription = $toolDef['description'] ?? $toolDef['purpose'] ?? '';
+                $description = is_string($rawDescription) ? $rawDescription : '';
+                $rawParameters = $toolDef['parameters'] ?? $toolDef['properties'] ?? [];
+                $parameters = [];
+                if (is_array($rawParameters)) {
+                    foreach ($rawParameters as $paramKey => $paramValue) {
+                        $parameters[(string) $paramKey] = $paramValue;
+                    }
+                }
                 $handler = $toolDef['handler'] ?? null;
 
                 if ($handler !== null && is_callable($handler)) {

--- a/src/SignalWire/Skills/Builtin/Datasphere.php
+++ b/src/SignalWire/Skills/Builtin/Datasphere.php
@@ -198,6 +198,9 @@ class Datasphere extends SkillBase
         return $header . implode("\n", $sections);
     }
 
+    /**
+     * @return array<string,mixed>
+     */
     public function getGlobalData(): array
     {
         return [
@@ -207,6 +210,9 @@ class Datasphere extends SkillBase
         ];
     }
 
+    /**
+     * @return list<array{title: string, body?: string, bullets?: list<string>}>
+     */
     public function getPromptSections(): array
     {
         if (!empty($this->params['skip_prompt'])) {

--- a/src/SignalWire/Skills/Builtin/Datasphere.php
+++ b/src/SignalWire/Skills/Builtin/Datasphere.php
@@ -58,20 +58,22 @@ class Datasphere extends SkillBase
     public function registerTools(): void
     {
         $toolName = $this->getToolName('search_knowledge');
-        $spaceName = (string) ($this->params['space_name'] ?? '');
-        $projectId = (string) ($this->params['project_id'] ?? '');
-        $token = (string) ($this->params['token'] ?? '');
-        $documentId = (string) ($this->params['document_id'] ?? '');
-        $count = max(1, min(10, (int) ($this->params['count'] ?? 1)));
-        $distance = (float) ($this->params['distance'] ?? 3.0);
-        $timeout = max(2, (int) ($this->params['timeout'] ?? 30));
+        $spaceName = $this->paramString('space_name');
+        $projectId = $this->paramString('project_id');
+        $token = $this->paramString('token');
+        $documentId = $this->paramString('document_id');
+        $count = max(1, min(10, $this->paramInt('count', 1)));
+        $distance = $this->paramFloat('distance', 3.0);
+        $timeout = max(2, $this->paramInt('timeout', 30));
         $tags = $this->params['tags'] ?? null;
         $language = $this->params['language'] ?? null;
         $posToExpand = $this->params['pos_to_expand'] ?? null;
         $maxSynonyms = $this->params['max_synonyms'] ?? null;
-        $noResultsMessage = (string) ($this->params['no_results_message']
-            ?? "I couldn't find any relevant information for '{query}' in the knowledge base. "
-                . 'Try rephrasing your question or asking about a different topic.');
+        $noResultsMessageRaw = $this->params['no_results_message'] ?? null;
+        $noResultsMessage = is_string($noResultsMessageRaw)
+            ? $noResultsMessageRaw
+            : "I couldn't find any relevant information for '{query}' in the knowledge base. "
+                . 'Try rephrasing your question or asking about a different topic.';
 
         $this->defineTool(
             $toolName,
@@ -168,7 +170,7 @@ class Datasphere extends SkillBase
     }
 
     /**
-     * @param array<int,mixed> $chunks
+     * @param array<mixed> $chunks
      */
     private function formatChunks(string $query, array $chunks): string
     {

--- a/src/SignalWire/Skills/Builtin/DatasphereServerless.php
+++ b/src/SignalWire/Skills/Builtin/DatasphereServerless.php
@@ -39,12 +39,12 @@ class DatasphereServerless extends SkillBase
     public function registerTools(): void
     {
         $toolName = $this->getToolName('search_knowledge');
-        $spaceName = $this->params['space_name'] ?? '';
-        $projectId = $this->params['project_id'] ?? '';
-        $token = $this->params['token'] ?? '';
-        $documentId = $this->params['document_id'] ?? '';
-        $count = max(1, min(10, (int) ($this->params['count'] ?? 1)));
-        $distance = (float) ($this->params['distance'] ?? 3.0);
+        $spaceName = $this->paramString('space_name');
+        $projectId = $this->paramString('project_id');
+        $token = $this->paramString('token');
+        $documentId = $this->paramString('document_id');
+        $count = max(1, min(10, $this->paramInt('count', 1)));
+        $distance = $this->paramFloat('distance', 3.0);
 
         $authString = base64_encode($projectId . ':' . $token);
 

--- a/src/SignalWire/Skills/Builtin/DatasphereServerless.php
+++ b/src/SignalWire/Skills/Builtin/DatasphereServerless.php
@@ -112,6 +112,9 @@ class DatasphereServerless extends SkillBase
         $this->agent->registerSwaigFunction($funcDef);
     }
 
+    /**
+     * @return array<string,mixed>
+     */
     public function getGlobalData(): array
     {
         return [
@@ -121,6 +124,9 @@ class DatasphereServerless extends SkillBase
         ];
     }
 
+    /**
+     * @return list<array{title: string, body?: string, bullets?: list<string>}>
+     */
     public function getPromptSections(): array
     {
         if (!empty($this->params['skip_prompt'])) {

--- a/src/SignalWire/Skills/Builtin/Datetime.php
+++ b/src/SignalWire/Skills/Builtin/Datetime.php
@@ -81,6 +81,9 @@ class Datetime extends SkillBase
         );
     }
 
+    /**
+     * @return list<array{title: string, body?: string, bullets?: list<string>}>
+     */
     public function getPromptSections(): array
     {
         if (!empty($this->params['skip_prompt'])) {

--- a/src/SignalWire/Skills/Builtin/GoogleMaps.php
+++ b/src/SignalWire/Skills/Builtin/GoogleMaps.php
@@ -29,7 +29,7 @@ class GoogleMaps extends SkillBase
 
     public function registerTools(): void
     {
-        $apiKey = $this->params['api_key'] ?? '';
+        $apiKey = $this->paramString('api_key');
         $lookupToolName = $this->params['lookup_tool_name'] ?? 'lookup_address';
         $routeToolName = $this->params['route_tool_name'] ?? 'compute_route';
 

--- a/src/SignalWire/Skills/Builtin/GoogleMaps.php
+++ b/src/SignalWire/Skills/Builtin/GoogleMaps.php
@@ -151,11 +151,17 @@ class GoogleMaps extends SkillBase
         $this->agent->registerSwaigFunction($routeDef);
     }
 
+    /**
+     * @return list<string>
+     */
     public function getHints(): array
     {
         return ['address', 'location', 'route', 'directions', 'miles', 'distance'];
     }
 
+    /**
+     * @return list<array{title: string, body?: string, bullets?: list<string>}>
+     */
     public function getPromptSections(): array
     {
         if (!empty($this->params['skip_prompt'])) {

--- a/src/SignalWire/Skills/Builtin/InfoGatherer.php
+++ b/src/SignalWire/Skills/Builtin/InfoGatherer.php
@@ -152,6 +152,9 @@ class InfoGatherer extends SkillBase
         );
     }
 
+    /**
+     * @return array<string,mixed>
+     */
     public function getGlobalData(): array
     {
         $namespace = $this->getInstanceKey();
@@ -166,6 +169,9 @@ class InfoGatherer extends SkillBase
         ];
     }
 
+    /**
+     * @return list<array{title: string, body?: string, bullets?: list<string>}>
+     */
     public function getPromptSections(): array
     {
         if (!empty($this->params['skip_prompt'])) {

--- a/src/SignalWire/Skills/Builtin/InfoGatherer.php
+++ b/src/SignalWire/Skills/Builtin/InfoGatherer.php
@@ -14,6 +14,41 @@ class InfoGatherer extends SkillBase
         return 'info_gatherer';
     }
 
+    /**
+     * Narrow the genuinely-mixed questions param to a list of question
+     * objects. Per the Python reference each question is a dict with
+     * 'key_name'/'question_text' (and optional 'confirm'/'prompt_add');
+     * non-array entries the platform might send are dropped.
+     *
+     * @param array<mixed> $questions
+     * @return list<array<string,mixed>>
+     */
+    private function normalizeQuestions(array $questions): array
+    {
+        $out = [];
+        foreach ($questions as $q) {
+            if (is_array($q)) {
+                $out[] = $q;
+            }
+        }
+        return $out;
+    }
+
+    /**
+     * Narrow a genuinely-mixed value (question field / SWAIG arg) to a
+     * string. Numeric scalars are stringified; anything else → $default.
+     */
+    private static function asString(mixed $value, string $default = ''): string
+    {
+        if (is_string($value)) {
+            return $value;
+        }
+        if (is_int($value) || is_float($value)) {
+            return (string) $value;
+        }
+        return $default;
+    }
+
     public function getDescription(): string
     {
         return 'Gather answers to a configurable list of questions';
@@ -35,9 +70,9 @@ class InfoGatherer extends SkillBase
 
     public function registerTools(): void
     {
-        $prefix = $this->params['prefix'] ?? '';
-        $questions = $this->params['questions'] ?? [];
-        $completionMessage = $this->params['completion_message'] ?? 'All questions have been answered. Thank you!';
+        $prefix = $this->paramString('prefix');
+        $questions = $this->normalizeQuestions($this->paramArray('questions'));
+        $completionMessage = $this->paramString('completion_message', 'All questions have been answered. Thank you!');
         $namespace = $this->getInstanceKey();
 
         $startToolName = $prefix !== '' ? $prefix . '_start_questions' : 'start_questions';
@@ -50,12 +85,12 @@ class InfoGatherer extends SkillBase
             function (array $args, array $rawData) use ($questions, $namespace): FunctionResult {
                 $result = new FunctionResult();
 
-                if (empty($questions)) {
+                if (count($questions) === 0) {
                     $result->setResponse('No questions configured.');
                     return $result;
                 }
 
-                $firstQuestion = $questions[0]['question_text'] ?? 'No question text.';
+                $firstQuestion = self::asString($questions[0]['question_text'] ?? null, 'No question text.');
 
                 $result->setResponse('Starting questions. First question: ' . $firstQuestion);
                 $result->updateGlobalData([
@@ -85,8 +120,8 @@ class InfoGatherer extends SkillBase
             ],
             function (array $args, array $rawData) use ($questions, $namespace, $completionMessage): FunctionResult {
                 $result = new FunctionResult();
-                $answer = $args['answer'] ?? '';
-                $confirmed = $args['confirmed_by_user'] ?? false;
+                $answer = self::asString($args['answer'] ?? null);
+                $confirmed = (bool) ($args['confirmed_by_user'] ?? false);
 
                 // In a stateful environment, question_index and answers would come from global data.
                 // For this stub, we use the questions array directly.
@@ -101,11 +136,11 @@ class InfoGatherer extends SkillBase
                     return $result;
                 }
 
-                $currentQuestion = $questions[$currentIndex] ?? null;
-                $needsConfirm = $currentQuestion['confirm'] ?? false;
+                $currentQuestion = $questions[$currentIndex] ?? [];
+                $needsConfirm = (bool) ($currentQuestion['confirm'] ?? false);
 
                 if ($needsConfirm && !$confirmed) {
-                    $questionText = $currentQuestion['question_text'] ?? '';
+                    $questionText = self::asString($currentQuestion['question_text'] ?? null);
                     $result->setResponse(
                         'You answered "' . $answer . '" for: ' . $questionText
                         . '. Can you confirm this is correct?'
@@ -123,7 +158,7 @@ class InfoGatherer extends SkillBase
                             'question_index' => $nextIndex,
                             'answers' => [
                                 [
-                                    'key' => $currentQuestion['key_name'] ?? 'q_' . $currentIndex,
+                                    'key' => self::asString($currentQuestion['key_name'] ?? null, 'q_' . $currentIndex),
                                     'answer' => $answer,
                                 ],
                             ],
@@ -131,7 +166,7 @@ class InfoGatherer extends SkillBase
                         ],
                     ]);
                 } else {
-                    $nextQuestion = $questions[$nextIndex]['question_text'] ?? 'No question text.';
+                    $nextQuestion = self::asString($questions[$nextIndex]['question_text'] ?? null, 'No question text.');
                     $result->setResponse('Answer recorded. Next question: ' . $nextQuestion);
                     $result->updateGlobalData([
                         $namespace => [
@@ -139,7 +174,7 @@ class InfoGatherer extends SkillBase
                             'question_index' => $nextIndex,
                             'answers' => [
                                 [
-                                    'key' => $currentQuestion['key_name'] ?? 'q_' . $currentIndex,
+                                    'key' => self::asString($currentQuestion['key_name'] ?? null, 'q_' . $currentIndex),
                                     'answer' => $answer,
                                 ],
                             ],
@@ -158,7 +193,7 @@ class InfoGatherer extends SkillBase
     public function getGlobalData(): array
     {
         $namespace = $this->getInstanceKey();
-        $questions = $this->params['questions'] ?? [];
+        $questions = $this->normalizeQuestions($this->paramArray('questions'));
 
         return [
             $namespace => [
@@ -179,7 +214,7 @@ class InfoGatherer extends SkillBase
         }
 
         $instanceKey = $this->getInstanceKey();
-        $questions = $this->params['questions'] ?? [];
+        $questions = $this->normalizeQuestions($this->paramArray('questions'));
         $bullets = [
             'Call start_questions to begin the question flow.',
             'Submit each answer using submit_answer with the user\'s response.',
@@ -187,7 +222,7 @@ class InfoGatherer extends SkillBase
         ];
 
         foreach ($questions as $q) {
-            $promptAdd = $q['prompt_add'] ?? '';
+            $promptAdd = self::asString($q['prompt_add'] ?? null);
             if ($promptAdd !== '') {
                 $bullets[] = $promptAdd;
             }

--- a/src/SignalWire/Skills/Builtin/Joke.php
+++ b/src/SignalWire/Skills/Builtin/Joke.php
@@ -74,11 +74,17 @@ class Joke extends SkillBase
         $this->agent->registerSwaigFunction($funcDef);
     }
 
+    /**
+     * @return array<string,mixed>
+     */
     public function getGlobalData(): array
     {
         return ['joke_skill_enabled' => true];
     }
 
+    /**
+     * @return list<array{title: string, body?: string, bullets?: list<string>}>
+     */
     public function getPromptSections(): array
     {
         if (!empty($this->params['skip_prompt'])) {

--- a/src/SignalWire/Skills/Builtin/Math.php
+++ b/src/SignalWire/Skills/Builtin/Math.php
@@ -75,6 +75,9 @@ class Math extends SkillBase
         );
     }
 
+    /**
+     * @return list<array{title: string, body?: string, bullets?: list<string>}>
+     */
     public function getPromptSections(): array
     {
         if (!empty($this->params['skip_prompt'])) {

--- a/src/SignalWire/Skills/Builtin/McpGateway.php
+++ b/src/SignalWire/Skills/Builtin/McpGateway.php
@@ -294,6 +294,9 @@ class McpGateway extends SkillBase
         };
     }
 
+    /**
+     * @return list<string>
+     */
     public function getHints(): array
     {
         $hints = ['MCP', 'gateway'];
@@ -311,6 +314,9 @@ class McpGateway extends SkillBase
         return $hints;
     }
 
+    /**
+     * @return array<string,mixed>
+     */
     public function getGlobalData(): array
     {
         $services = $this->params['services'] ?? [];
@@ -332,6 +338,9 @@ class McpGateway extends SkillBase
         ];
     }
 
+    /**
+     * @return list<array{title: string, body?: string, bullets?: list<string>}>
+     */
     public function getPromptSections(): array
     {
         if (!empty($this->params['skip_prompt'])) {

--- a/src/SignalWire/Skills/Builtin/McpGateway.php
+++ b/src/SignalWire/Skills/Builtin/McpGateway.php
@@ -36,6 +36,22 @@ class McpGateway extends SkillBase
         return 'mcp_gateway';
     }
 
+    /**
+     * Narrow a genuinely-mixed value (nested user config / SWAIG args /
+     * gateway JSON) to a string. Non-string scalars are stringified to
+     * match the loose typing the platform sends; anything else → $default.
+     */
+    private static function asString(mixed $value, string $default = ''): string
+    {
+        if (is_string($value)) {
+            return $value;
+        }
+        if (is_int($value) || is_float($value) || is_bool($value)) {
+            return (string) $value;
+        }
+        return $default;
+    }
+
     public function getDescription(): string
     {
         return 'Bridge MCP servers with SWAIG functions';
@@ -55,17 +71,17 @@ class McpGateway extends SkillBase
 
     public function registerTools(): void
     {
-        $gatewayUrl = rtrim((string) ($this->params['gateway_url'] ?? ''), '/');
-        $services = $this->params['services'] ?? [];
-        $authToken = (string) ($this->params['auth_token'] ?? '');
-        $authUser = (string) ($this->params['auth_user'] ?? '');
-        $authPassword = (string) ($this->params['auth_password'] ?? '');
-        $toolPrefix = (string) ($this->params['tool_prefix'] ?? 'mcp_');
-        $retryAttempts = max(1, (int) ($this->params['retry_attempts'] ?? 3));
-        $requestTimeout = max(2, (int) ($this->params['request_timeout'] ?? 30));
-        $sessionTimeout = (int) ($this->params['session_timeout'] ?? 300);
+        $gatewayUrl = rtrim($this->paramString('gateway_url'), '/');
+        $services = $this->paramArray('services');
+        $authToken = $this->paramString('auth_token');
+        $authUser = $this->paramString('auth_user');
+        $authPassword = $this->paramString('auth_password');
+        $toolPrefix = $this->paramString('tool_prefix', 'mcp_');
+        $retryAttempts = max(1, $this->paramInt('retry_attempts', 3));
+        $requestTimeout = max(2, $this->paramInt('request_timeout', 30));
+        $sessionTimeout = $this->paramInt('session_timeout', 300);
 
-        if (!is_array($services) || count($services) === 0) {
+        if (count($services) === 0) {
             $this->registerGatewayTool(
                 $toolPrefix . 'call',
                 'Call an MCP service through the gateway',
@@ -86,7 +102,7 @@ class McpGateway extends SkillBase
             if (!is_array($service)) {
                 continue;
             }
-            $serviceName = (string) ($service['name'] ?? '');
+            $serviceName = self::asString($service['name'] ?? null);
             $serviceTools = $service['tools'] ?? [];
             if ($serviceName === '' || !is_array($serviceTools)) {
                 continue;
@@ -95,8 +111,8 @@ class McpGateway extends SkillBase
                 if (!is_array($tool)) {
                     continue;
                 }
-                $toolName = (string) ($tool['name'] ?? '');
-                $toolDescription = (string) ($tool['description'] ?? '');
+                $toolName = self::asString($tool['name'] ?? null);
+                $toolDescription = self::asString($tool['description'] ?? null);
                 $toolParams = $tool['parameters'] ?? [];
                 if ($toolName === '') {
                     continue;
@@ -111,7 +127,7 @@ class McpGateway extends SkillBase
                         if (!is_array($param)) {
                             continue;
                         }
-                        $paramName = (string) ($param['name'] ?? '');
+                        $paramName = self::asString($param['name'] ?? null);
                         if ($paramName === '') {
                             continue;
                         }
@@ -218,10 +234,10 @@ class McpGateway extends SkillBase
             // (serviceName/mcpToolName captured at register time).
             $effectiveService = $serviceName !== ''
                 ? $serviceName
-                : (string) ($args['service'] ?? '');
+                : self::asString($args['service'] ?? null);
             $effectiveTool = $mcpToolName !== ''
                 ? $mcpToolName
-                : (string) ($args['tool'] ?? '');
+                : self::asString($args['tool'] ?? null);
             if ($effectiveService === '' || $effectiveTool === '') {
                 return new FunctionResult(
                     'MCP gateway: service and tool are required.'
@@ -231,8 +247,8 @@ class McpGateway extends SkillBase
             // Per Python: prefer global_data.mcp_call_id, else call_id.
             $globalData = $rawData['global_data'] ?? [];
             $sessionId = is_array($globalData) && isset($globalData['mcp_call_id'])
-                ? (string) $globalData['mcp_call_id']
-                : (string) ($rawData['call_id'] ?? 'unknown');
+                ? self::asString($globalData['mcp_call_id'])
+                : self::asString($rawData['call_id'] ?? null, 'unknown');
 
             $payload = [
                 'tool' => $effectiveTool,
@@ -281,7 +297,7 @@ class McpGateway extends SkillBase
                     continue;
                 }
                 $errMsg = is_array($parsed) && isset($parsed['error'])
-                    ? (string) $parsed['error']
+                    ? self::asString($parsed['error'])
                     : "HTTP {$status}: " . substr($body, 0, 200);
                 return new FunctionResult(
                     "Failed to call {$effectiveService}.{$effectiveTool}: {$errMsg}"
@@ -300,14 +316,11 @@ class McpGateway extends SkillBase
     public function getHints(): array
     {
         $hints = ['MCP', 'gateway'];
-        $services = $this->params['services'] ?? [];
-        if (is_array($services)) {
-            foreach ($services as $service) {
-                if (is_array($service)) {
-                    $name = (string) ($service['name'] ?? '');
-                    if ($name !== '' && !in_array($name, $hints, true)) {
-                        $hints[] = $name;
-                    }
+        foreach ($this->paramArray('services') as $service) {
+            if (is_array($service)) {
+                $name = self::asString($service['name'] ?? null);
+                if ($name !== '' && !in_array($name, $hints, true)) {
+                    $hints[] = $name;
                 }
             }
         }
@@ -319,20 +332,17 @@ class McpGateway extends SkillBase
      */
     public function getGlobalData(): array
     {
-        $services = $this->params['services'] ?? [];
         $serviceNames = [];
-        if (is_array($services)) {
-            foreach ($services as $service) {
-                if (is_array($service)) {
-                    $name = (string) ($service['name'] ?? '');
-                    if ($name !== '') {
-                        $serviceNames[] = $name;
-                    }
+        foreach ($this->paramArray('services') as $service) {
+            if (is_array($service)) {
+                $name = self::asString($service['name'] ?? null);
+                if ($name !== '') {
+                    $serviceNames[] = $name;
                 }
             }
         }
         return [
-            'mcp_gateway_url' => $this->params['gateway_url'] ?? '',
+            'mcp_gateway_url' => $this->paramString('gateway_url'),
             'mcp_session_id' => null,
             'mcp_services' => $serviceNames,
         ];
@@ -347,18 +357,15 @@ class McpGateway extends SkillBase
             return [];
         }
 
-        $services = $this->params['services'] ?? [];
         $bullets = [];
-        if (is_array($services)) {
-            foreach ($services as $service) {
-                if (is_array($service)) {
-                    $name = (string) ($service['name'] ?? '');
-                    $description = (string) ($service['description'] ?? '');
-                    if ($name !== '') {
-                        $bullets[] = $description !== ''
-                            ? "Service: {$name} - {$description}"
-                            : "Service: {$name}";
-                    }
+        foreach ($this->paramArray('services') as $service) {
+            if (is_array($service)) {
+                $name = self::asString($service['name'] ?? null);
+                $description = self::asString($service['description'] ?? null);
+                if ($name !== '') {
+                    $bullets[] = $description !== ''
+                        ? "Service: {$name} - {$description}"
+                        : "Service: {$name}";
                 }
             }
         }

--- a/src/SignalWire/Skills/Builtin/NativeVectorSearch.php
+++ b/src/SignalWire/Skills/Builtin/NativeVectorSearch.php
@@ -255,6 +255,9 @@ class NativeVectorSearch extends SkillBase
         return implode("\n\n", $lines);
     }
 
+    /**
+     * @return list<string>
+     */
     public function getHints(): array
     {
         $hints = ['search', 'find', 'look up', 'documentation', 'knowledge base'];

--- a/src/SignalWire/Skills/Builtin/NativeVectorSearch.php
+++ b/src/SignalWire/Skills/Builtin/NativeVectorSearch.php
@@ -32,6 +32,30 @@ class NativeVectorSearch extends SkillBase
         return 'native_vector_search';
     }
 
+    /**
+     * Narrow a genuinely-mixed value (remote search JSON) to a string.
+     * Numeric scalars are stringified; anything else → ''.
+     */
+    private static function asString(mixed $value): string
+    {
+        if (is_string($value)) {
+            return $value;
+        }
+        if (is_int($value) || is_float($value)) {
+            return (string) $value;
+        }
+        return '';
+    }
+
+    /**
+     * Narrow a genuinely-mixed value (remote search JSON) to a float.
+     * Numeric values are coerced; anything else → 0.0.
+     */
+    private static function asFloat(mixed $value): float
+    {
+        return is_numeric($value) ? (float) $value : 0.0;
+    }
+
     public function getDescription(): string
     {
         return 'Search document indexes using vector similarity and keyword search (local or remote)';
@@ -46,27 +70,25 @@ class NativeVectorSearch extends SkillBase
     {
         // Either remote_url is set (network mode, supported), or
         // index_file is set (local mode, NOT supported in PHP).
-        $remoteUrl = (string) ($this->params['remote_url'] ?? '');
-        $indexFile = (string) ($this->params['index_file'] ?? '');
+        $remoteUrl = $this->paramString('remote_url');
+        $indexFile = $this->paramString('index_file');
         return $remoteUrl !== '' || $indexFile !== '';
     }
 
     public function registerTools(): void
     {
         $toolName = $this->getToolName('search_knowledge');
-        $toolDescription = (string) ($this->params['description']
-            ?? 'Search the local knowledge base for information');
-        $defaultCount = max(1, min(20, (int) ($this->params['count'] ?? 5)));
-        $similarityThreshold = (float) ($this->params['similarity_threshold'] ?? 0.0);
-        $tags = is_array($this->params['tags'] ?? null) ? $this->params['tags'] : [];
-        $maxContentLength = max(1000, (int) ($this->params['max_content_length'] ?? 32768));
-        $noResultsMessage = (string) ($this->params['no_results_message']
-            ?? "No information found for '{query}'");
-        $responsePrefix = (string) ($this->params['response_prefix'] ?? '');
-        $responsePostfix = (string) ($this->params['response_postfix'] ?? '');
-        $remoteUrl = (string) ($this->params['remote_url'] ?? '');
-        $indexName = (string) ($this->params['index_name'] ?? 'default');
-        $timeout = max(2, (int) ($this->params['timeout'] ?? 30));
+        $toolDescription = $this->paramString('description', 'Search the local knowledge base for information');
+        $defaultCount = max(1, min(20, $this->paramInt('count', 5)));
+        $similarityThreshold = $this->paramFloat('similarity_threshold', 0.0);
+        $tags = $this->paramArray('tags');
+        $maxContentLength = max(1000, $this->paramInt('max_content_length', 32768));
+        $noResultsMessage = $this->paramString('no_results_message', "No information found for '{query}'");
+        $responsePrefix = $this->paramString('response_prefix');
+        $responsePostfix = $this->paramString('response_postfix');
+        $remoteUrl = $this->paramString('remote_url');
+        $indexName = $this->paramString('index_name', 'default');
+        $timeout = max(2, $this->paramInt('timeout', 30));
 
         $this->defineTool(
             $toolName,
@@ -95,8 +117,10 @@ class NativeVectorSearch extends SkillBase
                 $indexName,
                 $timeout,
             ): FunctionResult {
-                $query = trim((string) ($args['query'] ?? ''));
-                $count = max(1, (int) ($args['count'] ?? $defaultCount));
+                $queryArg = $args['query'] ?? '';
+                $query = trim(is_string($queryArg) ? $queryArg : '');
+                $countArg = $args['count'] ?? null;
+                $count = max(1, is_numeric($countArg) ? (int) $countArg : $defaultCount);
 
                 if ($query === '') {
                     return new FunctionResult('Please provide a search query.');
@@ -196,7 +220,7 @@ class NativeVectorSearch extends SkillBase
      * Format the remote search results into a single response string,
      * mirroring the Python skill's per-result truncation behaviour.
      *
-     * @param array<int,mixed> $results
+     * @param array<mixed> $results
      */
     private function formatResults(
         string $query,
@@ -226,11 +250,12 @@ class NativeVectorSearch extends SkillBase
             if (!is_array($result)) {
                 continue;
             }
-            $content = (string) ($result['content'] ?? '');
-            $score = (float) ($result['score'] ?? 0.0);
-            $metadata = is_array($result['metadata'] ?? null) ? $result['metadata'] : [];
-            $filename = (string) ($metadata['filename'] ?? '');
-            $section = (string) ($metadata['section'] ?? '');
+            $content = self::asString($result['content'] ?? null);
+            $score = self::asFloat($result['score'] ?? null);
+            $metadataRaw = $result['metadata'] ?? null;
+            $metadata = is_array($metadataRaw) ? $metadataRaw : [];
+            $filename = self::asString($metadata['filename'] ?? null);
+            $section = self::asString($metadata['section'] ?? null);
 
             if (strlen($content) > $perResultLimit) {
                 $content = substr($content, 0, $perResultLimit) . '...';

--- a/src/SignalWire/Skills/Builtin/PlayBackgroundFile.php
+++ b/src/SignalWire/Skills/Builtin/PlayBackgroundFile.php
@@ -13,6 +13,21 @@ class PlayBackgroundFile extends SkillBase
         return 'play_background_file';
     }
 
+    /**
+     * Narrow a genuinely-mixed value (nested user file config) to a string.
+     * Numeric scalars are stringified; anything else → $default.
+     */
+    private static function asString(mixed $value, string $default = ''): string
+    {
+        if (is_string($value)) {
+            return $value;
+        }
+        if (is_int($value) || is_float($value)) {
+            return (string) $value;
+        }
+        return $default;
+    }
+
     public function getDescription(): string
     {
         return 'Control background file playback';
@@ -35,15 +50,18 @@ class PlayBackgroundFile extends SkillBase
     public function registerTools(): void
     {
         $toolName = $this->getToolName('play_background_file');
-        $files = $this->params['files'] ?? [];
+        $files = $this->paramArray('files');
 
         // Build action enum: start_{key} for each file + stop
         $actionEnum = [];
         $descriptions = [];
 
         foreach ($files as $file) {
-            $key = $file['key'] ?? '';
-            $description = $file['description'] ?? $key;
+            if (!is_array($file)) {
+                continue;
+            }
+            $key = self::asString($file['key'] ?? null);
+            $description = self::asString($file['description'] ?? null, $key);
 
             if ($key === '') {
                 continue;
@@ -60,10 +78,13 @@ class PlayBackgroundFile extends SkillBase
         $expressions = [];
 
         foreach ($files as $file) {
-            $key = $file['key'] ?? '';
-            $url = $file['url'] ?? '';
-            $description = $file['description'] ?? $key;
-            $wait = $file['wait'] ?? false;
+            if (!is_array($file)) {
+                continue;
+            }
+            $key = self::asString($file['key'] ?? null);
+            $url = self::asString($file['url'] ?? null);
+            $description = self::asString($file['description'] ?? null, $key);
+            $wait = (bool) ($file['wait'] ?? false);
 
             if ($key === '' || $url === '') {
                 continue;

--- a/src/SignalWire/Skills/Builtin/Spider.php
+++ b/src/SignalWire/Skills/Builtin/Spider.php
@@ -50,17 +50,25 @@ class Spider extends SkillBase
 
     public function registerTools(): void
     {
-        $prefix = (string) ($this->params['tool_prefix'] ?? '');
-        $maxLength = max(100, (int) ($this->params['max_text_length'] ?? 5000));
-        $timeout = max(2, (int) ($this->params['timeout'] ?? 15));
-        $maxPages = max(1, (int) ($this->params['max_pages'] ?? 5));
-        $maxDepth = max(0, (int) ($this->params['max_depth'] ?? 2));
+        $prefix = $this->paramString('tool_prefix');
+        $maxLength = max(100, $this->paramInt('max_text_length', 5000));
+        $timeout = max(2, $this->paramInt('timeout', 15));
+        $maxPages = max(1, $this->paramInt('max_pages', 5));
+        $maxDepth = max(0, $this->paramInt('max_depth', 2));
         $followPatterns = $this->params['follow_patterns'] ?? [];
-        $userAgent = (string) ($this->params['user_agent']
-            ?? 'Spider/1.0 (SignalWire AI Agent)');
-        $extraHeaders = is_array($this->params['headers'] ?? null)
-            ? $this->params['headers']
-            : [];
+        $userAgentRaw = $this->params['user_agent'] ?? null;
+        $userAgent = is_string($userAgentRaw)
+            ? $userAgentRaw
+            : 'Spider/1.0 (SignalWire AI Agent)';
+        $headersParam = $this->params['headers'] ?? null;
+        $extraHeaders = [];
+        if (is_array($headersParam)) {
+            foreach ($headersParam as $headerKey => $headerValue) {
+                if (is_string($headerKey) && is_string($headerValue)) {
+                    $extraHeaders[$headerKey] = $headerValue;
+                }
+            }
+        }
 
         // ── scrape_url ────────────────────────────────────────────────
         $this->defineTool(

--- a/src/SignalWire/Skills/Builtin/Spider.php
+++ b/src/SignalWire/Skills/Builtin/Spider.php
@@ -450,6 +450,9 @@ class Spider extends SkillBase
         return "{$scheme}://{$host}{$port}{$dir}/{$href}";
     }
 
+    /**
+     * @return list<string>
+     */
     public function getHints(): array
     {
         return ['scrape', 'crawl', 'extract', 'web page', 'website', 'spider'];

--- a/src/SignalWire/Skills/Builtin/SwmlTransfer.php
+++ b/src/SignalWire/Skills/Builtin/SwmlTransfer.php
@@ -124,6 +124,9 @@ class SwmlTransfer extends SkillBase
         $this->agent->registerSwaigFunction($funcDef);
     }
 
+    /**
+     * @return list<string>
+     */
     public function getHints(): array
     {
         $hints = ['transfer', 'connect', 'speak to', 'talk to'];
@@ -131,7 +134,7 @@ class SwmlTransfer extends SkillBase
 
         foreach (array_keys($transfers) as $key) {
             // Split transfer keys into hint words
-            $words = preg_split('/[\s_\-]+/', (string) $key);
+            $words = preg_split('/[\s_\-]+/', (string) $key) ?: [];
             foreach ($words as $word) {
                 $word = trim($word);
                 if ($word !== '' && !in_array($word, $hints, true)) {
@@ -143,6 +146,9 @@ class SwmlTransfer extends SkillBase
         return $hints;
     }
 
+    /**
+     * @return list<array{title: string, body?: string, bullets?: list<string>}>
+     */
     public function getPromptSections(): array
     {
         if (!empty($this->params['skip_prompt'])) {

--- a/src/SignalWire/Skills/Builtin/SwmlTransfer.php
+++ b/src/SignalWire/Skills/Builtin/SwmlTransfer.php
@@ -13,6 +13,21 @@ class SwmlTransfer extends SkillBase
         return 'swml_transfer';
     }
 
+    /**
+     * Narrow a genuinely-mixed value (nested user transfer config) to a
+     * string. Numeric scalars are stringified; anything else → $default.
+     */
+    private static function asString(mixed $value, string $default = ''): string
+    {
+        if (is_string($value)) {
+            return $value;
+        }
+        if (is_int($value) || is_float($value)) {
+            return (string) $value;
+        }
+        return $default;
+    }
+
     public function getDescription(): string
     {
         return 'Transfer calls between agents based on pattern matching';
@@ -35,12 +50,12 @@ class SwmlTransfer extends SkillBase
     public function registerTools(): void
     {
         $toolName = $this->getToolName('transfer_call');
-        $transfers = $this->params['transfers'] ?? [];
-        $description = $this->params['description'] ?? 'Transfer call based on pattern matching';
-        $paramName = $this->params['parameter_name'] ?? 'transfer_type';
-        $paramDescription = $this->params['parameter_description'] ?? 'The type of transfer to perform';
-        $defaultMessage = $this->params['default_message'] ?? 'Transferring your call, please hold.';
-        $requiredFields = $this->params['required_fields'] ?? [];
+        $transfers = $this->paramArray('transfers');
+        $description = $this->paramString('description', 'Transfer call based on pattern matching');
+        $paramName = $this->paramString('parameter_name', 'transfer_type');
+        $paramDescription = $this->paramString('parameter_description', 'The type of transfer to perform');
+        $defaultMessage = $this->paramString('default_message', 'Transferring your call, please hold.');
+        $requiredFields = $this->paramArray('required_fields');
 
         $properties = [
             $paramName => [
@@ -52,13 +67,16 @@ class SwmlTransfer extends SkillBase
         $required = [$paramName];
 
         foreach ($requiredFields as $field) {
-            $fieldName = $field['name'] ?? '';
+            if (!is_array($field)) {
+                continue;
+            }
+            $fieldName = self::asString($field['name'] ?? null);
             if ($fieldName === '') {
                 continue;
             }
             $properties[$fieldName] = [
-                'type' => $field['type'] ?? 'string',
-                'description' => $field['description'] ?? $fieldName,
+                'type' => self::asString($field['type'] ?? null, 'string'),
+                'description' => self::asString($field['description'] ?? null, $fieldName),
             ];
             $required[] = $fieldName;
         }
@@ -67,21 +85,23 @@ class SwmlTransfer extends SkillBase
         $expressions = [];
 
         foreach ($transfers as $pattern => $config) {
-            $url = $config['url'] ?? $config['address'] ?? '';
-            $message = $config['message'] ?? $defaultMessage;
-            $returnMessage = $config['return_message'] ?? '';
-            $postProcess = $config['post_process'] ?? false;
+            if (!is_array($config)) {
+                continue;
+            }
+            $url = self::asString($config['url'] ?? $config['address'] ?? null);
+            $message = self::asString($config['message'] ?? null, $defaultMessage);
+            $postProcess = (bool) ($config['post_process'] ?? false);
 
             $expression = [
                 'string' => '${args.' . $paramName . '}',
-                'pattern' => $pattern,
+                'pattern' => (string) $pattern,
                 'output' => [
                     'response' => $message,
                     'action' => [],
                 ],
             ];
 
-            if (!empty($url)) {
+            if ($url !== '') {
                 if (str_starts_with($url, 'http://') || str_starts_with($url, 'https://')) {
                     $expression['output']['action'][] = ['transfer_uri' => $url];
                 } else {
@@ -130,7 +150,7 @@ class SwmlTransfer extends SkillBase
     public function getHints(): array
     {
         $hints = ['transfer', 'connect', 'speak to', 'talk to'];
-        $transfers = $this->params['transfers'] ?? [];
+        $transfers = $this->paramArray('transfers');
 
         foreach (array_keys($transfers) as $key) {
             // Split transfer keys into hint words
@@ -155,12 +175,12 @@ class SwmlTransfer extends SkillBase
             return [];
         }
 
-        $transfers = $this->params['transfers'] ?? [];
+        $transfers = $this->paramArray('transfers');
         $destinations = [];
 
         foreach ($transfers as $pattern => $config) {
-            $message = $config['message'] ?? '';
-            $destinations[] = $pattern . ($message !== '' ? ' - ' . $message : '');
+            $message = is_array($config) ? self::asString($config['message'] ?? null) : '';
+            $destinations[] = (string) $pattern . ($message !== '' ? ' - ' . $message : '');
         }
 
         $sections = [

--- a/src/SignalWire/Skills/Builtin/WeatherApi.php
+++ b/src/SignalWire/Skills/Builtin/WeatherApi.php
@@ -30,7 +30,7 @@ class WeatherApi extends SkillBase
     public function registerTools(): void
     {
         $toolName = $this->getToolName('get_weather');
-        $apiKey = $this->params['api_key'] ?? '';
+        $apiKey = $this->paramString('api_key');
         $unit = $this->params['temperature_unit'] ?? 'fahrenheit';
 
         if ($unit === 'celsius') {

--- a/src/SignalWire/Skills/Builtin/WebSearch.php
+++ b/src/SignalWire/Skills/Builtin/WebSearch.php
@@ -55,6 +55,21 @@ class WebSearch extends SkillBase
         return 'web_search';
     }
 
+    /**
+     * Narrow a genuinely-mixed value (Google CSE JSON item field) to a
+     * string. Numeric scalars are stringified; anything else → ''.
+     */
+    private static function asString(mixed $value): string
+    {
+        if (is_string($value)) {
+            return $value;
+        }
+        if (is_int($value) || is_float($value)) {
+            return (string) $value;
+        }
+        return '';
+    }
+
     public function getDescription(): string
     {
         return 'Search the web for information using Google Custom Search API';
@@ -89,7 +104,8 @@ class WebSearch extends SkillBase
         // "added a self.params read but forgot the schema entry" drift
         // (Python test_every_setup_param_is_advertised, commit 295745b).
         $schema = parent::getParameterSchema();
-        $schema['properties'] = array_merge($schema['properties'], [
+        $properties = $schema['properties'] ?? [];
+        $schema['properties'] = array_merge(is_array($properties) ? $properties : [], [
             'api_key' => [
                 'type' => 'string',
                 'description' => 'Google Custom Search API key.',
@@ -155,12 +171,11 @@ class WebSearch extends SkillBase
     public function registerTools(): void
     {
         $toolName = $this->getToolName('web_search');
-        $apiKey = (string) ($this->params['api_key'] ?? '');
-        $searchEngineId = (string) ($this->params['search_engine_id'] ?? '');
-        $numResults = max(1, min(10, (int) ($this->params['num_results'] ?? 3)));
-        $timeout = max(2, (int) ($this->params['timeout'] ?? 15));
-        $noResultsMessage = (string) ($this->params['no_results_message']
-            ?? 'No results found for the given query.');
+        $apiKey = $this->paramString('api_key');
+        $searchEngineId = $this->paramString('search_engine_id');
+        $numResults = max(1, min(10, $this->paramInt('num_results', 3)));
+        $timeout = max(2, $this->paramInt('timeout', 15));
+        $noResultsMessage = $this->paramString('no_results_message', 'No results found for the given query.');
 
         // Optional prefix/postfix wrapped around every non-empty search
         // result. Use these to give the calling agent a mechanical cue
@@ -168,8 +183,8 @@ class WebSearch extends SkillBase
         // without needing prompt-side rules. Mirrors the
         // native_vector_search wrapping pattern (response_format_callback
         // in the Python reference).
-        $responsePrefix = (string) ($this->params['response_prefix'] ?? '');
-        $responsePostfix = (string) ($this->params['response_postfix'] ?? '');
+        $responsePrefix = $this->paramString('response_prefix');
+        $responsePostfix = $this->paramString('response_postfix');
 
         // Latency-control params (Python skill.py:660-674, commit 51101da).
         //   perPageTimeout: max seconds to wait on a single page scrape;
@@ -181,11 +196,11 @@ class WebSearch extends SkillBase
         //   parallelScrape: accepted for parity only — PHP scrapes
         //     sequentially (see class docblock).
         //   snippetsOnly: skip scraping; format CSE snippets directly.
-        $perPageTimeout = max(0.1, (float) ($this->params['per_page_timeout'] ?? 2.0));
-        $overallDeadline = max(0.0, (float) ($this->params['overall_deadline'] ?? 10.0));
-        $parallelScrape = (bool) ($this->params['parallel_scrape'] ?? true);
-        $snippetsOnly = (bool) ($this->params['snippets_only'] ?? false);
-        $minQualityScore = (float) ($this->params['min_quality_score'] ?? 0.2);
+        $perPageTimeout = max(0.1, $this->paramFloat('per_page_timeout', 2.0));
+        $overallDeadline = max(0.0, $this->paramFloat('overall_deadline', 10.0));
+        $parallelScrape = $this->paramBool('parallel_scrape', true);
+        $snippetsOnly = $this->paramBool('snippets_only', false);
+        $minQualityScore = $this->paramFloat('min_quality_score', 0.2);
 
         $this->defineTool(
             $toolName,
@@ -215,7 +230,8 @@ class WebSearch extends SkillBase
                 // like Python's `deadline_at = time.monotonic() + deadline`.
                 $deadlineAt = microtime(true) + $overallDeadline;
 
-                $query = trim((string) ($args['query'] ?? ''));
+                $queryArg = $args['query'] ?? '';
+                $query = trim(is_string($queryArg) ? $queryArg : '');
                 if ($query === '') {
                     return new FunctionResult('Error: No search query provided.');
                 }
@@ -337,7 +353,7 @@ class WebSearch extends SkillBase
      * on parse failure / unreachable page / below-threshold quality.
      * Mirrors Python's `_scrape_one` (skill.py:458-481).
      *
-     * @param array<string,mixed> $item Raw CSE item (title/link/snippet).
+     * @param array<mixed> $item Raw CSE item (title/link/snippet).
      * @return array{title:string,url:string,snippet:string,content:string,score:float}|null
      */
     private function scrapeOne(
@@ -346,7 +362,7 @@ class WebSearch extends SkillBase
         int $perPageTimeout,
         float $minQualityScore,
     ): ?array {
-        $link = (string) ($item['link'] ?? '');
+        $link = self::asString($item['link'] ?? null);
         if ($link === '') {
             return null;
         }
@@ -377,9 +393,9 @@ class WebSearch extends SkillBase
         }
 
         return [
-            'title'   => (string) ($item['title'] ?? ''),
+            'title'   => self::asString($item['title'] ?? null),
             'url'     => $link,
-            'snippet' => (string) ($item['snippet'] ?? ''),
+            'snippet' => self::asString($item['snippet'] ?? null),
             'content' => $pageText,
             'score'   => $score,
         ];
@@ -394,7 +410,7 @@ class WebSearch extends SkillBase
      * returned anything, so the kernel never sees a webhook timeout.
      * Python parity: `_format_snippet_results` (skill.py:416-437).
      *
-     * @param list<array<string,mixed>> $items
+     * @param list<array<mixed>> $items
      */
     private static function formatSnippetResults(string $query, array $items, int $numResults): string
     {
@@ -409,9 +425,9 @@ class WebSearch extends SkillBase
         $i = 0;
         foreach ($top as $item) {
             $i++;
-            $title = (string) ($item['title'] ?? '');
-            $link = (string) ($item['link'] ?? '');
-            $snippet = trim((string) ($item['snippet'] ?? ''));
+            $title = self::asString($item['title'] ?? null);
+            $link = self::asString($item['link'] ?? null);
+            $snippet = trim(self::asString($item['snippet'] ?? null));
             $lines[] = "=== RESULT {$i} ===";
             $lines[] = "Title: {$title}";
             $lines[] = "URL: {$link}";

--- a/src/SignalWire/Skills/Builtin/WebSearch.php
+++ b/src/SignalWire/Skills/Builtin/WebSearch.php
@@ -78,6 +78,9 @@ class WebSearch extends SkillBase
         return true;
     }
 
+    /**
+     * @return array<string,mixed>
+     */
     public function getParameterSchema(): array
     {
         // Merge the base schema (swaig_fields / skip_prompt / tool_name)
@@ -540,6 +543,9 @@ class WebSearch extends SkillBase
         return new FunctionResult($response);
     }
 
+    /**
+     * @return array<string,mixed>
+     */
     public function getGlobalData(): array
     {
         return [
@@ -549,6 +555,9 @@ class WebSearch extends SkillBase
         ];
     }
 
+    /**
+     * @return list<array{title: string, body?: string, bullets?: list<string>}>
+     */
     public function getPromptSections(): array
     {
         if (!empty($this->params['skip_prompt'])) {

--- a/src/SignalWire/Skills/Builtin/WikipediaSearch.php
+++ b/src/SignalWire/Skills/Builtin/WikipediaSearch.php
@@ -173,6 +173,9 @@ class WikipediaSearch extends SkillBase
         );
     }
 
+    /**
+     * @return list<array{title: string, body?: string, bullets?: list<string>}>
+     */
     public function getPromptSections(): array
     {
         if (!empty($this->params['skip_prompt'])) {

--- a/src/SignalWire/Skills/Builtin/WikipediaSearch.php
+++ b/src/SignalWire/Skills/Builtin/WikipediaSearch.php
@@ -43,11 +43,13 @@ class WikipediaSearch extends SkillBase
 
     public function registerTools(): void
     {
-        $numResults = max(1, min(5, (int) ($this->params['num_results'] ?? 1)));
-        $timeout = max(2, (int) ($this->params['timeout'] ?? 10));
-        $noResultsMessage = (string) ($this->params['no_results_message']
-            ?? "I couldn't find any Wikipedia articles for '{query}'. "
-                . 'Try rephrasing your search or using different keywords.');
+        $numResults = max(1, min(5, $this->paramInt('num_results', 1)));
+        $timeout = max(2, $this->paramInt('timeout', 10));
+        $noResultsMessageRaw = $this->params['no_results_message'] ?? null;
+        $noResultsMessage = is_string($noResultsMessageRaw)
+            ? $noResultsMessageRaw
+            : "I couldn't find any Wikipedia articles for '{query}'. "
+                . 'Try rephrasing your search or using different keywords.';
 
         $this->defineTool(
             'search_wiki',
@@ -98,7 +100,8 @@ class WikipediaSearch extends SkillBase
                     );
                 }
 
-                $hits = $parsed['query']['search'] ?? [];
+                $queryBlock = $parsed['query'] ?? null;
+                $hits = is_array($queryBlock) ? ($queryBlock['search'] ?? []) : [];
                 if (!is_array($hits) || count($hits) === 0) {
                     return new FunctionResult(
                         str_replace('{query}', $query, $noResultsMessage)
@@ -108,11 +111,12 @@ class WikipediaSearch extends SkillBase
                 // Step 2: fetch the introductory extract for each hit.
                 $articles = [];
                 foreach (array_slice($hits, 0, $numResults) as $hit) {
-                    if (!is_array($hit) || empty($hit['title'])) {
+                    if (!is_array($hit) || empty($hit['title']) || !is_string($hit['title'])) {
                         continue;
                     }
-                    $title = (string) $hit['title'];
-                    $snippet = isset($hit['snippet']) ? (string) $hit['snippet'] : '';
+                    $title = $hit['title'];
+                    $snippetRaw = $hit['snippet'] ?? null;
+                    $snippet = is_string($snippetRaw) ? $snippetRaw : '';
 
                     try {
                         [$exStatus, , $extracted] = HttpHelper::get(
@@ -134,11 +138,13 @@ class WikipediaSearch extends SkillBase
 
                     $extract = '';
                     if ($exStatus >= 200 && $exStatus < 300 && is_array($extracted)) {
-                        $pages = $extracted['query']['pages'] ?? [];
+                        $extractedQuery = $extracted['query'] ?? null;
+                        $pages = is_array($extractedQuery) ? ($extractedQuery['pages'] ?? []) : [];
                         if (is_array($pages)) {
                             $first = reset($pages);
                             if (is_array($first)) {
-                                $extract = trim((string) ($first['extract'] ?? ''));
+                                $extractRaw = $first['extract'] ?? '';
+                                $extract = is_string($extractRaw) ? trim($extractRaw) : '';
                             }
                         }
                     }

--- a/src/SignalWire/Skills/HttpHelper.php
+++ b/src/SignalWire/Skills/HttpHelper.php
@@ -26,6 +26,8 @@ class HttpHelper
      * Issue a GET. Returns [status, body, parsed_json_or_null].
      *
      * @param array<string,string> $headers
+     * @param array<string,scalar>|null $query
+     * @param array{0:string,1:string}|null $basicAuth [user, password]
      * @return array{int, string, mixed}
      */
     public static function get(
@@ -46,6 +48,7 @@ class HttpHelper
      * Issue a POST with a JSON body. Returns [status, body, parsed].
      *
      * @param array<string,string> $headers
+     * @param array{0:string,1:string}|null $basicAuth [user, password]
      * @return array{int, string, mixed}
      */
     public static function postJson(

--- a/src/SignalWire/Skills/HttpHelper.php
+++ b/src/SignalWire/Skills/HttpHelper.php
@@ -112,6 +112,17 @@ class HttpHelper
         ?array $basicAuth = null,
         int $timeout = self::DEFAULT_TIMEOUT,
     ): array {
+        // Public entry boundary: $method/$url arrive directly from skill
+        // callers with no upstream contract. Fail fast on empty input (and
+        // carry the non-empty-string guarantee down to CURLOPT_CUSTOMREQUEST /
+        // CURLOPT_URL).
+        if ($method === '') {
+            throw new \InvalidArgumentException('HTTP request method must not be empty');
+        }
+        if ($url === '') {
+            throw new \InvalidArgumentException('HTTP request URL must not be empty');
+        }
+
         $ch = \curl_init();
         if ($ch === false) {
             throw new \RuntimeException('curl_init() failed');

--- a/src/SignalWire/Skills/SkillBase.php
+++ b/src/SignalWire/Skills/SkillBase.php
@@ -4,15 +4,16 @@ declare(strict_types=1);
 
 namespace SignalWire\Skills;
 
+use SignalWire\Agent\AgentInterface;
+
 abstract class SkillBase
 {
-    // $agent is duck-typed: in production it is a SignalWire\Agent\AgentBase
-    // (constructed via SkillManager from AgentBase), but the skill-contract
-    // tooling (scripts/emit_skills.php) passes a lightweight capturing fake
-    // that only implements defineTool()/registerSwaigFunction(). Keeping the
-    // declared type as `object` preserves that contract. See the deferred
-    // phpstan notes for the typed-interface option.
-    protected object $agent;
+    // $agent is duck-typed via the INTERNAL AgentInterface: in production it is
+    // a SignalWire\Agent\AgentBase (constructed via SkillManager), but the
+    // skill-contract tooling (scripts/emit_skills.php) passes a lightweight
+    // CapturingAgent fake. Both satisfy AgentInterface, which declares exactly
+    // the methods skills invoke on the agent (mirrors TS's RelayClientLike).
+    protected AgentInterface $agent;
     /** @var array<string,mixed> */
     protected array $params;
     /** @var array<string,mixed> */
@@ -21,11 +22,85 @@ abstract class SkillBase
     /**
      * @param array<string,mixed> $params
      */
-    public function __construct(object $agent, array $params = [])
+    public function __construct(AgentInterface $agent, array $params = [])
     {
         $this->agent = $agent;
         $this->params = $params;
-        $this->swaigFields = $params['swaig_fields'] ?? [];
+        $swaigFields = $params['swaig_fields'] ?? [];
+        $this->swaigFields = is_array($swaigFields) ? $swaigFields : [];
+    }
+
+    /**
+     * Read a string param, narrowing the genuinely-mixed value. Non-string
+     * values (including absent keys) fall back to $default. Numeric values
+     * are stringified to match the loose typing the platform sends.
+     */
+    protected function paramString(string $key, string $default = ''): string
+    {
+        $value = $this->params[$key] ?? null;
+        if (is_string($value)) {
+            return $value;
+        }
+        if (is_int($value) || is_float($value)) {
+            return (string) $value;
+        }
+        return $default;
+    }
+
+    /**
+     * Read an int param, narrowing the genuinely-mixed value. Numeric
+     * strings and floats are coerced; anything else falls back to $default.
+     */
+    protected function paramInt(string $key, int $default = 0): int
+    {
+        $value = $this->params[$key] ?? null;
+        if (is_int($value)) {
+            return $value;
+        }
+        if (is_float($value) || (is_string($value) && is_numeric($value))) {
+            return (int) $value;
+        }
+        return $default;
+    }
+
+    /**
+     * Read a float param, narrowing the genuinely-mixed value. Numeric
+     * strings and ints are coerced; anything else falls back to $default.
+     */
+    protected function paramFloat(string $key, float $default = 0.0): float
+    {
+        $value = $this->params[$key] ?? null;
+        if (is_float($value) || is_int($value)) {
+            return (float) $value;
+        }
+        if (is_string($value) && is_numeric($value)) {
+            return (float) $value;
+        }
+        return $default;
+    }
+
+    /**
+     * Read a bool param, narrowing the genuinely-mixed value via PHP's
+     * standard truthiness so '', 0, null, [] are falsey.
+     */
+    protected function paramBool(string $key, bool $default = false): bool
+    {
+        if (!array_key_exists($key, $this->params)) {
+            return $default;
+        }
+        return (bool) $this->params[$key];
+    }
+
+    /**
+     * Read an array param, narrowing the genuinely-mixed value. Non-arrays
+     * (including absent keys) fall back to an empty array.
+     *
+     * @return array<mixed>
+     */
+    protected function paramArray(string $key): array
+    {
+        $value = $this->params[$key] ?? null;
+        return is_array($value) ? $value : [];
     }
 
     abstract public function setup(): bool;
@@ -116,8 +191,9 @@ abstract class SkillBase
     {
         $key = $this->getName();
 
-        if (isset($this->params['tool_name'])) {
-            $key .= '_' . $this->params['tool_name'];
+        $toolName = $this->params['tool_name'] ?? null;
+        if (is_string($toolName) && $toolName !== '') {
+            $key .= '_' . $toolName;
         }
 
         return $key;
@@ -153,6 +229,7 @@ abstract class SkillBase
 
     protected function getToolName(string $default): string
     {
-        return $this->params['tool_name'] ?? $default;
+        $toolName = $this->params['tool_name'] ?? null;
+        return is_string($toolName) && $toolName !== '' ? $toolName : $default;
     }
 }

--- a/src/SignalWire/Skills/SkillBase.php
+++ b/src/SignalWire/Skills/SkillBase.php
@@ -6,10 +6,21 @@ namespace SignalWire\Skills;
 
 abstract class SkillBase
 {
+    // $agent is duck-typed: in production it is a SignalWire\Agent\AgentBase
+    // (constructed via SkillManager from AgentBase), but the skill-contract
+    // tooling (scripts/emit_skills.php) passes a lightweight capturing fake
+    // that only implements defineTool()/registerSwaigFunction(). Keeping the
+    // declared type as `object` preserves that contract. See the deferred
+    // phpstan notes for the typed-interface option.
     protected object $agent;
+    /** @var array<string,mixed> */
     protected array $params;
+    /** @var array<string,mixed> */
     protected array $swaigFields;
 
+    /**
+     * @param array<string,mixed> $params
+     */
     public function __construct(object $agent, array $params = [])
     {
         $this->agent = $agent;
@@ -30,6 +41,9 @@ abstract class SkillBase
         return '1.0.0';
     }
 
+    /**
+     * @return list<string>
+     */
     public function getRequiredEnvVars(): array
     {
         return [];
@@ -40,16 +54,25 @@ abstract class SkillBase
         return false;
     }
 
+    /**
+     * @return list<string>
+     */
     public function getHints(): array
     {
         return [];
     }
 
+    /**
+     * @return array<string,mixed>
+     */
     public function getGlobalData(): array
     {
         return [];
     }
 
+    /**
+     * @return list<array{title: string, body?: string, bullets?: list<string>}>
+     */
     public function getPromptSections(): array
     {
         if (!empty($this->params['skip_prompt'])) {
@@ -63,6 +86,9 @@ abstract class SkillBase
     {
     }
 
+    /**
+     * @return array<string,mixed>
+     */
     public function getParameterSchema(): array
     {
         return [
@@ -97,6 +123,9 @@ abstract class SkillBase
         return $key;
     }
 
+    /**
+     * @return list<string>
+     */
     public function validateEnvVars(): array
     {
         $missing = [];
@@ -110,6 +139,9 @@ abstract class SkillBase
         return $missing;
     }
 
+    /**
+     * @param array<string,mixed> $parameters
+     */
     protected function defineTool(string $name, string $description, array $parameters, callable $handler): void
     {
         if (!empty($this->swaigFields)) {

--- a/src/SignalWire/Skills/SkillManager.php
+++ b/src/SignalWire/Skills/SkillManager.php
@@ -4,16 +4,16 @@ declare(strict_types=1);
 
 namespace SignalWire\Skills;
 
-use SignalWire\Agent\AgentBase;
+use SignalWire\Agent\AgentInterface;
 
 class SkillManager
 {
-    protected AgentBase $agent;
+    protected AgentInterface $agent;
     /** @var array<string, SkillBase> */
     protected array $loadedSkills = [];
     protected SkillRegistry $registry;
 
-    public function __construct(AgentBase $agent)
+    public function __construct(AgentInterface $agent)
     {
         $this->agent = $agent;
         $this->registry = SkillRegistry::instance();

--- a/src/SignalWire/Skills/SkillManager.php
+++ b/src/SignalWire/Skills/SkillManager.php
@@ -4,19 +4,23 @@ declare(strict_types=1);
 
 namespace SignalWire\Skills;
 
+use SignalWire\Agent\AgentBase;
+
 class SkillManager
 {
-    protected object $agent;
+    protected AgentBase $agent;
+    /** @var array<string, SkillBase> */
     protected array $loadedSkills = [];
     protected SkillRegistry $registry;
 
-    public function __construct(object $agent)
+    public function __construct(AgentBase $agent)
     {
         $this->agent = $agent;
         $this->registry = SkillRegistry::instance();
     }
 
     /**
+     * @param array<string,mixed> $params
      * @return array{bool, string}
      */
     public function loadSkill(string $skillName, array $params = [], ?string $skillClass = null): array
@@ -53,17 +57,21 @@ class SkillManager
 
         $hints = $instance->getHints();
         if (!empty($hints)) {
-            $this->agent->mergeHints($hints);
+            $this->agent->addHints($hints);
         }
 
         $globalData = $instance->getGlobalData();
         if (!empty($globalData)) {
-            $this->agent->mergeGlobalData($globalData);
+            $this->agent->updateGlobalData($globalData);
         }
 
         $promptSections = $instance->getPromptSections();
-        if (!empty($promptSections)) {
-            $this->agent->mergePromptSections($promptSections);
+        foreach ($promptSections as $section) {
+            $this->agent->promptAddSection(
+                $section['title'],
+                $section['body'] ?? '',
+                $section['bullets'] ?? [],
+            );
         }
 
         $this->loadedSkills[$instanceKey] = $instance;
@@ -83,6 +91,9 @@ class SkillManager
         return true;
     }
 
+    /**
+     * @return list<string>
+     */
     public function listSkills(): array
     {
         return array_keys($this->loadedSkills);

--- a/src/SignalWire/Skills/SkillRegistry.php
+++ b/src/SignalWire/Skills/SkillRegistry.php
@@ -61,6 +61,9 @@ class SkillRegistry
         return null;
     }
 
+    /**
+     * @return list<string>
+     */
     public function listSkills(): array
     {
         foreach (self::BUILTIN_SKILL_NAMES as $name) {
@@ -148,21 +151,16 @@ class SkillRegistry
             $entry = ['name' => $name, 'parameters' => []];
             $className = $this->getFactory($name);
             if ($className && \class_exists($className)) {
-                if (\method_exists($className, 'getDescription')) {
-                    try {
-                        $skill = new $className();
+                try {
+                    $skill = new $className();
+                    if (\method_exists($skill, 'getDescription')) {
                         $entry['description'] = $skill->getDescription();
-                    } catch (\Throwable $e) {
-                        // Skip on construction failure
                     }
-                }
-                if (\method_exists($className, 'getVersion')) {
-                    try {
-                        $skill = $skill ?? new $className();
+                    if (\method_exists($skill, 'getVersion')) {
                         $entry['version'] = $skill->getVersion();
-                    } catch (\Throwable $e) {
-                        // Skip on construction failure
                     }
+                } catch (\Throwable $e) {
+                    // Skip on construction failure
                 }
             }
             $out[$name] = $entry;

--- a/src/SignalWire/Utils/SchemaUtils.php
+++ b/src/SignalWire/Utils/SchemaUtils.php
@@ -41,7 +41,7 @@ final class SchemaUtils
     /** @var bool Whether validation is enabled (false when the env var disabled it). */
     private bool $validationEnabled;
 
-    /** @var array<string, array{name: string, schema_name: string, definition: array}> */
+    /** @var array<string, array{name: string, schema_name: string, definition: array<string,mixed>}> */
     private array $verbs = [];
 
     /** @var mixed|null Optional full JSON Schema validator (reserved). */

--- a/src/SignalWire/Utils/SchemaUtils.php
+++ b/src/SignalWire/Utils/SchemaUtils.php
@@ -204,7 +204,26 @@ final class SchemaUtils
         if (!is_array($inner)) {
             return [];
         }
-        return $inner;
+        return self::onlyStringKeys($inner);
+    }
+
+    /**
+     * Keep only string-keyed entries. JSON objects always decode to string
+     * keys, so this narrows array<mixed,mixed> to array<string,mixed> without
+     * discarding any real schema data.
+     *
+     * @param array<mixed, mixed> $arr
+     * @return array<string, mixed>
+     */
+    private static function onlyStringKeys(array $arr): array
+    {
+        $out = [];
+        foreach ($arr as $k => $v) {
+            if (is_string($k)) {
+                $out[$k] = $v;
+            }
+        }
+        return $out;
     }
 
     /**
@@ -236,7 +255,7 @@ final class SchemaUtils
         if (!is_array($props)) {
             return [];
         }
-        return $props;
+        return self::onlyStringKeys($props);
     }
 
     /**

--- a/src/SignalWire/Utils/UrlValidator.php
+++ b/src/SignalWire/Utils/UrlValidator.php
@@ -49,7 +49,7 @@ final class UrlValidator
      * Signature: function(string $hostname): ?array (array of IP
      * strings, or null on resolution failure).
      *
-     * @var (callable(string): ?array)|null
+     * @var (callable(string): (list<string>|null))|null
      */
     public static $resolver = null;
 

--- a/tests/RelayTest.php
+++ b/tests/RelayTest.php
@@ -17,6 +17,7 @@ use SignalWire\Relay\FaxAction;
 use SignalWire\Relay\Message;
 use SignalWire\Relay\PlayAction;
 use SignalWire\Relay\RecordAction;
+use SignalWire\Relay\RelayClientLike;
 
 class RelayTest extends TestCase
 {
@@ -26,13 +27,20 @@ class RelayTest extends TestCase
 
     private function makeMockClient(): object
     {
-        return new class () {
+        return new class () implements RelayClientLike {
+            /** @var list<array{method: string, params: array<string,mixed>}> */
             public array $executed = [];
+
+            /**
+             * @param array<string,mixed> $params
+             * @return array<string,mixed>
+             */
             public function execute(string $method, array $params = []): array
             {
                 $this->executed[] = ['method' => $method, 'params' => $params];
                 return [];
             }
+
             public function readOnce(): void
             {
             }

--- a/tests/ServerlessTest.php
+++ b/tests/ServerlessTest.php
@@ -7,6 +7,7 @@ namespace SignalWire\Tests;
 use PHPUnit\Framework\TestCase;
 use SignalWire\Serverless\Adapter;
 use SignalWire\Serverless\ExecutionMode;
+use SignalWire\SWML\RequestHandlerLike;
 
 class ServerlessTest extends TestCase
 {
@@ -461,7 +462,7 @@ class ServerlessTest extends TestCase
 
         $captured = null;
 
-        $agent = new class ($captured) {
+        $agent = new class ($captured) implements RequestHandlerLike {
             private mixed $ref;
 
             public function __construct(mixed &$ref)
@@ -476,6 +477,10 @@ class ServerlessTest extends TestCase
             {
                 $this->ref = $headers;
                 return [200, ['Content-Type' => 'application/json'], '{"ok":true}'];
+            }
+
+            public function run(): void
+            {
             }
         };
 
@@ -502,7 +507,7 @@ class ServerlessTest extends TestCase
 
         $captured = null;
 
-        $agent = new class ($captured) {
+        $agent = new class ($captured) implements RequestHandlerLike {
             private mixed $ref;
 
             public function __construct(mixed &$ref)
@@ -517,6 +522,10 @@ class ServerlessTest extends TestCase
             {
                 $this->ref = $headers;
                 return [200, ['Content-Type' => 'application/json'], '{}'];
+            }
+
+            public function run(): void
+            {
             }
         };
 
@@ -739,7 +748,7 @@ class ServerlessTest extends TestCase
 
     private function makeRecordingAgent(): object
     {
-        return new class () {
+        return new class () implements RequestHandlerLike {
             public bool $ran = false;
             public int $handleRequestCalls = 0;
 
@@ -777,7 +786,7 @@ class ServerlessTest extends TestCase
     ): object {
         $test = $this;
 
-        return new class ($statusCode, $responseData, $expectedMethod, $expectedPath, $expectedHeaders, $expectedBody, $test) {
+        return new class ($statusCode, $responseData, $expectedMethod, $expectedPath, $expectedHeaders, $expectedBody, $test) implements RequestHandlerLike {
             private int $statusCode;
             private array $responseData;
             private string $expectedMethod;
@@ -827,6 +836,12 @@ class ServerlessTest extends TestCase
                     ['Content-Type' => 'application/json'],
                     $responseBody,
                 ];
+            }
+
+            public function run(): void
+            {
+                // No-op: the serverless dispatch tests never invoke the
+                // blocking serve loop (RequestHandlerLike contract method).
             }
         };
     }

--- a/tests/SkillsTest.php
+++ b/tests/SkillsTest.php
@@ -283,7 +283,8 @@ class SkillsTest extends TestCase
         $manager = new SkillManager($agent);
 
         // Datetime has no required env vars and setup returns true.
-        // Pass skip_prompt to avoid calling mergePromptSections.
+        // Pass skip_prompt to keep this test focused on load bookkeeping
+        // (skips the promptAddSection path).
         [$ok, $msg] = $manager->loadSkill('datetime', ['skip_prompt' => true]);
 
         $this->assertTrue($ok);
@@ -391,6 +392,33 @@ class SkillsTest extends TestCase
         $this->assertStringContainsString('not found', $msg);
     }
 
+    /**
+     * Regression: loading a skill WITHOUT skip_prompt must merge the skill's
+     * prompt sections into the agent (Python parity: SkillManager forwards
+     * get_prompt_sections() to agent.prompt_add_section()). This path was
+     * previously broken — SkillManager called a non-existent mergePromptSections()
+     * which would fatal at runtime — so every other test passes skip_prompt to
+     * dodge it. Here we exercise the real merge path end-to-end.
+     */
+    public function testSkillManagerLoadMergesPromptSections(): void
+    {
+        $agent = $this->makeAgent();
+        $manager = new SkillManager($agent);
+
+        [$ok, $msg] = $manager->loadSkill('datetime');
+
+        $this->assertTrue($ok, "datetime should load: {$msg}");
+
+        $prompt = $agent->getPrompt();
+        $this->assertIsArray($prompt, 'POM sections should be present after merge');
+        $titles = array_map(static fn (array $s): mixed => $s['title'] ?? null, $prompt);
+        $this->assertContains(
+            'Date and Time Information',
+            $titles,
+            'datetime skill prompt section should be merged into the agent',
+        );
+    }
+
     // ══════════════════════════════════════════════════════════════════════
     //  Agent integration tests (5)
     // ══════════════════════════════════════════════════════════════════════
@@ -398,7 +426,7 @@ class SkillsTest extends TestCase
     public function testAgentAddSkillDatetimeWorks(): void
     {
         $agent = $this->makeAgent();
-        // Use skip_prompt to keep integration clean (avoids mergePromptSections)
+        // Use skip_prompt to keep integration clean (skips promptAddSection)
         $agent->addSkill('datetime', ['skip_prompt' => true]);
 
         $this->assertTrue($agent->hasSkill('datetime'));
@@ -566,8 +594,9 @@ class SkillsTest extends TestCase
 
     /**
      * Construct + register a WebSearch skill directly (bypassing
-     * SkillManager so we don't drag in unrelated AgentBase merge
-     * methods). Returns the agent so the caller can dispatch.
+     * SkillManager so we don't drag in the agent hint/global-data/
+     * prompt-section merge step). Returns the agent so the caller can
+     * dispatch.
      *
      * @param array<string,mixed> $params
      */


### PR DESCRIPTION
## Summary

Raises the PHP port's PHPStan gate from **level 5** to a **fully-clean level 6** — every finding fixed at the source, **no suppression of any kind** (no `@phpstan-ignore`, no `ignoreErrors`, no baseline file, no silencing casts, no widening-to-`mixed` to dodge a finding). `phpstan.neon` `level:` is now `6`; the Gate-8 LINT comment/label in `scripts/run-ci.sh` updated to match.

Array shapes were sourced the way the TypeScript port did — from the **Python reference** (`~/src/signalwire-python`), the **SWML schema**, and the **actual call sites** — not reflexive `array<string,mixed>`.

## Level achieved & why not higher

**Level 6 is the highest fully-clean level.** It clears the entire bare-`array` value-type block (the 369 `missingType.iterableValue` findings that gate every level ≥ 6) plus the misc `missingType.*`.

Levels 7–9 are **not** the gate because a small residual of **genuinely-ambiguous items** remains, deferred for human triage (below). Per the task's rule 4, it is correct to stop at an honest level 6 rather than force a higher level by contorting types or suppressing.

## Fix counts by category (the burndown)

Level 6: **372 → 0**
| identifier | count | fix |
|---|---|---|
| `missingType.iterableValue` | ~369 | precise PHPDoc value types (`list<string>`, `array<string,mixed>`, `array{...}` shapes, `array<int,Class>`), sourced from python ref / schema / call sites |
| `missingType.return` / `parameter` / `generics` | 3 | typed; `PaginatedIterator` declares `@implements \Iterator<int,array<string,mixed>>` |

Genuine fixes also made while clearing level 7 (these are real and resolved cleanly even though L7 isn't the gate):
| category | what |
|---|---|
| **GENUINE BUG** (`method.notFound`) | `SkillManager` called `$agent->mergeHints()/mergeGlobalData()/mergePromptSections()` — **none of those methods exist on `AgentBase`**. A skill returning non-empty hints/global_data/prompt_sections would **fatal at runtime**. Every test dodged it with `skip_prompt` (with comments saying exactly that). Fixed to the real, Python-parity API: `addHints()` / `updateGlobalData()` / `promptAddSection()` per section. **Added a regression test** that loads a skill *without* `skip_prompt` and asserts the section is merged. |
| `return.type` (json_encode `string\|false`) | handled the `false` branch via `RuntimeException` (matching the codebase's existing `PromptObjectModel` convention) in `FunctionResult::toJson`, `Document::render/renderPretty`, `Service`/`AgentServer::jsonResponse`, `HttpClient` request body |
| `foreach.nonIterable` (`preg_split \|false`) | `?: []` in `FAQBotAgent`, `SwmlTransfer` |
| `argument.type` (`string\|false`) | `file_get_contents`/`realpath` guards in `Schema`, `scripts/signature_dump.php` |
| `assign.propertyType` | `AgentBase::deepCopyArray()` made generic (`@template T`) so clone-time `list<...>` property assignments type-check; setters annotated |
| `argument.type` (shapes) | Context/POM/WebhookValidator/HttpClient param + shape annotations; `HttpClient` query-param contract widened to the **accurate** `array<string,mixed>` that `http_build_query` genuinely accepts; `parse_str` int-key normalisation |
| `method.notFound` (receiver typing) | typing `SkillManager::$agent` as `AgentBase` (only `AgentBase` ever constructs it) + the bare-array annotations resolved the Skills/Relay/Service receiver findings; `swaigPreDispatch` return typed `array{0:self,1:?array<string,mixed>}` |

## NO suppression — confirmed

No `@phpstan-ignore`, no `ignoreErrors`, no baseline, no silencing casts, no `mixed`-widening to dodge. The two `/** @var T */` annotations added (`deepCopyArray` return, `emit_skills` corpus) are precise *narrowing* type assertions of a genuinely-true documented contract — the standard PHPStan idiom for a generic accumulator / a validated trust-boundary value — not error suppression.

## DEFERRED LIST (rule 4 — for human triage)

These block levels 7+. Each is left **unfixed and unsuppressed**; the gate simply stays at 6.

**A. Duck-typed receivers (5 sites + the Skills cluster) — needs a decision on adding a PHP interface.**
The Python reference uses duck typing; these PHP receivers are declared `object` and are deliberately driven by lightweight fakes in tests / tooling, so they can't be narrowed without inventing a new interface (a port **surface addition** that, per project rules, needs explicit sign-off).
- `src/SignalWire/Serverless/Adapter.php:86,119,151,185,249` — `object $agent`→`handleRequest()/run()`. Tests (`tests/ServerlessTest.php`) pass anonymous classes implementing only those methods.
- `src/SignalWire/Relay/Call.php:1004,1074` — `public object $client`→`execute()`. Tests (`tests/RelayTest.php::makeMockClient`) pass an anonymous mock client.
- `src/SignalWire/Skills/SkillBase.php` `protected object $agent` (and the per-skill `$this->agent->registerSwaigFunction()/defineTool()` calls in `Skills/Builtin/*`) — production passes a real `AgentBase`, but `scripts/emit_skills.php` (the SKILL-CONTRACT CI gate) passes a `CapturingAgent` fake. *(I initially narrowed this to `AgentBase` and it broke the SKILL-CONTRACT gate — reverted to `object` to preserve the duck-typed contract.)*
  - **Options:** (1) introduce a narrow `RequestHandler` / `RelayExecutor` / `SkillHost` interface implemented by `Service`/`Client`/`AgentBase` *and* the test mocks + `CapturingAgent` (typed, behavior-preserving, but adds public surface — needs sign-off); or (2) leave duck-typed and keep the gate at 6.

**B. `src/SignalWire/Relay/Call.php:1087` — `startAction()` returns `FaxAction|T`.**
Generic-template limitation: in the `$actionClass === FaxAction::class` branch PHPStan can't prove `FaxAction` *is* `T`. A clean fix means restructuring how `FaxAction` (which needs an extra `$faxType` ctor arg) is constructed, which risks behavior. (A `@psalm-suppress` already exists for psalm; no phpstan suppression added.)

**C. `curl_setopt_array` `CURLOPT_URL` non-empty-string (2 sites).**
- `src/SignalWire/REST/HttpClient.php:232` and `src/SignalWire/Skills/HttpHelper.php:160` — `$url` is `string`, the curl stub wants `non-empty-string`. Resolving needs either a runtime non-empty-URL guard (a behavior addition on an error path) or threading `non-empty-string` through the `RestClient`→`HttpClient` constructor chain (which `rtrim()` doesn't preserve). Left for a small validation decision.

## CI

Full `scripts/run-ci.sh` is **green**: TEST (1885 tests, parallel), FMT (php-cs-fixer), **LINT (phpstan level 6, zero findings)**, SIGNATURES/DRIFT/SURFACE-FRESH/SURFACE-DIFF, NO-CHEAT, REST-COVERAGE, SPEC-PARITY, EMISSION, DOC-AUDIT, SKILL-CONTRACT. `port_signatures.json` regen reflects `SkillManager::__construct($agent)` now typed `AgentBase` (improves Python parity; DRIFT still clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Update — deferred A/B/C cleared; PHPStan raised to **level 9** (max), zero findings, no suppression

The three deferred item-groups above are now resolved at the source, and `phpstan.neon` is at **level 9** (the highest level, full mixed-type strictness) with zero findings and **no suppression** (no `@phpstan-ignore`, no baseline, no `ignoreErrors`, no `mixed`-widening, no silencing casts/docblocks).

### A — duck-typed receivers → minimal **internal** interfaces (the TS `RelayClientLike` pattern)
Rather than narrowing to the concrete classes (which broke SKILL-CONTRACT), each duck-typed receiver got a minimal `@internal` interface declaring exactly the methods the call sites invoke. The interfaces are **not** on the public surface (see "parity tooling" below).
- **A1** — new `@internal SignalWire\Agent\AgentInterface` declaring the 6 methods skills call (`addSkill`, `addHints`, `defineTool`, `promptAddSection`, `registerSwaigFunction`, `updateGlobalData`). `AgentBase implements AgentInterface`; `SkillBase::$agent` + ctor param and `SkillManager`'s agent param are typed to it. `scripts/emit_skills.php`'s `CapturingAgent` now `implements AgentInterface` (the 4 missing capturing impls were added — this also hardens the harness against the `addHints`-fatal class of bug). Interface returns are `static` so `Service`'s `static`-returning `defineTool()` and `CapturingAgent` both satisfy it (`AgentBase`'s 4 own methods went `self`→`static`).
- **A2** — new `@internal SignalWire\Relay\RelayClientLike` (`execute()` + `readOnce()`). `Client implements` it; `Call::$client` is typed to it **and made `protected`**, mirroring Python's private `Call._client` (this drops a port-only *public* extra instead of introducing a typed-class surface symbol).
- **A3** — new `@internal SignalWire\SWML\RequestHandlerLike` (`handleRequest()` + `run()`). The serverless `Adapter` drives only the request-serving surface (the `{ fetch }`-style shape), **not** agent-config methods, so this is the right shape; `Service implements` it and the 5 `Adapter` `$agent` params are typed to it.

### B — `Call::startAction()` `FaxAction|T`
Added the genuine runtime invariant `assert($action instanceof $actionClass);` before `return $action;` (clears `return.type`; the FaxAction branch only runs when `$actionClass === FaxAction::class`).

### C — `CURLOPT_URL` non-empty-string, acting where each invariant truly lives
- **chain-1 (`HttpClient`)** — the non-empty guarantee originates upstream in `RestClient` (throws on empty `space`, then prepends `https://`). Typed `RestClient`/`HttpClient` `$baseUrl` as `non-empty-string` and asserted the invariant right after the `rtrim()` PHPStan can't see through, so the type is **carried to `CURLOPT_URL` with no guard at the curl leaf**. The private `request()` `$method` is typed `non-empty-string` (an HTTP verb, non-empty at every call site) for `CURLOPT_CUSTOMREQUEST`.
- **chain-2 (`HttpHelper`)** — added a fail-fast empty-input guard for `$method`/`$url` at the public `request()` entry, the genuine external boundary for skill callers.

### Level 8 → 9
~375 mixed-strictness findings cleared across ~37 files by genuine runtime narrowing (`is_string`/`is_array`/`is_int`/`is_numeric`/`instanceof`) and precise array shapes sourced from the Python reference / SWML schema — **no `mixed`-widening**.

### Parity tooling kept clean — a **rename, not an omission**
The `@internal` interfaces leaked into the surface enumerator (which previously only knew `class|enum`, so `interface` method declarations were mis-counted as `__module__` free functions). Fixed at the source: `scripts/enumerate_surface.py` now recognises `interface` as a scope **and skips `@internal` interfaces**; `scripts/signature_dump.php` skips `@internal` types; and any *type reference* to one folds onto its canonical concrete class via `CLASS_RENAME_MAP` (`AgentInterface→AgentBase`, `RelayClientLike→RelayClient`, `RequestHandlerLike→SWMLService`). No allowlist/omission entries were added. Test mocks (`RelayTest` client, `ServerlessTest` agents) now `implements` the new interfaces.

### Final level & CI
- `phpstan.neon` `level: 6 → 9`; `scripts/run-ci.sh` Gate-8 comment + label updated to "phpstan level 9".
- Full `scripts/run-ci.sh` is **green**: TEST (1885 tests), SIGNATURES, **DRIFT**, **SURFACE-FRESH**, NO-CHEAT, REST-COVERAGE, SPEC-PARITY, **EMISSION**, FMT, **LINT (phpstan 9, zero findings)**, DOC-AUDIT, **SURFACE-DIFF**, **SKILL-CONTRACT**.
- **No new deferred items.**
