### PR TITLE
fix(examples): addHints call sites pass the correct shape (no TypeError) (#3.3)

### DIFF
--- a/docs/agent_guide.md
+++ b/docs/agent_guide.md
@@ -198,7 +198,7 @@ $agent->setDynamicConfigCallback(function ($queryParams, $bodyParams, $headers, 
 ```php
 $agent->addLanguage(name: 'English', code: 'en-US', voice: 'inworld.Mark');
 $agent->addLanguage(name: 'Spanish', code: 'es', voice: 'inworld.Sarah');
-$agent->addHints('SignalWire', 'SWML', 'SWAIG');
+$agent->addHints(['SignalWire', 'SWML', 'SWAIG']);
 $agent->addPronunciation('API', 'A P I', ignoreCase: false);
 ```
 

--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -27,7 +27,7 @@ new AgentBase(
 | `setPostPrompt(string $prompt)` | Set the post-conversation summary prompt |
 | `setParams(array $params)` | Set AI behavior parameters |
 | `setGlobalData(array $data)` | Set global data available to the AI |
-| `addHints(string ...$hints)` | Add speech recognition hints |
+| `addHints(array $hints)` | Add speech recognition hints (list of strings) |
 | `addPronunciation(string $word, string $pronunciation, bool $ignoreCase = true)` | Add pronunciation mapping |
 
 ### Language Methods

--- a/examples/comprehensive_dynamic_agent.php
+++ b/examples/comprehensive_dynamic_agent.php
@@ -149,12 +149,12 @@ $agent->setDynamicConfigCallback(function ($qp, $bp, $headers, $a)
             'Show decision-making process when appropriate',
             'Explain feature availability based on tier',
         ]);
-        $a->addHints('debug', 'verbose', 'capabilities');
+        $a->addHints(['debug', 'verbose', 'capabilities']);
     }
 
     // --- A/B Testing ---
     if ($testGroup === 'B') {
-        $a->addHints('enhanced', 'personalised', 'proactive');
+        $a->addHints(['enhanced', 'personalised', 'proactive']);
         $a->promptAddSection('Enhanced Interaction Style', 'You are using an enhanced conversation style:', bullets: [
             'Ask clarifying questions more frequently',
             'Offer proactive suggestions when appropriate',

--- a/examples/custom_path_agent.php
+++ b/examples/custom_path_agent.php
@@ -53,7 +53,7 @@ $agent->setDynamicConfigCallback(function ($qp, $bp, $headers, $a) {
         'session_type' => 'chat',
     ]);
 
-    $a->addHints('chat', 'assistant', 'help', 'conversation', 'question');
+    $a->addHints(['chat', 'assistant', 'help', 'conversation', 'question']);
 });
 
 echo "Starting Chat Agent\n";

--- a/examples/simple_dynamic_agent.php
+++ b/examples/simple_dynamic_agent.php
@@ -31,7 +31,7 @@ $agent->setDynamicConfigCallback(function ($queryParams, $bodyParams, $headers, 
     ]);
 
     // Hints for speech recognition
-    $agentClone->addHints('SignalWire', 'SWML', 'API', 'webhook', 'SIP');
+    $agentClone->addHints(['SignalWire', 'SWML', 'API', 'webhook', 'SIP']);
 
     // Global data
     $agentClone->setGlobalData([

--- a/examples/simple_dynamic_enhanced.php
+++ b/examples/simple_dynamic_enhanced.php
@@ -58,7 +58,7 @@ $agent->setDynamicConfigCallback(function ($qp, $bp, $headers, $a) {
     } else {
         array_push($hints, 'support', 'technical', 'troubleshoot', 'configuration');
     }
-    $a->addHints(...$hints);
+    $a->addHints($hints);
 
     // --- Global Data ---
     $globalData = [


### PR DESCRIPTION
## What

`addHints` example/doc call sites passed the wrong shape and threw a
`TypeError` at runtime. This aligns them with the real SDK signature.

## The signature (correct as-is — parity matches Python)

```php
public function addHints(array $hints): static
```

Matches the Python reference `add_hints(self, hints: list[str])` — a single
LIST of strings, not variadic. The internal caller
(`SkillManager::addHints($hints)`) already passes an array correctly. **The
method signature is right; only the call sites were wrong**, so this PR does
not touch the method.

## The bug

Five example call sites (and two doc references) passed variadic strings, or
spread an array into variadic args:

```
addHints('SignalWire', 'SWML', 'SWAIG');   // → TypeError
addHints(...$hints);                        // spread array → TypeError
```

PHP throws `TypeError: SignalWire\Agent\AgentBase::addHints(): Argument #1
($hints) must be of type array, string given` the instant the line runs. The
four dynamic-config examples call `addHints` inside the per-request
dynamic-config callback, so a plain `php -l` / syntax check does not catch it
— it only fires when the callback runs.

## Sites fixed (before → after)

| File:line | Before | After |
|---|---|---|
| `examples/custom_path_agent.php:56` | `addHints('chat','assistant','help','conversation','question')` | `addHints(['chat','assistant','help','conversation','question'])` |
| `examples/simple_dynamic_enhanced.php:61` | `addHints(...$hints)` | `addHints($hints)` |
| `examples/simple_dynamic_agent.php:34` | `addHints('SignalWire','SWML','API','webhook','SIP')` | `addHints([...])` |
| `examples/comprehensive_dynamic_agent.php:152` | `addHints('debug','verbose','capabilities')` | `addHints([...])` |
| `examples/comprehensive_dynamic_agent.php:157` | `addHints('enhanced','personalised','proactive')` | `addHints([...])` |
| `docs/agent_guide.md:201` | `addHints('SignalWire','SWML','SWAIG')` | `addHints([...])` |
| `docs/api_reference.md:30` | signature doc `addHints(string ...$hints)` | `addHints(array $hints)` |

(`examples/simple_agent.php` and `examples/simple_static_agent.php` already
passed arrays — left unchanged.)

## How verified

- `php -l` clean on all edited examples.
- Focused runtime harness proves the old variadic-string call throws
  `TypeError` and the array form runs clean.
- `EXAMPLES-RUN` passes on all fixed examples (mock ON, server-started).
- Full `bash scripts/run-ci.sh` **GREEN** — FMT, phpstan L9 LINT, TEST, and
  all wire/behavioral gates.

## Note

The `EXAMPLES-RUN` one-request-probe that would surface the per-request
dynamic-callback `TypeError` (rather than only catching it on load/start) is
separate wiring — plan §3.3, not this task. These call-site fixes ensure the
examples are correct when that probe lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PqshDQajCmDHD3xPo4CXMC
