### PR TITLE
ci: unpin porting-sdk checkout from deleted wave/1-aplus to main

### DIFF
--- a/.github/workflows/doc-audit.yml
+++ b/.github/workflows/doc-audit.yml
@@ -43,7 +43,7 @@ jobs:
           # WIRED-MODES / DOC-SURFACE gate scripts (check_wired_modes.py,
           # doc_surface.py) plus the A+ gate corpora, none yet on main.
           # REVERT this ref to main when porting-sdk wave/1-aplus merges.
-          ref: wave/1-aplus
+          ref: main
           path: porting-sdk
           token: ${{ secrets.PORTING_SDK_TOKEN }}
 

--- a/.github/workflows/multi-os.yml
+++ b/.github/workflows/multi-os.yml
@@ -93,7 +93,7 @@ jobs:
           # (SECURE-DEFAULT / PAGINATION-CORPUS / CA-VAR / TLS-VERIFY / SECRET-SCRUB
           # + their corpora/differs) live on porting-sdk wave/1-aplus, not yet on
           # main. REVERT this ref to main when porting-sdk wave/1-aplus merges.
-          ref: wave/1-aplus
+          ref: main
           path: porting-sdk
           token: ${{ secrets.PORTING_SDK_TOKEN }}
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -93,7 +93,7 @@ jobs:
           # (SECURE-DEFAULT / PAGINATION-CORPUS / CA-VAR / TLS-VERIFY / SECRET-SCRUB
           # + their corpora/differs) live on porting-sdk wave/1-aplus, not yet on
           # main. REVERT this ref to main when porting-sdk wave/1-aplus merges.
-          ref: wave/1-aplus
+          ref: main
           path: porting-sdk
           token: ${{ secrets.PORTING_SDK_TOKEN }}
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,7 +41,7 @@ jobs:
           # (SECURE-DEFAULT / PAGINATION-CORPUS / CA-VAR / TLS-VERIFY / SECRET-SCRUB
           # + their corpora/differs) live on porting-sdk wave/1-aplus, not yet on
           # main. REVERT this ref to main when porting-sdk wave/1-aplus merges.
-          ref: wave/1-aplus
+          ref: main
           path: porting-sdk
           token: ${{ secrets.PORTING_SDK_TOKEN }}
 

--- a/.github/workflows/surface-audit.yml
+++ b/.github/workflows/surface-audit.yml
@@ -40,7 +40,7 @@ jobs:
           # PINNED to wave/1-aplus: the A+ campaign branch carries the surface
           # oracle + gate scripts the wave's gates use, not yet on main.
           # REVERT this ref to main when porting-sdk wave/1-aplus merges.
-          ref: wave/1-aplus
+          ref: main
           path: porting-sdk
           token: ${{ secrets.PORTING_SDK_TOKEN }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,7 @@ jobs:
           # (SECURE-DEFAULT / PAGINATION-CORPUS / CA-VAR / TLS-VERIFY / SECRET-SCRUB
           # + their corpora/differs) live on porting-sdk wave/1-aplus, not yet on
           # main. REVERT this ref to main when porting-sdk wave/1-aplus merges.
-          ref: wave/1-aplus
+          ref: main
           path: porting-sdk
           token: ${{ secrets.PORTING_SDK_TOKEN }}
 


### PR DESCRIPTION
porting-sdk `wave/1-aplus` was merged into porting-sdk main (via porting-sdk#108) and the branch **deleted**. Workflows here still pinned the porting-sdk checkout to that branch, which now fails:

```
gh: No commit found for SHA: wave/1-aplus (HTTP 422)
```

(confirmed live on java's `Multi-OS (nightly)` guard step, run 29858501705). The wave content — request_options threading through the REST generator, the regenerated `python_signatures.json` oracle, the mcp_gateway skill oracle — is all on **porting-sdk main @72c7ff5** now, so `main` is the correct ref. This is exactly the REVERT the inline `# REVERT this ref to main when porting-sdk wave/1-aplus merges` comments prescribed.

Reverts every active `ref: wave/1-aplus` / `commits/wave/1-aplus` → `main`. No behavior change beyond restoring a resolvable ref.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NqhUoqrbptHNS3cypq9s6t
