### PR TITLE
ci: unpin porting-sdk checkout to main (post-merge)

### DIFF
--- a/.github/workflows/doc-audit.yml
+++ b/.github/workflows/doc-audit.yml
@@ -43,7 +43,7 @@ jobs:
           # WIRED-MODES / DOC-SURFACE gate scripts (check_wired_modes.py,
           # doc_surface.py) plus the A+ gate corpora, none yet on main.
           # REVERT this ref to main when porting-sdk wave/1-aplus merges.
-          ref: wave/1-aplus
+          ref: main
           path: porting-sdk
           token: ${{ secrets.PORTING_SDK_TOKEN }}
 

--- a/.github/workflows/multi-os.yml
+++ b/.github/workflows/multi-os.yml
@@ -93,7 +93,7 @@ jobs:
           # (SECURE-DEFAULT / PAGINATION-CORPUS / CA-VAR / TLS-VERIFY / SECRET-SCRUB
           # + their corpora/differs) live on porting-sdk wave/1-aplus, not yet on
           # main. REVERT this ref to main when porting-sdk wave/1-aplus merges.
-          ref: wave/1-aplus
+          ref: main
           path: porting-sdk
           token: ${{ secrets.PORTING_SDK_TOKEN }}
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -93,7 +93,7 @@ jobs:
           # (SECURE-DEFAULT / PAGINATION-CORPUS / CA-VAR / TLS-VERIFY / SECRET-SCRUB
           # + their corpora/differs) live on porting-sdk wave/1-aplus, not yet on
           # main. REVERT this ref to main when porting-sdk wave/1-aplus merges.
-          ref: wave/1-aplus
+          ref: main
           path: porting-sdk
           token: ${{ secrets.PORTING_SDK_TOKEN }}
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,7 +41,7 @@ jobs:
           # (SECURE-DEFAULT / PAGINATION-CORPUS / CA-VAR / TLS-VERIFY / SECRET-SCRUB
           # + their corpora/differs) live on porting-sdk wave/1-aplus, not yet on
           # main. REVERT this ref to main when porting-sdk wave/1-aplus merges.
-          ref: wave/1-aplus
+          ref: main
           path: porting-sdk
           token: ${{ secrets.PORTING_SDK_TOKEN }}
 

--- a/.github/workflows/surface-audit.yml
+++ b/.github/workflows/surface-audit.yml
@@ -40,7 +40,7 @@ jobs:
           # PINNED to wave/1-aplus: the A+ campaign branch carries the surface
           # oracle + gate scripts the wave's gates use, not yet on main.
           # REVERT this ref to main when porting-sdk wave/1-aplus merges.
-          ref: wave/1-aplus
+          ref: main
           path: porting-sdk
           token: ${{ secrets.PORTING_SDK_TOKEN }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,7 @@ jobs:
           # (SECURE-DEFAULT / PAGINATION-CORPUS / CA-VAR / TLS-VERIFY / SECRET-SCRUB
           # + their corpora/differs) live on porting-sdk wave/1-aplus, not yet on
           # main. REVERT this ref to main when porting-sdk wave/1-aplus merges.
-          ref: wave/1-aplus
+          ref: main
           path: porting-sdk
           token: ${{ secrets.PORTING_SDK_TOKEN }}
 


### PR DESCRIPTION
Wave 1 merged; wave/1-aplus deleted. Revert workflow pins to `ref: main`. 0 residual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)