### PR TITLE
ci: unpin porting-sdk checkout back to main (post-merge)

### DIFF
--- a/.github/workflows/doc-audit.yml
+++ b/.github/workflows/doc-audit.yml
@@ -43,7 +43,7 @@ jobs:
           # gates wired on this branch call porting-sdk scripts (check_wired_modes.py,
           # doc_surface.py) that live on porting-sdk plan/a-bar-2026-07-18, not yet on
           # main. REVERT this ref to main when that porting-sdk branch merges.
-          ref: plan/a-bar-2026-07-18
+          ref: main
           path: porting-sdk
           token: ${{ secrets.PORTING_SDK_TOKEN }}
 

--- a/.github/workflows/multi-os.yml
+++ b/.github/workflows/multi-os.yml
@@ -93,7 +93,7 @@ jobs:
           # gates wired on this branch call porting-sdk scripts (check_wired_modes.py,
           # doc_surface.py) that live on porting-sdk plan/a-bar-2026-07-18, not yet on
           # main. REVERT this ref to main when that porting-sdk branch merges.
-          ref: plan/a-bar-2026-07-18
+          ref: main
           path: porting-sdk
           token: ${{ secrets.PORTING_SDK_TOKEN }}
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -93,7 +93,7 @@ jobs:
           # gates wired on this branch call porting-sdk scripts (check_wired_modes.py,
           # doc_surface.py) that live on porting-sdk plan/a-bar-2026-07-18, not yet on
           # main. REVERT this ref to main when that porting-sdk branch merges.
-          ref: plan/a-bar-2026-07-18
+          ref: main
           path: porting-sdk
           token: ${{ secrets.PORTING_SDK_TOKEN }}
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,7 +41,7 @@ jobs:
           # gates wired on this branch call porting-sdk scripts (check_wired_modes.py,
           # doc_surface.py) that live on porting-sdk plan/a-bar-2026-07-18, not yet on
           # main. REVERT this ref to main when that porting-sdk branch merges.
-          ref: plan/a-bar-2026-07-18
+          ref: main
           path: porting-sdk
           token: ${{ secrets.PORTING_SDK_TOKEN }}
 

--- a/.github/workflows/surface-audit.yml
+++ b/.github/workflows/surface-audit.yml
@@ -41,7 +41,7 @@ jobs:
           # gates wired on this branch call porting-sdk scripts (check_wired_modes.py,
           # doc_surface.py) that live on porting-sdk plan/a-bar-2026-07-18, not yet on
           # main. REVERT this ref to main when that porting-sdk branch merges.
-          ref: plan/a-bar-2026-07-18
+          ref: main
           path: porting-sdk
           token: ${{ secrets.PORTING_SDK_TOKEN }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,7 @@ jobs:
           # gates wired on this branch call porting-sdk scripts (check_wired_modes.py,
           # doc_surface.py) that live on porting-sdk plan/a-bar-2026-07-18, not yet on
           # main. REVERT this ref to main when that porting-sdk branch merges.
-          ref: plan/a-bar-2026-07-18
+          ref: main
           path: porting-sdk
           token: ${{ secrets.PORTING_SDK_TOKEN }}
 


### PR DESCRIPTION
The `plan/a-bar-2026-07-18` branch merged and was deleted; workflows still pinned to it fail at the porting-sdk checkout step (gone branch), reddening main CI. Reverts all pins to `ref: main` per the REVERT-on-merge comments. Same mechanical fix as perl #50 / porting-sdk #106.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NqhUoqrbptHNS3cypq9s6t