### PR TITLE
ci(swaig-test): wire shared SWAIG-CLI mini-contract gate

### DIFF
--- a/scripts/run-ci.sh
+++ b/scripts/run-ci.sh
@@ -427,6 +427,20 @@ run_gate "SKILL-CONTRACT" "diff_skill_contracts vs python reference" \
         --dump-cmd "php scripts/emit_skills.php" \
         --port-repo "$PORT_ROOT"
 
+# SWAIG-CLI — lightweight shared swaig-test mini-contract (NOT python parity;
+# python's in-process simulator surface is reference-only). Black-box: invokes
+# `php bin/swaig-test --help` + golden invocations and asserts the shared verbs
+# are documented and no-action errors (the cross-port majority default). PHP has
+# no --simulate-serverless, so the no-serverless clause asserts the flag is
+# rejected as an unknown option (no half-accept).
+run_gate "SWAIG-CLI" "swaig-test shared mini-contract (verbs/serverless-reject/default-action)" \
+    python3 "$PORTING_SDK_DIR/scripts/audit_swaig_cli_contract.py" \
+        --port php \
+        --cmd "php $PORT_ROOT/bin/swaig-test" \
+        --require-url-model \
+        --default-action-argv='--url|http://user:pass@127.0.0.1:1/' \
+        --no-serverless-argv='--url|http://user:pass@127.0.0.1:1/|--simulate-serverless|lambda|--list-tools'
+
 if [ -z "$FAILED_GATES" ]; then
     echo "==> CI PASS"
     exit 0


### PR DESCRIPTION
Wires porting-sdk's `audit_swaig_cli_contract.py` (PR signalwire/porting-sdk#50) into `scripts/run-ci.sh` as the **SWAIG-CLI** gate — a lightweight cross-port consistency floor, **not** a Python-parity target.

Black-box: invokes `php bin/swaig-test --help` plus golden invocations and asserts the shared verbs are documented and a target with no action flag errors (PHP already does this). PHP has no `--simulate-serverless`, so the no-serverless clause asserts the flag is rejected as an unknown option (PHP's parser already rejects it) — proving PHP doesn't half-accept serverless.

**No source change** — PHP was already compliant; this enforces it. Full `run-ci.sh` is green including the new gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)