### PR TITLE
fix(env): rename datasphere token env var to SIGNALWIRE_API_TOKEN (plan 4.4)

### DIFF
--- a/examples/datasphere_serverless_env_demo.php
+++ b/examples/datasphere_serverless_env_demo.php
@@ -8,7 +8,7 @@
  * Required environment variables:
  *   SIGNALWIRE_SPACE_NAME   - Your SignalWire space name
  *   SIGNALWIRE_PROJECT_ID   - Your SignalWire project ID
- *   SIGNALWIRE_TOKEN        - Your SignalWire authentication token
+ *   SIGNALWIRE_API_TOKEN    - Your SignalWire authentication token
  *   DATASPHERE_DOCUMENT_ID  - The DataSphere document ID to search
  *
  * Optional:
@@ -28,7 +28,7 @@ function requireEnv(string $name): string
     if (!$value) {
         echo "Error: Required environment variable {$name} is not set\n\n";
         echo "Required:\n";
-        echo "  SIGNALWIRE_SPACE_NAME, SIGNALWIRE_PROJECT_ID, SIGNALWIRE_TOKEN, DATASPHERE_DOCUMENT_ID\n";
+        echo "  SIGNALWIRE_SPACE_NAME, SIGNALWIRE_PROJECT_ID, SIGNALWIRE_API_TOKEN, DATASPHERE_DOCUMENT_ID\n";
         echo "Optional:\n";
         echo "  DATASPHERE_COUNT, DATASPHERE_DISTANCE, DATASPHERE_TAGS, DATASPHERE_LANGUAGE\n";
         exit(1);
@@ -38,7 +38,7 @@ function requireEnv(string $name): string
 
 $spaceName  = requireEnv('SIGNALWIRE_SPACE_NAME');
 $projectId  = requireEnv('SIGNALWIRE_PROJECT_ID');
-$token      = requireEnv('SIGNALWIRE_TOKEN');
+$token      = requireEnv('SIGNALWIRE_API_TOKEN');
 $documentId = requireEnv('DATASPHERE_DOCUMENT_ID');
 
 $count    = (int) ($_ENV['DATASPHERE_COUNT'] ?? getenv('DATASPHERE_COUNT') ?: 3);

--- a/examples/datasphere_webhook_env_demo.php
+++ b/examples/datasphere_webhook_env_demo.php
@@ -9,7 +9,7 @@
  * Required environment variables:
  *   SIGNALWIRE_SPACE_NAME   - Your SignalWire space name
  *   SIGNALWIRE_PROJECT_ID   - Your SignalWire project ID
- *   SIGNALWIRE_TOKEN        - Your SignalWire authentication token
+ *   SIGNALWIRE_API_TOKEN    - Your SignalWire authentication token
  *   DATASPHERE_DOCUMENT_ID  - The DataSphere document ID to search
  *
  * Optional:
@@ -29,7 +29,7 @@ function requireEnv(string $name): string
     if (!$value) {
         echo "Error: Required environment variable {$name} is not set\n\n";
         echo "Required:\n";
-        echo "  SIGNALWIRE_SPACE_NAME, SIGNALWIRE_PROJECT_ID, SIGNALWIRE_TOKEN, DATASPHERE_DOCUMENT_ID\n";
+        echo "  SIGNALWIRE_SPACE_NAME, SIGNALWIRE_PROJECT_ID, SIGNALWIRE_API_TOKEN, DATASPHERE_DOCUMENT_ID\n";
         echo "Optional:\n";
         echo "  DATASPHERE_COUNT, DATASPHERE_DISTANCE, DATASPHERE_TAGS, DATASPHERE_LANGUAGE\n";
         exit(1);
@@ -39,7 +39,7 @@ function requireEnv(string $name): string
 
 $spaceName  = requireEnv('SIGNALWIRE_SPACE_NAME');
 $projectId  = requireEnv('SIGNALWIRE_PROJECT_ID');
-$token      = requireEnv('SIGNALWIRE_TOKEN');
+$token      = requireEnv('SIGNALWIRE_API_TOKEN');
 $documentId = requireEnv('DATASPHERE_DOCUMENT_ID');
 
 $count    = (int) ($_ENV['DATASPHERE_COUNT'] ?? getenv('DATASPHERE_COUNT') ?: 3);

--- a/src/SignalWire/Skills/Builtin/Datasphere.php
+++ b/src/SignalWire/Skills/Builtin/Datasphere.php
@@ -121,7 +121,7 @@ class Datasphere extends SkillBase
                 'description' => 'SignalWire API token',
                 'required' => true,
                 'hidden' => true,
-                'env_var' => 'SIGNALWIRE_TOKEN',
+                'env_var' => 'SIGNALWIRE_API_TOKEN',
             ],
             'document_id' => [
                 'type' => 'string',

--- a/src/SignalWire/Skills/Builtin/DatasphereServerless.php
+++ b/src/SignalWire/Skills/Builtin/DatasphereServerless.php
@@ -78,7 +78,7 @@ class DatasphereServerless extends SkillBase
                 'description' => 'SignalWire API token',
                 'required' => true,
                 'hidden' => true,
-                'env_var' => 'SIGNALWIRE_TOKEN',
+                'env_var' => 'SIGNALWIRE_API_TOKEN',
             ],
             'document_id' => [
                 'type' => 'string',


### PR DESCRIPTION
## What

Plan 4.4 ripple. The python reference standardized its token env var on canonical `SIGNALWIRE_API_TOKEN` and removed `SIGNALWIRE_TOKEN` outright (no back-compat alias). The PHP datasphere skills still used `SIGNALWIRE_TOKEN`; this renames it to `SIGNALWIRE_API_TOKEN` everywhere — outright, no alias/fallback.

## Sites changed (all 7 occurrences)

- `src/SignalWire/Skills/Builtin/Datasphere.php` — `token` param `env_var` schema metadata.
- `src/SignalWire/Skills/Builtin/DatasphereServerless.php` — `token` param `env_var` schema metadata.
- `examples/datasphere_serverless_env_demo.php` — doc-comment, error hint, and runtime `requireEnv(...)` read (3).
- `examples/datasphere_webhook_env_demo.php` — same 3.

## Parity confirmation

Both python reference datasphere skills (`datasphere/skill.py`, `datasphere_serverless/skill.py`) declare `env_var: "SIGNALWIRE_API_TOKEN"` and no `SIGNALWIRE_TOKEN` anywhere.

## Tests

No test asserted the old env-var string value, so no test change was required.

## Verification

- `grep -rn SIGNALWIRE_TOKEN` (code + tests + docs, excluding vendor/.git/.sw-tmp) → zero hits.
- `bash scripts/run-ci.sh` (pr tier) → CI PASS, all gates green (DOC-ENV, DOC-AUDIT, FMT, LINT, TEST included).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PqshDQajCmDHD3xPo4CXMC
