### PR TITLE
docs+examples: wire-truth W1 burn — areacode + params-wrapped tts (php)

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,8 +168,8 @@ $client = new RestClient(
 );
 
 $client->fabric()->aiAgents()->create(['name' => 'Support Bot', 'prompt' => ['text' => 'You are helpful.']]);
-$client->calling()->play($callId, play: [['type' => 'tts', 'text' => 'Hello!']]);
-$client->phoneNumbers()->search(['areaCode' => '512']);
+$client->calling()->play($callId, play: [['type' => 'tts', 'params' => ['text' => 'Hello!']]]);
+$client->phoneNumbers()->search(['areacode' => '512']);
 $client->datasphere()->documents()->search(queryString: 'billing policy');
 ```
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -109,7 +109,7 @@ $client = new RestClient(
 );
 
 $client->fabric()->aiAgents()->create(['name' => 'Bot', 'prompt' => ['text' => 'You are helpful.']]);
-$client->phoneNumbers()->search(['area_code' => '512']);
+$client->phoneNumbers()->search(['areacode' => '512']);
 $client->calling()->dial(['from' => '+15559876543', 'to' => '+15551234567', 'url' => 'https://example.com/handler']);
 ```
 

--- a/examples/quickstart_rest.php
+++ b/examples/quickstart_rest.php
@@ -25,7 +25,7 @@ $client = new RestClient(
 );
 
 $client->fabric()->aiAgents()->create(['name' => 'Support Bot', 'prompt' => ['text' => 'You are helpful.']]);
-$client->calling()->play($callId, play: [['type' => 'tts', 'text' => 'Hello!']]);
-$client->phoneNumbers()->search(['areaCode' => '512']);
+$client->calling()->play($callId, play: [['type' => 'tts', 'params' => ['text' => 'Hello!']]]);
+$client->phoneNumbers()->search(['areacode' => '512']);
 $client->datasphere()->documents()->search(queryString: 'billing policy');
 // endregion: construct

--- a/examples/rest_demo.php
+++ b/examples/rest_demo.php
@@ -44,7 +44,7 @@ if ($numbers) {
 // 2. Search available numbers
 echo "\nSearching available numbers...\n";
 safe('Search 512', function () use ($client) {
-    $avail = $client->phoneNumbers->search(areaCode: '512', maxResults: 3);
+    $avail = $client->phoneNumbers->search(['areacode' => '512', 'max_results' => 3]);
     foreach (($avail['data'] ?? []) as $n) {
         echo "    - " . ($n['e164'] ?? $n['number'] ?? 'unknown') . "\n";
     }

--- a/rest/README.md
+++ b/rest/README.md
@@ -23,7 +23,7 @@ $agent = $client->fabric->aiAgents->create(
 );
 
 // Search for a phone number
-$results = $client->phoneNumbers->search(areaCode: '512');
+$results = $client->phoneNumbers->search(['areacode' => '512']);
 
 // Place a call via REST
 $client->calling->dial(

--- a/rest/docs/namespaces.md
+++ b/rest/docs/namespaces.md
@@ -37,7 +37,7 @@ $client->chat()->...             // Chat tokens
 
 ```php
 // Search
-$available = $client->phoneNumbers()->search(['area_code' => '512', 'max_results' => 5]);
+$available = $client->phoneNumbers()->search(['areacode' => '512', 'max_results' => 5]);
 
 // Purchase
 $number = $client->phoneNumbers()->create(['number' => '+15125551234']);

--- a/rest/examples/rest_calling_ivr_and_ai.php
+++ b/rest/examples/rest_calling_ivr_and_ai.php
@@ -40,7 +40,7 @@ function safe(string $label, callable $fn): mixed
 echo "Collecting DTMF input...\n";
 safe('Collect', fn() => $client->calling->collect($CALL_ID,
     digits: ['max' => 4, 'terminators' => '#'],
-    play:   [['type' => 'tts', 'text' => 'Enter your PIN followed by pound.']],
+    play:   [['type' => 'tts', 'params' => ['text' => 'Enter your PIN followed by pound.']]],
 ));
 safe('Start input timers', fn() => $client->calling->collectStartInputTimers($CALL_ID));
 safe('Stop collect',       fn() => $client->calling->collectStop($CALL_ID));


### PR DESCRIPTION
**Wave-1 wire-truth burn** (§A1 red list, php) — 6 areacode sites (3 spellings; 2 were also invalid PHP named-arg calls against an array-param method) + 3 flat-tts sites the plan's php list missed. Mechanisms verified against the generated pass-through methods; spec param list confirmed from relay-rest openapi.

**Verified:** php -l clean · README-INCLUDE PASS · NO-LAUNDER clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013DbkphxGZfj9bx9uyYDMFp